### PR TITLE
Option to list PRs by status (Issue #90)

### DIFF
--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -168,7 +168,7 @@ function configureRepoTools(
       repositoryId: z.string().describe("The ID of the repository where the pull requests are located."),
       created_by_me: z.boolean().default(false).describe("Filter pull requests created by the current user."),
       i_am_reviewer: z.boolean().default(false).describe("Filter pull requests where the current user is a reviewer."),
-      status: z.enum(["abandoned", "active", "all", "completed", "notSet"]).default("notSet").describe("Filter pull requests by status. Defaults to 'notSet'."),
+      status: z.enum(["abandoned", "active", "all", "completed", "notSet"]).default("active").describe("Filter pull requests by status. Defaults to 'active'."),
     },
     async ({ repositoryId, created_by_me, i_am_reviewer, status }) => {
       const connection = await connectionProvider();
@@ -233,7 +233,7 @@ function configureRepoTools(
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       created_by_me: z.boolean().default(false).describe("Filter pull requests created by the current user."),
       i_am_reviewer: z.boolean().default(false).describe("Filter pull requests where the current user is a reviewer."),
-      status: z.enum(["abandoned", "active", "all", "completed", "notSet"]).default("notSet").describe("Filter pull requests by status. Defaults to 'notSet'."),
+      status: z.enum(["abandoned", "active", "all", "completed", "notSet"]).default("active").describe("Filter pull requests by status. Defaults to 'active'."),
     },
     async ({ project, created_by_me, i_am_reviewer, status }) => {
       const connection = await connectionProvider();


### PR DESCRIPTION
Adding an optional argument to the tools for listing PRs for specifying the status of the PR. Fixes #90. Fixes #125 .

## GitHub issue number

## **Associated Risks**
_Replace_ by possible risks this pull request can bring you might have thought of

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry - N/A
- [x] 📄 Documentation - N/A
- [x] 🛡️ Automated tests - N/A (all repo tool tests are yet to be added)

## 🧪 **How did you test it?**
Manually tested with all PR states.