### PR TITLE
fix: do not log to STDOUT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,6 @@ async function main() {
   );
 
   const transport = new StdioServerTransport();
-  console.log("Azure DevOps MCP Server version : " + packageVersion);
   await server.connect(transport);
 }
 


### PR DESCRIPTION
We may need to find alternative way of logging the successful server startup event (and versoin).
But for now we have stop breaking MCP contract and unblock Claude desktop users.

## GitHub issue number
https://github.com/microsoft/azure-devops-mcp/issues/147

## **Associated Risks**
None

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
N/A