### PR TITLE
Add AssignedTo field to wit_get_work_items_batch_by_ids tool

### DIFF
--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -762,4 +762,3 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 }
 
 export { configureWorkItemTools, WORKITEM_TOOLS };
-

--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -4,11 +4,9 @@
 import { AccessToken } from "@azure/identity";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
-import { WorkItemExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
-import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
-import { Operation } from "azure-devops-node-api/interfaces/common/VSSInterfaces.js";
+import { QueryExpand, WorkItemExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { z } from "zod";
-import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, safeEnumConvert } from "../utils.js";
+import { batchApiVersion, getEnumKeys, markdownCommentsApiVersion, safeEnumConvert } from "../utils.js";
 
 /**
  * Converts Operation enum key to lowercase string for API usage
@@ -140,7 +138,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, ids }) => {
       const connection = await connectionProvider();
       const workItemApi = await connection.getWorkItemTrackingApi();
-      const fields = ["System.Id", "System.WorkItemType", "System.Title", "System.State", "System.Parent", "System.Tags"];
+      const fields = ["System.Id", "System.WorkItemType", "System.Title", "System.State", "System.Parent", "System.Tags", "System.AssignedTo"];
       const workitems = await workItemApi.getWorkItemsBatch({ ids, fields }, project);
 
       return {
@@ -763,4 +761,5 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
   );
 }
 
-export { WORKITEM_TOOLS, configureWorkItemTools };
+export { configureWorkItemTools, WORKITEM_TOOLS };
+

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -1,9 +1,9 @@
 import { AccessToken } from "@azure/identity";
 import { describe, expect, it } from "@jest/globals";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { configureWorkItemTools } from "../../../src/tools/workitems";
 import { WebApi } from "azure-devops-node-api";
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
+import { configureWorkItemTools } from "../../../src/tools/workitems";
 import {
   _mockBacklogs,
   _mockQuery,
@@ -285,7 +285,15 @@ describe("configureWorkItemTools", () => {
       expect(mockWorkItemTrackingApi.getWorkItemsBatch).toHaveBeenCalledWith(
         {
           ids: params.ids,
-          fields: ["System.Id", "System.WorkItemType", "System.Title", "System.State", "System.Parent", "System.Tags"],
+          fields: [
+            "System.Id",
+            "System.WorkItemType",
+            "System.Title",
+            "System.State",
+            "System.Parent",
+            "System.Tags",
+            "System.AssignedTo",
+          ],
         },
         params.project
       );

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -285,15 +285,7 @@ describe("configureWorkItemTools", () => {
       expect(mockWorkItemTrackingApi.getWorkItemsBatch).toHaveBeenCalledWith(
         {
           ids: params.ids,
-          fields: [
-            "System.Id",
-            "System.WorkItemType",
-            "System.Title",
-            "System.State",
-            "System.Parent",
-            "System.Tags",
-            "System.AssignedTo",
-          ],
+          fields: ["System.Id", "System.WorkItemType", "System.Title", "System.State", "System.Parent", "System.Tags", "System.AssignedTo"],
         },
         params.project
       );


### PR DESCRIPTION
Add `System.AssignedTo` field to `wit_get_work_items_batch_by_ids` tool in `workitems.ts`

## GitHub issue number
#327 

## **Associated Risks**
n/a

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Unit test passed
