### PR TITLE
fix: update the multi-tenant mcp.json structure to a working format

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -79,19 +79,19 @@ The MCP server may be authenticating with a different tenant than your Azure Dev
        {
          "id": "ado_org",
          "type": "promptString",
-         "description": "Azure DevOps organization name (e.g. 'contoso')"
+         "description": "Azure DevOps organization name  (e.g. 'contoso')"
        },
        {
          "id": "ado_tenant",
          "type": "promptString",
          "description": "Azure tenant ID (required for multi-tenant scenarios)"
-       }
+        }
      ],
      "servers": {
        "ado": {
          "type": "stdio",
-         "command": "mcp-server-azuredevops",
-         "args": ["${input:ado_org}", "--tenant", "${input:ado_tenant}"]
+         "command": "npx",
+         "args": ["-y", "@azure-devops/mcp", "${input:ado_org}", "--tenant", "${input:ado_tenant}"]
        }
      }
    }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -79,13 +79,13 @@ The MCP server may be authenticating with a different tenant than your Azure Dev
        {
          "id": "ado_org",
          "type": "promptString",
-         "description": "Azure DevOps organization name  (e.g. 'contoso')"
+         "description": "Azure DevOps organization name (e.g. 'contoso')"
        },
        {
          "id": "ado_tenant",
          "type": "promptString",
          "description": "Azure tenant ID (required for multi-tenant scenarios)"
-        }
+       }
      ],
      "servers": {
        "ado": {


### PR DESCRIPTION
The structure of the JSON for the `mcp.json` sample in the configuration when using multi-tenant accounts was not working and the server could not be started. Updated the configuration to follow the same approach as the guidance from `README.MD` on root of the repo. This approach works.

## GitHub issue number

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- Reload VS Code to load the new settings.
- Start the server > VS Code prompts for the tenant and project. 
- Use GHCP Chat to search for a work item, results from the ADO project work as expected.

