### PR TITLE
Retrieve work item details with call to my_work_items

### DIFF
--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -21,10 +21,6 @@ const WORKITEM_TOOLS = {
   get_work_items_for_iteration: "ado_get_work_items_for_iteration",
   add_work_item_comment: "ado_add_work_item_comment",
   add_child_work_item: "ado_add_child_work_item",
-<<<<<<< Updated upstream
-=======
-  update_work_item_assign: "ado_update_work_item_assign",
->>>>>>> Stashed changes
   link_work_item_to_pull_request: "ado_link_work_item_to_pull_request",
   get_work_item_type: "ado_get_work_item_type",
   get_query: "ado_get_query",
@@ -41,7 +37,7 @@ function configureWorkItemTools(
 
   server.tool(
     WORKITEM_TOOLS.list_backlogs,
-    "Revieve a list of backlogs for a given project and team.",
+    "Retrieve a list of backlogs for a given project and team.",
     {
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       team: z.string().describe("The name or ID of the Azure DevOps team.")


### PR DESCRIPTION
Added an option to the my_work_items tool to retrieve full work item details in one round trip rather than just the work item ids. This will allow users to see all the details of their work items in one go, rather than having to make multiple calls to the server.

## GitHub issue number
#19 
## **Associated Risks**


## ✅ **PR Checklist**

- [x ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x ] Title of the pull request is clear and informative.
- [x ] 👌 Code hygiene
- [x ] 🔭 Telemetry added, updated, or N/A
- [x ] 📄 Documentation added, updated, or N/A
- [ x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
I verified that the MCP server returned a full list of work items when the flag was set to true.