### PR TITLE
Add CommentThreadStatus parameter to repos.create_pull_request_thread

### DIFF
--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -584,8 +584,6 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
     }
   );
 
-  const commentThreadStatusStrings = Object.values(CommentThreadStatus).filter((value): value is string => typeof value === "string");
-
   server.tool(
     REPO_TOOLS.create_pull_request_thread,
     "Creates a new comment thread on a pull request.",
@@ -596,7 +594,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
       project: z.string().optional().describe("Project ID or project name (optional)"),
       filePath: z.string().optional().describe("The path of the file where the comment thread will be created. (optional)"),
       status: z
-        .enum(commentThreadStatusStrings as [string, ...string[]])
+        .enum(getEnumKeys(CommentThreadStatus) as [string, ...string[]])
         .optional()
         .default(CommentThreadStatus[CommentThreadStatus.Active])
         .describe("The status of the comment thread. Defaults to 'Active'."),


### PR DESCRIPTION
Add CommentThreadStatus parameter to repos.create_pull_request_thread to fix all comments being created with "Unknown" status

## GitHub issue number
[339](https://github.com/microsoft/azure-devops-mcp/issues/339)
## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Used GPT-4.1 with prompt "Create a comment on {PR url} with the content "Test 123" and status of Fixed"

<img width="441" height="491" alt="pr_review_1" src="https://github.com/user-attachments/assets/56e10956-bb6c-4ef9-b798-658fe0a71c8c" />
<img width="1749" height="192" alt="pr_review_2" src="https://github.com/user-attachments/assets/26518526-50a8-442c-8c04-d7e2e9a77ea5" />
