### PR TITLE
add build tests to improve code coverage

### DIFF
--- a/test/src/tools/builds.test.ts
+++ b/test/src/tools/builds.test.ts
@@ -17,13 +17,14 @@ describe("configureBuildTools", () => {
   let server: McpServer;
   let tokenProvider: TokenProviderMock;
   let connectionProvider: ConnectionProviderMock;
-  let mockConnection: { getBuildApi: jest.Mock; serverUrl: string };
+  let mockConnection: { getBuildApi: jest.Mock; getPipelinesApi: jest.Mock; serverUrl: string };
 
   beforeEach(() => {
     server = { tool: jest.fn() } as unknown as McpServer;
     tokenProvider = jest.fn();
     mockConnection = {
       getBuildApi: jest.fn(),
+      getPipelinesApi: jest.fn(),
       serverUrl: "https://dev.azure.com/test-org",
     };
     connectionProvider = jest.fn().mockResolvedValue(mockConnection);
@@ -216,6 +217,653 @@ describe("configureBuildTools", () => {
           }),
         })
       );
+    });
+  });
+
+  describe("get_definitions tool", () => {
+    it("should call getDefinitions with correct parameters and return expected result", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_definitions");
+      if (!call) throw new Error("build_get_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitions: jest.fn().mockResolvedValue([
+          { id: 1, name: "Build Definition 1" },
+          { id: 2, name: "Build Definition 2" },
+        ]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "repo-123",
+        repositoryType: "TfsGit" as const,
+        name: "test-build",
+        top: 10,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getDefinitions).toHaveBeenCalledWith(
+        "test-project",
+        "test-build",
+        "repo-123",
+        "TfsGit",
+        undefined, // queryOrder
+        10, // top
+        undefined, // continuationToken
+        undefined, // minMetricsTime
+        undefined, // definitionIds
+        undefined, // path
+        undefined, // builtAfter
+        undefined, // notBuiltAfter
+        undefined, // includeAllProperties
+        undefined, // includeLatestBuilds
+        undefined, // taskIdFilter
+        undefined, // processType
+        undefined // yamlFilename
+      );
+
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          [
+            { id: 1, name: "Build Definition 1" },
+            { id: 2, name: "Build Definition 2" },
+          ],
+          null,
+          2
+        )
+      );
+    });
+
+    it("should handle API errors for get_definitions", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_definitions");
+      if (!call) throw new Error("build_get_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitions: jest.fn().mockRejectedValue(new Error("API Error")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = { project: "test-project" };
+
+      await expect(handler(params)).rejects.toThrow("API Error");
+    });
+  });
+
+  describe("get_definition_revisions tool", () => {
+    it("should call getDefinitionRevisions with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_definition_revisions");
+      if (!call) throw new Error("build_get_definition_revisions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitionRevisions: jest.fn().mockResolvedValue([
+          { revision: 1, comment: "Initial revision" },
+          { revision: 2, comment: "Updated build steps" },
+        ]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 123,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getDefinitionRevisions).toHaveBeenCalledWith("test-project", 123);
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          [
+            { revision: 1, comment: "Initial revision" },
+            { revision: 2, comment: "Updated build steps" },
+          ],
+          null,
+          2
+        )
+      );
+    });
+
+    it("should handle API errors for get_definition_revisions", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_definition_revisions");
+      if (!call) throw new Error("build_get_definition_revisions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitionRevisions: jest.fn().mockRejectedValue(new Error("Definition not found")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 999,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Definition not found");
+    });
+  });
+
+  describe("get_builds tool", () => {
+    it("should call getBuilds with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_builds");
+      if (!call) throw new Error("build_get_builds tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuilds: jest.fn().mockResolvedValue([
+          { id: 1, buildNumber: "20241201.1", status: "completed" },
+          { id: 2, buildNumber: "20241201.2", status: "inProgress" },
+        ]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        definitions: [1, 2],
+        top: 5,
+        branchName: "refs/heads/main",
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getBuilds).toHaveBeenCalledWith(
+        "test-project",
+        [1, 2], // definitions
+        undefined, // queues
+        undefined, // buildNumber
+        undefined, // minTime
+        undefined, // maxTime
+        undefined, // requestedFor
+        undefined, // reasonFilter
+        undefined, // statusFilter
+        undefined, // resultFilter
+        undefined, // tagFilters
+        undefined, // properties
+        5, // top
+        undefined, // continuationToken
+        undefined, // maxBuildsPerDefinition
+        undefined, // deletedFilter
+        undefined, // queryOrder (default BuildQueryOrder.QueueTimeDescending)
+        "refs/heads/main", // branchName
+        undefined, // buildIds
+        undefined, // repositoryId
+        undefined // repositoryType
+      );
+
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          [
+            { id: 1, buildNumber: "20241201.1", status: "completed" },
+            { id: 2, buildNumber: "20241201.2", status: "inProgress" },
+          ],
+          null,
+          2
+        )
+      );
+    });
+
+    it("should handle API errors for get_builds", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_builds");
+      if (!call) throw new Error("build_get_builds tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuilds: jest.fn().mockRejectedValue(new Error("Project not found")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = { project: "nonexistent-project" };
+
+      await expect(handler(params)).rejects.toThrow("Project not found");
+    });
+  });
+
+  describe("get_log tool", () => {
+    it("should call getBuildLogs with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_log");
+      if (!call) throw new Error("build_get_log tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildLogs: jest.fn().mockResolvedValue([
+          { id: 1, lineCount: 100 },
+          { id: 2, lineCount: 50 },
+        ]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getBuildLogs).toHaveBeenCalledWith("test-project", 123);
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          [
+            { id: 1, lineCount: 100 },
+            { id: 2, lineCount: 50 },
+          ],
+          null,
+          2
+        )
+      );
+    });
+
+    it("should handle API errors for get_log", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_log");
+      if (!call) throw new Error("build_get_log tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildLogs: jest.fn().mockRejectedValue(new Error("Build not found")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 999,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Build not found");
+    });
+  });
+
+  describe("get_log_by_id tool", () => {
+    it("should call getBuildLogLines with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_log_by_id");
+      if (!call) throw new Error("build_get_log_by_id tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildLogLines: jest.fn().mockResolvedValue(["2024-12-01T10:00:00.000Z Starting build...", "2024-12-01T10:01:00.000Z Build completed successfully"]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+        logId: 1,
+        startLine: 10,
+        endLine: 20,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getBuildLogLines).toHaveBeenCalledWith("test-project", 123, 1, 10, 20);
+      expect(result.content[0].text).toBe(JSON.stringify(["2024-12-01T10:00:00.000Z Starting build...", "2024-12-01T10:01:00.000Z Build completed successfully"], null, 2));
+    });
+
+    it("should handle API errors for get_log_by_id", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_log_by_id");
+      if (!call) throw new Error("build_get_log_by_id tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildLogLines: jest.fn().mockRejectedValue(new Error("Log not found")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+        logId: 999,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Log not found");
+    });
+  });
+
+  describe("get_changes tool", () => {
+    it("should call getBuildChanges with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_changes");
+      if (!call) throw new Error("build_get_changes tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildChanges: jest.fn().mockResolvedValue([
+          { id: "abc123", message: "Fixed bug in login" },
+          { id: "def456", message: "Added new feature" },
+        ]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+        continuationToken: "token123",
+        top: 50,
+        includeSourceChange: true,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getBuildChanges).toHaveBeenCalledWith("test-project", 123, "token123", 50, true);
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          [
+            { id: "abc123", message: "Fixed bug in login" },
+            { id: "def456", message: "Added new feature" },
+          ],
+          null,
+          2
+        )
+      );
+    });
+
+    it("should use default top value when not provided", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_changes");
+      if (!call) throw new Error("build_get_changes tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildChanges: jest.fn().mockResolvedValue([]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+      };
+
+      await handler(params);
+
+      expect(mockBuildApi.getBuildChanges).toHaveBeenCalledWith("test-project", 123, undefined, undefined, undefined);
+    });
+
+    it("should handle API errors for get_changes", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_changes");
+      if (!call) throw new Error("build_get_changes tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildChanges: jest.fn().mockRejectedValue(new Error("Changes not available")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Changes not available");
+    });
+  });
+
+  describe("run_build tool", () => {
+    it("should trigger build with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_run_build");
+      if (!call) throw new Error("build_run_build tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue({
+          repository: {
+            defaultBranch: "refs/heads/main",
+          },
+        }),
+        getBuildReport: jest.fn().mockResolvedValue({
+          id: 456,
+          status: "queued",
+        }),
+      };
+
+      const mockPipelinesApi = {
+        runPipeline: jest.fn().mockResolvedValue({
+          id: 456,
+        }),
+      };
+
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getPipelinesApi.mockResolvedValue(mockPipelinesApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 123,
+        sourceBranch: "refs/heads/feature/new-feature",
+        parameters: { key1: "value1", key2: "value2" },
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getDefinition).toHaveBeenCalledWith("test-project", 123);
+      expect(mockPipelinesApi.runPipeline).toHaveBeenCalledWith(
+        {
+          resources: {
+            repositories: {
+              self: {
+                refName: "refs/heads/feature/new-feature",
+              },
+            },
+          },
+          templateParameters: { key1: "value1", key2: "value2" },
+        },
+        "test-project",
+        123
+      );
+      expect(mockBuildApi.getBuildReport).toHaveBeenCalledWith("test-project", 456);
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          {
+            id: 456,
+            status: "queued",
+          },
+          null,
+          2
+        )
+      );
+    });
+
+    it("should use default branch when sourceBranch not provided", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_run_build");
+      if (!call) throw new Error("build_run_build tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue({
+          repository: {
+            defaultBranch: "refs/heads/develop",
+          },
+        }),
+        getBuildReport: jest.fn().mockResolvedValue({ id: 456 }),
+      };
+
+      const mockPipelinesApi = {
+        runPipeline: jest.fn().mockResolvedValue({ id: 456 }),
+      };
+
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getPipelinesApi.mockResolvedValue(mockPipelinesApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 123,
+      };
+
+      await handler(params);
+
+      expect(mockPipelinesApi.runPipeline).toHaveBeenCalledWith(
+        {
+          resources: {
+            repositories: {
+              self: {
+                refName: "refs/heads/develop",
+              },
+            },
+          },
+          templateParameters: undefined,
+        },
+        "test-project",
+        123
+      );
+    });
+
+    it("should use fallback branch when no repository default branch", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_run_build");
+      if (!call) throw new Error("build_run_build tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue({
+          repository: null,
+        }),
+        getBuildReport: jest.fn().mockResolvedValue({ id: 456 }),
+      };
+
+      const mockPipelinesApi = {
+        runPipeline: jest.fn().mockResolvedValue({ id: 456 }),
+      };
+
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getPipelinesApi.mockResolvedValue(mockPipelinesApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 123,
+      };
+
+      await handler(params);
+
+      expect(mockPipelinesApi.runPipeline).toHaveBeenCalledWith(
+        {
+          resources: {
+            repositories: {
+              self: {
+                refName: "refs/heads/main",
+              },
+            },
+          },
+          templateParameters: undefined,
+        },
+        "test-project",
+        123
+      );
+    });
+
+    it("should handle missing build ID from pipeline run", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_run_build");
+      if (!call) throw new Error("build_run_build tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue({
+          repository: { defaultBranch: "refs/heads/main" },
+        }),
+      };
+
+      const mockPipelinesApi = {
+        runPipeline: jest.fn().mockResolvedValue({
+          id: undefined, // Missing build ID
+        }),
+      };
+
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getPipelinesApi = jest.fn().mockResolvedValue(mockPipelinesApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 123,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Failed to get build ID from pipeline run");
+    });
+
+    it("should handle API errors for run_build", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_run_build");
+      if (!call) throw new Error("build_run_build tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockRejectedValue(new Error("Definition not found")),
+      };
+
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        definitionId: 999,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Definition not found");
+    });
+  });
+
+  describe("get_status tool", () => {
+    it("should call getBuildReport with correct parameters", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_status");
+      if (!call) throw new Error("build_get_status tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildReport: jest.fn().mockResolvedValue({
+          id: 123,
+          status: "completed",
+          result: "succeeded",
+        }),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 123,
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getBuildReport).toHaveBeenCalledWith("test-project", 123);
+      expect(result.content[0].text).toBe(
+        JSON.stringify(
+          {
+            id: 123,
+            status: "completed",
+            result: "succeeded",
+          },
+          null,
+          2
+        )
+      );
+    });
+
+    it("should handle API errors for get_status", async () => {
+      configureBuildTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "build_get_status");
+      if (!call) throw new Error("build_get_status tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getBuildReport: jest.fn().mockRejectedValue(new Error("Build not found")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        buildId: 999,
+      };
+
+      await expect(handler(params)).rejects.toThrow("Build not found");
     });
   });
 });


### PR DESCRIPTION
Improve Build code coverage from;

```sh
----------------|---------|----------|---------|---------|------------------------------------------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                    
----------------|---------|----------|---------|---------|------------------------------------------------------
  builds.ts     |   40.29 |    28.57 |      20 |   39.39 | 66-88,102-106,161-187,201-205,222-226,243-247,263-286,300-304
----------------|---------|----------|---------|---------|------------------------------------------------------
```

to

```sh
----------------|---------|----------|---------|---------|------------------------------------------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                    
----------------|---------|----------|---------|---------|------------------------------------------------------
     builds.ts  |     100 |      100 |     100 |     100 |
----------------|---------|----------|---------|---------|------------------------------------------------------
```

## GitHub issue number

#57 (Don't close the issue, there are other tools to improve test coverages)

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Run `npm run test` in the project root