### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build the project


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/azure-devops-mcp/security/code-scanning/3](https://github.com/microsoft/azure-devops-mcp/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow to explicitly define the minimum required permissions for each job. Since the jobs in this workflow only need to read repository contents and do not perform write operations, the `contents: read` permission is sufficient. This change ensures that the `GITHUB_TOKEN` has limited access, reducing the risk of unintended repository modifications.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to define permissions specific to that job. In this case, adding it at the root level is more concise and effective.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
