### PR TITLE
Remove non-json version stdio output which causes errors on some MCP clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,6 @@ async function main() {
   );
 
   const transport = new StdioServerTransport();
-  console.log("Azure DevOps MCP Server version : " + packageVersion);
   await server.connect(transport);
 }
 


### PR DESCRIPTION
The MCP server was logging version information to stdout during startup:
```typescript
console.log("Azure DevOps MCP Server version : " + packageVersion);
```

This caused issues when the server was used with MCP clients (like Claude Desktop) because:
- MCP protocol requires stdout to be reserved exclusively for JSON-RPC messages;
- Any non-JSON output on stdout breaks the protocol communication;
- Clients receive parsing errors like: `Unexpected token 'A', "Azure DevO"... is not valid JSON` which caused MCP client to fail;
![image](https://github.com/user-attachments/assets/bee77a0c-7595-45ca-a0e5-f9e82eb82a9e)

https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
> "The server MUST NOT write anything to its stdout that is not a valid MCP message."

Version info is still accessible via MCP server properties (`server.name` and `server.version`).

## GitHub issue number
- none
## **Associated Risks**
I don't think that the change can introduce any risk.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
After the change I've used it with the following MCP clients:
- VS Code (Windows)
- Claude Desktop (Windows)
- Claude Code (Ubuntu, WSL)