### PR TITLE
Added support of markdown for work item comments 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,4 @@ import { packageVersion } from "./version.js";
 
 export const apiVersion = "7.2-preview.1";
 export const batchApiVersion = "5.0";
+export const markdownCommentsApiVersion = "7.2-preview.4";


### PR DESCRIPTION
Added support of markdown for work item comments.
[Add work item comments API reference](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/comments/add-work-item-comment?view=azure-devops-rest-7.2&tabs=HTTP)

## GitHub issue number
#66

## **Associated Risks**
None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Tested with `Claude Sonnet 4`.
Tried adding comments containing markdown or HTML content or just a plain text. It successfully uses the format parameter in most of the cases.
