### PR TITLE
Add pull request update tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Interact with these Azure DevOps services:
 - **repo_get_pull_request_by_id**: Get a pull request by its ID.
 - **repo_create_pull_request**: Create a new pull request.
 - **repo_update_pull_request_status**: Update the status of an existing pull request to active or abandoned.
+- **repo_update_pull_request**: Update various fields of an existing pull request (title, description, draft status, target branch).
 - **repo_update_pull_request_reviewers**: Add or remove reviewers for an existing pull request.
 - **repo_reply_to_comment**: Replies to a specific comment on a pull request.
 - **repo_resolve_comment**: Resolves a specific comment thread on a pull request.

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -144,7 +144,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
 
   server.tool(
     REPO_TOOLS.update_pull_request,
-    "Update a Pull Request by id with specified fields.",
+    "Update a Pull Request by ID with specified fields.",
     {
       repositoryId: z.string().describe("The ID of the repository where the pull request exists."),
       pullRequestId: z.number().describe("The ID of the pull request to update."),

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -187,7 +187,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
         targetRefName?: string;
       } = {};
       if (title !== undefined) updateRequest.title = title;
-      if (description !== undefined) updateRequest.description = description;  
+      if (description !== undefined) updateRequest.description = description;
       if (isDraft !== undefined) updateRequest.isDraft = isDraft;
       if (targetRefName !== undefined) updateRequest.targetRefName = targetRefName;
 

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -144,7 +144,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
 
   server.tool(
     REPO_TOOLS.update_pull_request,
-    "Update various fields of an existing pull request (title, description, draft status, target branch, status).",
+    "Update a Pull Request by id with specified fields.",
     {
       repositoryId: z.string().describe("The ID of the repository where the pull request exists."),
       pullRequestId: z.number().describe("The ID of the pull request to update."),

--- a/test/src/tools/repos.test.ts
+++ b/test/src/tools/repos.test.ts
@@ -47,7 +47,7 @@ describe("repos tools", () => {
         pullRequestId: 123,
         title: "Updated Title",
         description: "Updated Description",
-        isDraft: true
+        isDraft: true,
       };
       mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
 
@@ -57,17 +57,21 @@ describe("repos tools", () => {
         title: "Updated Title",
         description: "Updated Description",
         isDraft: true,
-        targetRefName: "refs/heads/main"
+        targetRefName: "refs/heads/main",
       };
 
       const result = await handler(params);
 
-      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith({
-        title: "Updated Title",
-        description: "Updated Description",
-        isDraft: true,
-        targetRefName: "refs/heads/main"
-      }, "repo123", 123);
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        {
+          title: "Updated Title",
+          description: "Updated Description",
+          isDraft: true,
+          targetRefName: "refs/heads/main",
+        },
+        "repo123",
+        123
+      );
 
       expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
     });
@@ -86,14 +90,18 @@ describe("repos tools", () => {
       const params = {
         repositoryId: "repo123",
         pullRequestId: 123,
-        title: "New Title"
+        title: "New Title",
       };
 
       const result = await handler(params);
 
-      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith({
-        title: "New Title"
-      }, "repo123", 123);
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        {
+          title: "New Title",
+        },
+        "repo123",
+        123
+      );
 
       expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
     });
@@ -108,7 +116,7 @@ describe("repos tools", () => {
 
       const params = {
         repositoryId: "repo123",
-        pullRequestId: 123
+        pullRequestId: 123,
       };
 
       const result = await handler(params);

--- a/test/src/tools/repos.test.ts
+++ b/test/src/tools/repos.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { AccessToken } from "@azure/identity";
+import { WebApi } from "azure-devops-node-api";
+import { configureRepoTools, REPO_TOOLS } from "../../../src/tools/repos";
+
+// Mock the auth module
+jest.mock("../../../src/tools/auth", () => ({
+  getCurrentUserDetails: jest.fn(),
+}));
+
+describe("repos tools", () => {
+  let server: McpServer;
+  let tokenProvider: jest.MockedFunction<() => Promise<AccessToken>>;
+  let connectionProvider: jest.MockedFunction<() => Promise<WebApi>>;
+  let mockGitApi: {
+    updatePullRequest: jest.MockedFunction<(...args: unknown[]) => Promise<unknown>>;
+  };
+
+  beforeEach(() => {
+    server = {
+      tool: jest.fn(),
+    } as unknown as McpServer;
+
+    tokenProvider = jest.fn();
+    mockGitApi = {
+      updatePullRequest: jest.fn(),
+    };
+
+    connectionProvider = jest.fn().mockResolvedValue({
+      getGitApi: jest.fn().mockResolvedValue(mockGitApi),
+    });
+  });
+
+  describe("repo_update_pull_request", () => {
+    it("should update pull request with all provided fields", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = {
+        pullRequestId: 123,
+        title: "Updated Title",
+        description: "Updated Description",
+        isDraft: true
+      };
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123,
+        title: "Updated Title",
+        description: "Updated Description",
+        isDraft: true,
+        targetRefName: "refs/heads/main"
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith({
+        title: "Updated Title",
+        description: "Updated Description",
+        isDraft: true,
+        targetRefName: "refs/heads/main"
+      }, "repo123", 123);
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
+    });
+
+    it("should update pull request with only title", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = { pullRequestId: 123, title: "New Title" };
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123,
+        title: "New Title"
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith({
+        title: "New Title"
+      }, "repo123", 123);
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
+    });
+
+    it("should return error when no fields provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("At least one field");
+    });
+  });
+});

--- a/test/src/tools/repos.test.ts
+++ b/test/src/tools/repos.test.ts
@@ -106,6 +106,102 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
     });
 
+    it("should update pull request status to Active", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = { pullRequestId: 123, status: 1 }; // Active status
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123,
+        status: "Active" as const,
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        {
+          status: 1, // PullRequestStatus.Active
+        },
+        "repo123",
+        123
+      );
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
+    });
+
+    it("should update pull request status to Abandoned", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = { pullRequestId: 123, status: 2 }; // Abandoned status
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123,
+        status: "Abandoned" as const,
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        {
+          status: 2, // PullRequestStatus.Abandoned
+        },
+        "repo123",
+        123
+      );
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
+    });
+
+    it("should update pull request with status and other fields", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = {
+        pullRequestId: 123,
+        title: "Updated Title",
+        status: 1,
+      };
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 123,
+        title: "Updated Title",
+        status: "Active" as const,
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        {
+          title: "Updated Title",
+          status: 1, // PullRequestStatus.Active
+        },
+        "repo123",
+        123
+      );
+
+      expect(result.content[0].text).toBe(JSON.stringify(mockUpdatedPR, null, 2));
+    });
+
     it("should return error when no fields provided", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider);
 
@@ -123,7 +219,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.updatePullRequest).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("At least one field");
+      expect(result.content[0].text).toContain("At least one field (title, description, isDraft, targetRefName, or status) must be provided for update.");
     });
   });
 });


### PR DESCRIPTION
- Add repo_update_pull_request tool for updating PR title, description, draft status, and target branch
- Update documentation to reflect new tool capabilities
- Add validation to ensure at least one field is provided for update
- Support partial updates with optional parameters

## GitHub issue number
[322](https://github.com/microsoft/azure-devops-mcp/issues/322)

## **Associated Risks**

- May cause confusion with similar `update_pull_request_status` and `update_pull_request_reviewers`, neither of those operations can be accomplished with the underlying API

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
- Been using it for a little over a week for personal uses. 
- src/tools/repos.test.ts (some very loose unit tests I let copilot author)

