### PR TITLE
fix: resolve Jest ES module and TypeScript configuration issues

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,9 +1,12 @@
 module.exports = {
-  // Use ts-jest preset for TypeScript support
-  preset: "ts-jest",
+  // Use ts-jest preset for TypeScript support with ES modules
+  preset: "ts-jest/presets/default-esm",
 
   // Specify the test environment (node for backend projects)
   testEnvironment: "node",
+
+  // Enable ES modules
+  extensionsToTreatAsEsm: [".ts"],
 
   // Root directory for test files
   roots: ["<rootDir>/test"],
@@ -36,13 +39,23 @@ module.exports = {
   // Module file extensions for importing
   moduleFileExtensions: ["ts", "js"],
 
-  // Transform settings for ts-jest
+  // Transform settings for ts-jest with ESM support
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: {
+          module: "esnext",
+        },
+      },
+    ],
   },
 
+  // Module name mapping for .js imports to .ts files
   moduleNameMapper: {
     "^(.+)/version\\.js$": "$1/version.ts",
     "^(.+)/utils\\.js$": "$1/utils.ts",
+    "^(\\.{1,2}/.*)\\.js$": "$1"
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "isolatedModules": true,
     "paths": {
       "@modules/*": ["modules/*"],
       "@tools/*": ["tools/*"],


### PR DESCRIPTION
`npm run test` command shows warnings;

```sh
npm run test

> @azure-devops/mcp@1.1.0 test
> jest

ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
```

This PR is to fix configuration for Jest for ES modules and TypeScript

- Add isolatedModules: true to tsconfig.json to resolve ts-jest warnings
- Update Jest config to use ts-jest/presets/default-esm preset
- Configure extensionsToTreatAsEsm and proper transform settings
- Add module name mapping for .js imports to .ts files
- Resolves ES module import errors in test suite

Fixes all 7 test suites to run successfully with 96 passing tests

## GitHub issue number

None

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Run `npm run test` and see the warnings gone