### PR TITLE
Option to link work items when creating the PR (Issue #115)

### DIFF
--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -52,6 +52,7 @@ function configureRepoTools(
       title: z.string().describe("The title of the pull request."),
       description: z.string().optional().describe("The description of the pull request. Optional."),
       isDraft: z.boolean().optional().default(false).describe("Indicates whether the pull request is a draft. Defaults to false."),
+      workItems: z.string().optional().describe("Work item IDs to associate with the pull request, space-separated."),
     },
     async ({
       repositoryId,
@@ -60,9 +61,18 @@ function configureRepoTools(
       title,
       description,
       isDraft,
+      workItems,
     }) => {
       const connection = await connectionProvider();
       const gitApi = await connection.getGitApi();
+      const workItemRefs = workItems
+        ? workItems.split(" ").map((id) => ({
+        id: id.trim(),
+        url: `https://dev.azure.com/your_organization/_apis/wit/workitems/${id.trim()}`,
+        rel: "WorkItem",
+          }))
+        : [];
+
       const pullRequest = await gitApi.createPullRequest(
         {
           sourceRefName,
@@ -70,6 +80,7 @@ function configureRepoTools(
           title,
           description,
           isDraft,
+          workItemRefs: workItemRefs,
         },
         repositoryId
       );


### PR DESCRIPTION
Adding the option to specify the work items to be linked when calling the `repo_create_pull_request` tool.

## GitHub issue number
Fixes #115 .

## **Associated Risks**
None, it's an optional parameter.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry - N/A
- [x] 📄 Documentation - N/A
- [x] 🛡️ Automated tests - N/A

## 🧪 **How did you test it?**
Manually tested locally by creating a PR with:
-  2 linked work items
- 1 linked work item
- no linked work items