### PR TITLE
Improve code search experience by slip function and add new search tool

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -7,10 +7,11 @@
         }
     ],
     "servers": {
-        "ado": {
+        "ado-in-dev": {
             "type": "stdio",
-            "command": "mcp-server-azuredevops",
+            "command": "node",
             "args": [
+                "dist/index.js",
                 "${input:ado_org}"
             ]
         }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -21,7 +21,7 @@ function configurePrompts(server: McpServer) {
             text: String.raw`
 # Prerequisites
 1. Unless already provided, ask user for the project name
-2. Unless already provided, use '${REPO_TOOLS.list_repos_by_project}' tool to get a summarized response of the repositories in this project and ask user to select one
+2. Unless already provided, use '${REPO_TOOLS.list_all_repos_by_project}' tool to get a summarized response of the repositories in this project and ask user to select one
 
 # Task
 Find all pull requests for repository ${repositoryId} using '${REPO_TOOLS.list_pull_requests_by_repo}' tool and summarize them in a table.

--- a/src/tools/core.ts
+++ b/src/tools/core.ts
@@ -8,7 +8,8 @@ import { z } from "zod";
 
 const CORE_TOOLS = {
   list_project_teams: "core_list_project_teams",
-  list_projects: "core_list_projects",  
+  list_all_projects: "core_list_projects",  
+  search_projects: "core_search_projects",
 };
 
 function configureCoreTools(
@@ -44,7 +45,7 @@ function configureCoreTools(
   );
  
   server.tool(
-    CORE_TOOLS.list_projects,
+    CORE_TOOLS.list_all_projects,
     "Retrieve a list of projects in your Azure DevOps organization.",
     {
       stateFilter: z.enum(["all", "wellFormed", "createPending", "deleted"]).default("wellFormed").describe("Filter projects by their state. Defaults to 'wellFormed'."),
@@ -65,6 +66,40 @@ function configureCoreTools(
 
       return {
         content: [{ type: "text", text: JSON.stringify(projects, null, 2) }],
+      };
+    }
+  ); 
+  
+  server.tool(
+    CORE_TOOLS.search_projects,
+    "Search and retrieve a list of projects in your Azure DevOps organization filtered by name or description.",
+    {
+      searchText: z.string().describe("The search text to filter projects by name or description. Case-insensitive partial matching."),
+      stateFilter: z.enum(["all", "wellFormed", "createPending", "deleted"]).default("wellFormed").describe("Filter projects by their state. Defaults to 'wellFormed'."),
+      top: z.number().optional().describe("The maximum number of projects to return. Defaults to 100."),
+      skip: z.number().optional().describe("The number of projects to skip for pagination. Defaults to 0."),
+      continuationToken: z.number().optional().describe("Continuation token for pagination. Used to fetch the next set of results if available."),      
+    },
+    async ({ searchText, stateFilter, top, skip, continuationToken }) => {
+      const connection = await connectionProvider();
+      const coreApi = await connection.getCoreApi();
+      const projects = await coreApi.getProjects(
+        stateFilter,
+        top,
+        skip,
+        continuationToken,
+        false
+      );
+
+      // Filter projects by name or description using case-insensitive search
+      const filteredProjects = projects?.filter((project) => {
+        const nameMatch = project.name?.toLowerCase().includes(searchText.toLowerCase());
+        const descriptionMatch = project.description?.toLowerCase().includes(searchText.toLowerCase());
+        return nameMatch || descriptionMatch;
+      });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(filteredProjects, null, 2) }],
       };
     }
   ); 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -115,7 +115,7 @@ server.tool(
       projectId: z.string().describe("Project ID"),
       repositoryId: z.string().describe("Repository ID"),
       path: z.string().describe("File path"),
-      versionsChangeId: z.string().describe("Change ID/commit hash")
+      versionsChangeId: z.string().describe("Change ID/commit hash, **Don't use branchName**. If not provided, the latest version will be fetched."),
     }).describe("A search result to fetch content for"),
     maxResults: z.number().default(5).describe("Maximum number of files to fetch content for")
   },

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -29,7 +29,7 @@ function configureSearchTools(
   */
 server.tool(
   SEARCH_TOOLS.search_code,
-  "Get the code search results for a given search text.",
+  "Get the code search results for a given search text. No content is returned, only metadata about the search results. Use the get_code_content tool to fetch actual file content.",
   {
     searchRequest: z.object({
       searchText: z.string().describe("Search text to find in code"),


### PR DESCRIPTION
- current search retrieve too much information, reduce match details to match summary, and move  get code content to new tool
- current list project and list repo return too match content, add search project and search repo

## GitHub issue number

## **Associated Risks**
_Replace_ by possible risks this pull request can bring you might have thought of

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
_Replace_ with use cases tested and models used