### PR TITLE
fix: to link work items to pr

### DIFF
--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -335,19 +335,19 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     WORKITEM_TOOLS.link_work_item_to_pull_request,
     "Link a single work item to an existing pull request.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      projectId: z.string().describe("The project ID of the Azure DevOps project (note: project name is not valid)."),
       repositoryId: z.string().describe("The ID of the repository containing the pull request. Do not use the repository name here, use the ID instead."),
       pullRequestId: z.number().describe("The ID of the pull request to link to."),
       workItemId: z.number().describe("The ID of the work item to link to the pull request."),
     },
-    async ({ project, repositoryId, pullRequestId, workItemId }) => {
+    async ({ projectId, repositoryId, pullRequestId, workItemId }) => {
       try {
         const connection = await connectionProvider();
         const workItemTrackingApi = await connection.getWorkItemTrackingApi();
 
         // Create artifact link relation using vstfs format
         // Format: vstfs:///Git/PullRequestId/{project}/{repositoryId}/{pullRequestId}
-        const artifactPathValue = `${project}/${repositoryId}/${pullRequestId}`;
+        const artifactPathValue = `${projectId}/${repositoryId}/${pullRequestId}`;
         const vstfsUrl = `vstfs:///Git/PullRequestId/${encodeURIComponent(artifactPathValue)}`;
 
         // Use the PATCH document format for adding a relation
@@ -366,7 +366,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         ];
 
         // Use the WorkItem API to update the work item with the new relation
-        const workItem = await workItemTrackingApi.updateWorkItem({}, patchDocument, workItemId, project);
+        const workItem = await workItemTrackingApi.updateWorkItem({}, patchDocument, workItemId, projectId);
 
         if (!workItem) {
           return { content: [{ type: "text", text: "Work item update failed" }], isError: true };

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -382,13 +382,13 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
       const params = {
-        project: "Contoso",
+        projectId: "6bfde89e-b22e-422e-814a-e8db432f5a58",
         repositoryId: 12345,
         pullRequestId: 67890,
         workItemId: 131489,
       };
 
-      const artifactPathValue = `${params.project}/${params.repositoryId}/${params.pullRequestId}`;
+      const artifactPathValue = `${params.projectId}/${params.repositoryId}/${params.pullRequestId}`;
       const vstfsUrl = `vstfs:///Git/PullRequestId/${encodeURIComponent(artifactPathValue)}`;
 
       const document = [
@@ -407,7 +407,7 @@ describe("configureWorkItemTools", () => {
 
       const result = await handler(params);
 
-      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith({}, document, params.workItemId, params.project);
+      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith({}, document, params.workItemId, params.projectId);
 
       expect(result.content[0].text).toBe(
         JSON.stringify(
@@ -432,7 +432,7 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("API failure"));
 
       const params = {
-        project: "Contoso",
+        projectId: "6bfde89e-b22e-422e-814a-e8db432f5a58",
         repositoryId: 12345,
         pullRequestId: 67890,
         workItemId: 131489,
@@ -443,7 +443,7 @@ describe("configureWorkItemTools", () => {
       expect(result.content[0].text).toContain("API failure");
     });
 
-    it("should encode special characters in project and repositoryId for vstfsUrl", async () => {
+    it("should encode special characters in projectId and repositoryId for vstfsUrl", async () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
@@ -452,12 +452,12 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
       const params = {
-        project: "Contoso Project",
+        projectId: "6bfde89e-b22e-422e-814a-e8db432f5a58",
         repositoryId: "repo/with/slash",
         pullRequestId: 67890,
         workItemId: 131489,
       };
-      const artifactPathValue = `${params.project}/${params.repositoryId}/${params.pullRequestId}`;
+      const artifactPathValue = `${params.projectId}/${params.repositoryId}/${params.pullRequestId}`;
       const vstfsUrl = `vstfs:///Git/PullRequestId/${encodeURIComponent(artifactPathValue)}`;
       const document = [
         {
@@ -473,7 +473,7 @@ describe("configureWorkItemTools", () => {
         },
       ];
       await handler(params);
-      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith({}, document, params.workItemId, params.project);
+      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith({}, document, params.workItemId, params.projectId);
     });
 
     it("should handle link_work_item_to_pull_request unknown error type", async () => {
@@ -487,7 +487,7 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue("String error");
 
       const params = {
-        project: "TestProject",
+        projectId: "6bfde89e-b22e-422e-814a-e8db432f5a58",
         repositoryId: "repo-123",
         pullRequestId: 42,
         workItemId: 1,


### PR DESCRIPTION
Changed param from project to projectid. Looks like only projectid is accepted when adding link to PR.

## GitHub issue number #281 

## **Associated Risks**
None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Updated automated tests and tested manually
