### PR TITLE
chore: add missing copyright and license comments to useragent.ts

### DIFF
--- a/src/useragent.ts
+++ b/src/useragent.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 interface McpClientInfo {
   name: string;
   version: string;


### PR DESCRIPTION
Adding missing header to the useragent.ts file to fix linter warnings

## GitHub issue number

None

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Open the useragent.ts file and see the linter warnings gone