### PR TITLE
[docs]: Add quick start video link to README for easier onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ After installation, select GitHub Copilot Agent Mode and refresh the tools list.
 
 This installation method is the easiest for all users using Visual Studio Code.
 
+🎥 [Watch this quick start video to get up and running in under two minutes!](https://youtu.be/EUmFM6qXoYk)
+
 ##### Steps
 
 1. In your project, add a `.vscode\mcp.json` file and add the following:


### PR DESCRIPTION

This pull request adds a helpful resource to the `README.md` file to assist users in quickly setting up GitHub Copilot Agent Mode.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156-R157): Included a link to a quick start video to help users get up and running with GitHub Copilot Agent Mode in under two minutes.

## GitHub issue number
None

## **Associated Risks**
None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Manual testing