### PR TITLE
fix: Ensure work tools are configured in the tool setup

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,6 +6,7 @@ import { AccessToken } from "@azure/identity";
 import { WebApi } from "azure-devops-node-api";
 
 import { configureCoreTools } from "./tools/core.js";
+import { configureWorkTools } from "./tools/work.js";
 import { configureBuildTools } from "./tools/builds.js";
 import { configureRepoTools } from "./tools/repos.js";
 import { configureWorkItemTools } from "./tools/workitems.js";
@@ -20,6 +21,7 @@ function configureAllTools(
   connectionProvider: () => Promise<WebApi>
 ) {
     configureCoreTools(server, tokenProvider, connectionProvider);
+    configureWorkTools(server, tokenProvider, connectionProvider);
     configureBuildTools(server, tokenProvider, connectionProvider);
     configureRepoTools(server, tokenProvider, connectionProvider);
     configureWorkItemTools(server, tokenProvider, connectionProvider);


### PR DESCRIPTION
Register work tools in tools.ts. That toolset was missing.

## GitHub issue number #99 

## **Associated Risks**
No real risk

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Fixed code and re-ran to ensure toolsets were registered. Ran tests.