### PR TITLE
[docs] Include azure cli in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ For the best experience, use Visual Studio Code and GitHub Copilot.
 
 1. Install [VS Code](https://code.visualstudio.com/download) or [VS Code Insiders](https://code.visualstudio.com/insiders)
 2. Install [Node.js](https://nodejs.org/en/download) 20+
-3. Open VS Code in an empty folder
+3. Install [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+4. Open VS Code in an empty folder
 
 ### Azure Login
 


### PR DESCRIPTION
I deleted the template text as i literally just changed the readme.

To me it feels a bit silly that things like node are listed in the prerequisites, but azure cli is not, while the exact first step is checking if you are logged in to it :)

I for one didnt even knew Azure CLI existed :)