### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -1,5 +1,10 @@
 name: Update Package Version
 
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/azure-devops-mcp/security/code-scanning/4](https://github.com/microsoft/azure-devops-mcp/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `pull-requests: write` for interacting with pull requests.
- `packages: write` for updating the package version and pushing tags.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`update-version`) to limit its scope. In this case, adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
