### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build the project


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/azure-devops-mcp/security/code-scanning/5](https://github.com/microsoft/azure-devops-mcp/security/code-scanning/5)

To fix the issue, we need to add the `permissions` key to the workflow file. Since the workflow does not require write access to the repository, we can set the permissions to `contents: read`. This will limit the access of the `GITHUB_TOKEN` to read-only for repository contents, ensuring the workflow adheres to the principle of least privilege.

The `permissions` key should be added at the root level of the workflow file to apply to all jobs (`build` and `static-code-analysis`) unless overridden by a specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
