### PR TITLE
feat: add support for fork source repository in pull request creation (Issue 254)

### DIFF
--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -6,6 +6,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import {
   GitRef,
+  GitForkRef,
   PullRequestStatus,
   GitQueryCommitsCriteria,
   GitVersionType,
@@ -86,11 +87,20 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
       description: z.string().optional().describe("The description of the pull request. Optional."),
       isDraft: z.boolean().optional().default(false).describe("Indicates whether the pull request is a draft. Defaults to false."),
       workItems: z.string().optional().describe("Work item IDs to associate with the pull request, space-separated."),
+      forkSourceRepositoryId: z.string().optional().describe("The ID of the fork repository that the pull request originates from. Optional, used when creating a pull request from a fork."),
     },
-    async ({ repositoryId, sourceRefName, targetRefName, title, description, isDraft, workItems }) => {
+    async ({ repositoryId, sourceRefName, targetRefName, title, description, isDraft, workItems, forkSourceRepositoryId }) => {
       const connection = await connectionProvider();
       const gitApi = await connection.getGitApi();
       const workItemRefs = workItems ? workItems.split(" ").map((id) => ({ id: id.trim() })) : [];
+
+      const forkSource: GitForkRef | undefined = forkSourceRepositoryId
+        ? {
+            repository: {
+              id: forkSourceRepositoryId,
+            },
+          }
+        : undefined;
 
       const pullRequest = await gitApi.createPullRequest(
         {
@@ -100,6 +110,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
           description,
           isDraft,
           workItemRefs: workItemRefs,
+          forkSource,
         },
         repositoryId
       );


### PR DESCRIPTION
This pull request enhances the `create_pull_request` tool in `src/tools/repos.ts` to support creating pull requests from forked repositories. The changes include adding a new parameter for specifying the fork repository ID and updating the logic to handle this parameter when creating pull requests.

## GitHub issue number
Fixes #254 

## **Associated Risks**
none

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested manually - managed to create a PR from a forked repo into the original one.