### PR TITLE
chore: publishConfig access to "public"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "preinstall": "npm config set registry https://registry.npmjs.org/",
     "prebuild": "node -p \"'export const packageVersion = ' + JSON.stringify(require('./package.json').version) + ';\\r'\" > src/version.ts",


### PR DESCRIPTION
Configure access as public. Required pre-step to publish the package into npmjs.