### PR TITLE
Added `includeWorkItemRefs` param to the `repo_get_pull_request_by_id` tool

### DIFF
--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -535,11 +535,12 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
     {
       repositoryId: z.string().describe("The ID of the repository where the pull request is located."),
       pullRequestId: z.number().describe("The ID of the pull request to retrieve."),
+      includeWorkItemRefs: z.boolean().optional().default(false).describe("Whether to reference work items associated with the pull request."),
     },
-    async ({ repositoryId, pullRequestId }) => {
+    async ({ repositoryId, pullRequestId, includeWorkItemRefs }) => {
       const connection = await connectionProvider();
       const gitApi = await connection.getGitApi();
-      const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId);
+      const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, undefined, undefined, undefined, undefined, undefined, includeWorkItemRefs);
       return {
         content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
       };


### PR DESCRIPTION
Added the `includeWorkItemRefs` param to include work items references linked to the PR.

how it looks in output json:

```json
  "workItemRefs": [
    {
      "id": "1",
      "url": "https://dev.azure.com/localconst-org/_apis/wit/workItems/1"
    },
    {
      "id": "2",
      "url": "https://dev.azure.com/localconst-org/_apis/wit/workItems/2"
     }
  ],
```

## GitHub issue number

#274 

## **Associated Risks**

Not actually a risk, but a note that to get full info about WIs agent will need to use another tools.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested on: GH Copilot in VSCode with gpt-4.1

1. Built server with changes
2. Configured it for VSCode
3. Created several test work items
4. Created test PR
5. Linked WIs to PR
6. Made call:  "get all PR's attached work items: <PR url>"
7. Observed tool call. Verified params included new `includeWorkItemRefs`
8. Observed tool call result. Verified work items are included in output json
9. Verified GH copilot understand how to use WI refs in future calls, specifically in `wit_get_work_item`
