### PR TITLE
Title: Add list_user_stories Tool to Retrieve User Stories from Azure DevOps

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -71,6 +71,68 @@ Present the results in a table with the following columns: Project ID, Name, and
       ],
     })
   );
+  server.prompt(
+  "listUserStories",
+  "Retrieves a list of User Story work items from a specified Azure DevOps project.",
+  {
+    project: z.string().describe("The name or ID of the Azure DevOps project."),
+    team: z.string().optional().describe("The name or ID of the Azure DevOps team. If not provided, will search across all teams."),
+    state: z.enum(["Active", "New", "Resolved", "Closed", "Removed"]).optional().describe("Filter by work item state."),
+    assignedTo: z.string().optional().describe("Filter by assignee display name or email."),
+    areaPath: z.string().optional().describe("Filter by area path."),
+    iterationPath: z.string().optional().describe("Filter by iteration path."),
+    top: z.string().optional().describe("Maximum number of User Stories to return."),
+    orderBy: z.enum(["System.Id", "System.Title", "System.CreatedDate", "System.ChangedDate", "System.State"]).optional().describe("Field to order results by."),
+    orderDirection: z.enum(["asc", "desc"]).optional().describe("Order direction."),
+  },
+  ({ project, team, state, assignedTo, areaPath, iterationPath, top, orderBy, orderDirection }) => {
+    let filterText = "";
+    
+    if (state) filterText += `\n- State: ${state}`;
+    if (assignedTo) filterText += `\n- Assigned To: ${assignedTo}`;
+    if (areaPath) filterText += `\n- Area Path: ${areaPath}`;
+    if (iterationPath) filterText += `\n- Iteration Path: ${iterationPath}`;
+    if (team) filterText += `\n- Team: ${team}`;
+    
+    return {
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: String.raw`
+# Task
+Use the '${WORKITEM_TOOLS.list_user_stories}' tool to retrieve User Story work items from the project '${project}'.
+
+## Parameters
+- Project: ${project}
+- Maximum Results: ${top}
+- Order By: ${orderBy} (${orderDirection})${filterText}
+
+## Required Output Format
+Present the results in a well-formatted table with the following columns:
+- ID
+- Title
+- State
+- Assigned To
+- Story Points
+- Priority
+- Area Path
+- Iteration Path
+- Created Date
+
+If no User Stories are found, display a message indicating that no User Stories match the specified criteria.
+
+Additionally, provide a summary showing:
+- Total number of User Stories found
+- Distribution by state (if multiple states are present)
+- Distribution by assignee (if multiple assignees are present)`,
+          },
+        },
+      ],
+    };
+  }
+);
 
 }
 


### PR DESCRIPTION
## Description
This PR introduces a new tool, `list_user_stories`, to the Azure DevOps MCP server. The tool allows users to retrieve a list of User Story work items from a specified Azure DevOps project with various filtering and ordering options.

## Key Features
- **Filters**:
  - `state`: Filter by work item state (e.g., Active, New, Resolved, etc.).
  - `assignedTo`: Filter by assignee (display name or email).
  - `areaPath`: Filter by area path.
  - `iterationPath`: Filter by iteration path.
- **Ordering**:
  - Supports ordering by fields such as `System.Id`, `System.Title`, `System.CreatedDate`, etc., in ascending or descending order.
- **Pagination**:
  - Limits the number of results with the `top` parameter (default: 100).
- **Detailed Information**:
  - Provides detailed information about each User Story, including fields like `System.Title`, `System.State`, `System.AssignedTo`, `System.Tags`, and more.

## Implementation Details
- The tool uses a WIQL query to fetch User Stories from Azure DevOps.
- It retrieves additional details for the fetched work items using the `getWorkItemsBatch` API.
- Handles scenarios where no User Stories match the criteria by returning an appropriate message.

## Usage
The tool can be invoked with the following parameters:
```json
{
  "project": "YourProjectName",
  "team": "YourTeamName",
  "state": "Active",
  "assignedTo": "user@example.com",
  "areaPath": "YourAreaPath",
  "iterationPath": "YourIterationPath",
  "top": 10,
  "orderBy": "System.Title",
  "orderDirection": "asc"
}
## GitHub issue number



## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
_Replace_ with use cases tested and models used