### PR TITLE
updated create_work_item to support markdown format in large text fields

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -104,7 +104,7 @@ The model should automatically use the `wit_get_work_items_batch_by_ids` tool to
 You need project, team and backlog (Epics, Stories, Features) context in order to get a list of all the work items in a backlog.
 
 ```plaintext
-get backlogs for Contoso project and Fabrikam Team
+get backlogs for Contoso project and Fabrikam team
 ```
 
 Once you have the backlog levels, you can then get work items for that backlog.
@@ -139,7 +139,7 @@ Assign this work item to myemail@outlook.com and add a comment "I will own this 
 
 📽️ [Azure DevOps MCP Server: Work with Work Items](https://youtu.be/tT7wqSIPKdA)
 
-### Create and Link Test Cases
+### Create and link test cases
 
 Open a user story and automatically generate test cases with detailed steps based on the story's description. Link the generated test cases back to the original user story.
 
@@ -170,3 +170,20 @@ List of work items for Stories backlog. But then go thru and find all the securi
 ```
 
 📽️ [Azure DevOps MCP Server: Triage Work](https://youtu.be/gCI_pPS76C8)
+
+### Adding and updating work items using the `format` paramater
+
+You can use the `format` paramater to indicate markdown formatting for large text fields. It is now available on the following tools:
+
+ - **wit_update_work_items_batch**
+ - **wit_add_child_work_items**
+ - **wit_create_work_item**
+
+ > 🚩 HTML is the default unless `Markdown` is explicity set.
+
+```plaintext
+Update work item 12345 with a new description and use Markdown text. Use Markdown format param. Use bulk update.
+```
+📽️ [Azure DevOps MCP Server: Using Markdown format for create and update work items](https://youtu.be/OD4c2m7Fj9U)
+
+

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -175,15 +175,14 @@ List of work items for Stories backlog. But then go thru and find all the securi
 
 You can use the `format` paramater to indicate markdown formatting for large text fields. It is now available on the following tools:
 
- - **wit_update_work_items_batch**
- - **wit_add_child_work_items**
- - **wit_create_work_item**
+- **wit_update_work_items_batch**
+- **wit_add_child_work_items**
+- **wit_create_work_item**
 
- > 🚩 HTML is the default unless `Markdown` is explicity set.
+> 🚩 HTML is the default unless `Markdown` is explicity set.
 
 ```plaintext
 Update work item 12345 with a new description and use Markdown text. Use Markdown format param. Use bulk update.
 ```
+
 📽️ [Azure DevOps MCP Server: Using Markdown format for create and update work items](https://youtu.be/OD4c2m7Fj9U)
-
-

--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -478,7 +478,8 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
             value: z.string().describe("The value of the field."),
             format: z.enum(["Html", "Markdown"]).optional().describe("the format of the field value, e.g., 'Html', 'Markdown'. Optional, defaults to 'Html'."),
           })
-        ).describe("A record of field names and values to set on the new work item. Each fild is the field name and each value is the corresponding value to set for that field."),
+        )
+        .describe("A record of field names and values to set on the new work item. Each fild is the field name and each value is the corresponding value to set for that field."),
     },
     async ({ project, workItemType, fields }) => {
       try {

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -594,25 +594,129 @@ describe("configureWorkItemTools", () => {
       if (!call) throw new Error("wit_create_work_item tool not registered");
       const [, , , handler] = call;
 
-      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
 
       const params = {
         project: "Contoso",
         workItemType: "Task",
-        fields: ["System.Title", "Hello World!", "System.Description", "This is a sample task", "System.AreaPath", "Contoso\\Development"],
+        fields: [
+          { name: "System.Title", value: "Hello World!" },
+          { name: "System.Description", value: "This is a sample task" },
+          { name: "System.AreaPath", value: "Contoso\\Development" }
+        ],
       };
 
-      const document = Object.entries(params.fields).map(([key, value]) => ({
-        op: "add",
-        path: `/fields/${key}`,
-        value,
-      }));
+      const expectedDocument = [
+        { op: "add", path: "/fields/System.Title", value: "Hello World!" },
+        { op: "add", path: "/fields/System.Description", value: "This is a sample task" },
+        { op: "add", path: "/fields/System.AreaPath", value: "Contoso\\Development" }
+      ];
 
       const result = await handler(params);
 
-      expect(mockWorkItemTrackingApi.createWorkItem).toHaveBeenCalledWith(null, document, params.project, params.workItemType);
+      expect(mockWorkItemTrackingApi.createWorkItem).toHaveBeenCalledWith(null, expectedDocument, params.project, params.workItemType);
 
-      expect(result.content[0].text).toBe(JSON.stringify([_mockWorkItem], null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
+
+    it("should handle Markdown format for long fields", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+
+      if (!call) throw new Error("wit_create_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
+
+      const longDescription = "This is a very long description that is definitely more than 50 characters long and should trigger Markdown formatting";
+
+      const params = {
+        project: "Contoso",
+        workItemType: "Task",
+        fields: [
+          { name: "System.Title", value: "Hello World!" },
+          { name: "System.Description", value: longDescription, format: "Markdown" }
+        ],
+      };
+
+      const expectedDocument = [
+        { op: "add", path: "/fields/System.Title", value: "Hello World!" },
+        { op: "add", path: "/fields/System.Description", value: longDescription },
+        { op: "add", path: "/multilineFieldsFormat/System.Description", value: "Markdown" }
+      ];
+
+      const result = await handler(params);
+
+      expect(mockWorkItemTrackingApi.createWorkItem).toHaveBeenCalledWith(null, expectedDocument, params.project, params.workItemType);
+
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
+
+    it("should handle null response from createWorkItem", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+
+      if (!call) throw new Error("wit_create_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(null);
+
+      const params = {
+        project: "Contoso",
+        workItemType: "Task",
+        fields: [{ name: "System.Title", value: "Test" }],
+      };
+
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Work item was not created");
+    });
+
+    it("should handle errors from createWorkItem", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+
+      if (!call) throw new Error("wit_create_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue(new Error("API failure"));
+
+      const params = {
+        project: "Contoso",
+        workItemType: "Task",
+        fields: [{ name: "System.Title", value: "Test" }],
+      };
+
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error creating work item: API failure");
+    });
+
+    it("should handle unknown error types", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+
+      if (!call) throw new Error("wit_create_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue("String error");
+
+      const params = {
+        project: "Contoso",
+        workItemType: "Task",
+        fields: [{ name: "System.Title", value: "Test" }],
+      };
+
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error creating work item: Unknown error occurred");
     });
   });
 
@@ -983,10 +1087,10 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         workItemType: "Task",
-        fields: {
-          "System.Title": "Test Task",
-          "System.Description": "Test Description",
-        },
+        fields: [
+          { name: "System.Title", value: "Test Task" },
+          { name: "System.Description", value: "Test Description" }
+        ],
       };
 
       const result = await handler(params);
@@ -1007,9 +1111,9 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         workItemType: "Task",
-        fields: {
-          "System.Title": "Test Task",
-        },
+        fields: [
+          { name: "System.Title", value: "Test Task" }
+        ],
       };
 
       const result = await handler(params);
@@ -1075,9 +1179,9 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         workItemType: "Task",
-        fields: {
-          "System.Title": "Test Task",
-        },
+        fields: [
+          { name: "System.Title", value: "Test Task" }
+        ],
       };
 
       const result = await handler(params);

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -602,14 +602,14 @@ describe("configureWorkItemTools", () => {
         fields: [
           { name: "System.Title", value: "Hello World!" },
           { name: "System.Description", value: "This is a sample task" },
-          { name: "System.AreaPath", value: "Contoso\\Development" }
+          { name: "System.AreaPath", value: "Contoso\\Development" },
         ],
       };
 
       const expectedDocument = [
         { op: "add", path: "/fields/System.Title", value: "Hello World!" },
         { op: "add", path: "/fields/System.Description", value: "This is a sample task" },
-        { op: "add", path: "/fields/System.AreaPath", value: "Contoso\\Development" }
+        { op: "add", path: "/fields/System.AreaPath", value: "Contoso\\Development" },
       ];
 
       const result = await handler(params);
@@ -636,14 +636,14 @@ describe("configureWorkItemTools", () => {
         workItemType: "Task",
         fields: [
           { name: "System.Title", value: "Hello World!" },
-          { name: "System.Description", value: longDescription, format: "Markdown" }
+          { name: "System.Description", value: longDescription, format: "Markdown" },
         ],
       };
 
       const expectedDocument = [
         { op: "add", path: "/fields/System.Title", value: "Hello World!" },
         { op: "add", path: "/fields/System.Description", value: longDescription },
-        { op: "add", path: "/multilineFieldsFormat/System.Description", value: "Markdown" }
+        { op: "add", path: "/multilineFieldsFormat/System.Description", value: "Markdown" },
       ];
 
       const result = await handler(params);
@@ -1089,7 +1089,7 @@ describe("configureWorkItemTools", () => {
         workItemType: "Task",
         fields: [
           { name: "System.Title", value: "Test Task" },
-          { name: "System.Description", value: "Test Description" }
+          { name: "System.Description", value: "Test Description" },
         ],
       };
 
@@ -1111,9 +1111,7 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         workItemType: "Task",
-        fields: [
-          { name: "System.Title", value: "Test Task" }
-        ],
+        fields: [{ name: "System.Title", value: "Test Task" }],
       };
 
       const result = await handler(params);
@@ -1179,9 +1177,7 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         workItemType: "Task",
-        fields: [
-          { name: "System.Title", value: "Test Task" }
-        ],
+        fields: [{ name: "System.Title", value: "Test Task" }],
       };
 
       const result = await handler(params);


### PR DESCRIPTION
Updated `create_work_item` to accept a `format` param so that you can set large text fields to use markdown. By default it is HTML. Also note, there is not good way on create to know if the field is a large text field or not. So it is going to assume the LLM knows what you ared doing based on your prompt. As a secondary check, we are looking at the value and if it is greater than 50 characters, it is safer to assume it is a large text field. Worse case, the opp will fail if you try and set a field to markdown that is not large text.

Updated `update_work_items_batch` as well to take format

## GitHub issue number #218 #264

## **Associated Risks**

Should be fine, no risks

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

updated tests and ran thru manual tests
