### PR TITLE
Adding work_item_unlink to remove links from a work item

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Interact with these Azure DevOps services:
 - **wit_get_query_results_by_id**: Retrieve the results of a work item query given the query ID.
 - **wit_update_work_items_batch**: Update work items in batch.
 - **wit_work_items_link**: Link work items together in batch.
+- **wit_work_item_unlink**: Unlink one or many links from a work item.
 
 #### Deprecated Tools
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -136,7 +136,7 @@ Update work item 12345 with a new description and use Markdown text. Use Markdow
 
 ### Remove One or More Links from a Work Item
 
-Use this tool to remove one, several, or all links from a work item. You can also remove links by a specified type.
+Use this tool to remove one or more links from a work item, either by specifying individual links or by link type.
 
 First, retrieve the work item whose links you want to remove:
 
@@ -144,10 +144,8 @@ First, retrieve the work item whose links you want to remove:
 Get work item 1234 in Contoso project and show me the relations
 ```
 
-Next, remove a specific link to a work item, pull request, etc., remove multiple links, or remove links by type (for example, "related"):
+Next, remove a specific link to a work item, pull request, etc. or remove links by type (for example, "related"):
 
 ```plaintext
-Remove link 5678 and 91011 from work item 1234. Also remove any related links and links to pull request #121314
+Remove link 5678 and 91011 from work item 1234. Also remove any related links and links to pull request 121314
 ```
-
-📽️ [Azure DevOps MCP Server: Removing links from a work item](https://youtu.be/ShhONjJhQCA)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -10,6 +10,7 @@ This guide offers step-by-step examples for using the Azure DevOps MCP Server to
 [Create and Link Test Cases](#create-and-link-test-cases)<br/>
 [Triage Work](#triage-work)<br/>
 [Using Markdown Format](#adding-and-updating-work-items-using-the-format-paramater)<br/>
+[Remove Links from a Work Item](#remove-one-or-more-links-from-a-work-item)
 
 ## 🙋‍♂️ Projects and Teams
 
@@ -132,3 +133,21 @@ Update work item 12345 with a new description and use Markdown text. Use Markdow
 ```
 
 📽️ [Azure DevOps MCP Server: Using Markdown format for create and update work items](https://youtu.be/OD4c2m7Fj9U)
+
+### Remove One or More Links from a Work Item
+
+Use this tool to remove one, several, or all links from a work item. You can also remove links by a specified type.
+
+First, retrieve the work item whose links you want to remove:
+
+```plaintext
+Get work item 1234 in Contoso project and show me the relations
+```
+
+Next, remove a specific link to a work item, pull request, etc., remove multiple links, or remove links by type (for example, "related"):
+
+```plaintext
+Remove link 5678 and 91011 from work item 1234. Also remove any related links and links to pull request #121314
+```
+
+📽️ [Azure DevOps MCP Server: Removing links from a work item](https://youtu.be/ShhONjJhQCA)

--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -786,7 +786,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       try {
         const connection = await connectionProvider();
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const workItem = await workItemApi.getWorkItem(id, [], undefined, WorkItemExpand.Relations, project);
+        const workItem = await workItemApi.getWorkItem(id, ["System.Id"], undefined, WorkItemExpand.Relations, project);
         const relations: WorkItemRelation[] = workItem.relations ?? [];
 
         const allRelationIndexes: number[] = [];

--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -4,7 +4,7 @@
 import { AccessToken } from "@azure/identity";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
-import { WorkItemExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
+import { WorkItemExpand, WorkItemRelation } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { z } from "zod";
 import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, safeEnumConvert } from "../utils.js";
@@ -27,6 +27,7 @@ const WORKITEM_TOOLS = {
   get_query_results_by_id: "wit_get_query_results_by_id",
   update_work_items_batch: "wit_update_work_items_batch",
   work_items_link: "wit_work_items_link",
+  work_item_unlink: "wit_work_item_unlink",
 };
 
 function getLinkTypeFromName(name: string) {
@@ -53,6 +54,8 @@ function getLinkTypeFromName(name: string) {
       return "Microsoft.VSTS.Common.Affects-Forward";
     case "affected by":
       return "Microsoft.VSTS.Common.Affects-Reverse";
+    case "artifact":
+      return "ArtifactLink";
     default:
       throw new Error(`Unknown link type: ${name}`);
   }
@@ -756,6 +759,98 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
       };
+    }
+  );
+
+  server.tool(
+    WORKITEM_TOOLS.work_item_unlink,
+    "Remove one or many links from a single work item.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      id: z.number().describe("The ID of the work item to remove the links from."),
+      updates: z
+        .array(
+          z.object({
+            type: z
+              .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by", "artifact"])
+              .default("related")
+              .describe(
+                "Type of link to remove. Options include 'parent', 'child', 'duplicate', 'duplicate of', 'related', 'successor', 'predecessor', 'tested by', 'tests', 'affects', 'affected by', and 'artifact'. Defaults to 'related'."
+              ),
+            url: z.string().optional().describe("Optional URL to match for the link to remove. If not provided, all links of the specified type will be removed."),
+          })
+        )
+        .describe("type and url of the link to remove. If url is not provided, all links of the specified type will be removed. You can remove more than one link at a time."),
+    },
+    async ({ project, id, updates }) => {
+      try {
+        const connection = await connectionProvider();
+        const workItemApi = await connection.getWorkItemTrackingApi();
+        const workItem = await workItemApi.getWorkItem(id, [], undefined, WorkItemExpand.Relations, project);
+        const relations: WorkItemRelation[] = workItem.relations ?? [];
+
+        const allRelationIndexes: number[] = [];
+        const removedRelations: WorkItemRelation[] = [];
+
+        // Process each update request
+        for (const update of updates) {
+          const linkType = getLinkTypeFromName(update.type);
+          let relationIndexes: number[] = [];
+
+          if (update.url && update.url.trim().length > 0) {
+            // If url is provided, find relations matching both rel type and url
+            relationIndexes = relations.map((relation, idx) => (relation.rel === linkType && relation.url === update.url ? idx : -1)).filter((idx) => idx !== -1);
+          } else {
+            // If url is not provided, find all relations matching rel type
+            relationIndexes = relations.map((relation, idx) => (relation.rel === linkType ? idx : -1)).filter((idx) => idx !== -1);
+          }
+
+          // Add to the list of indexes to remove (avoiding duplicates)
+          for (const idx of relationIndexes) {
+            if (!allRelationIndexes.includes(idx)) {
+              allRelationIndexes.push(idx);
+              removedRelations.push(relations[idx]);
+            }
+          }
+        }
+
+        if (allRelationIndexes.length === 0) {
+          return {
+            content: [{ type: "text", text: `No matching relations found for any of the specified updates.\n${JSON.stringify(relations, null, 2)}` }],
+            isError: true,
+          };
+        }
+
+        // Sort indexes in descending order to avoid index shifting when removing
+        allRelationIndexes.sort((a, b) => b - a);
+
+        const apiUpdates = allRelationIndexes.map((idx) => ({
+          op: "remove",
+          path: `/relations/${idx}`,
+        }));
+
+        const updatedWorkItem = await workItemApi.updateWorkItem(null, apiUpdates, id);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Removed the following links:\n` + JSON.stringify(removedRelations, null, 2) + `\n\nUpdated work item result:\n` + JSON.stringify(updatedWorkItem, null, 2),
+            },
+          ],
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error unlinking work item: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
     }
   );
 }

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -1310,7 +1310,7 @@ describe("configureWorkItemTools", () => {
 
       const result = await handler(params);
 
-      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, [], undefined, 1, "TestProject");
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, ["System.Id"], undefined, 1, "TestProject");
       expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(null, [{ op: "remove", path: "/relations/0" }], 1);
 
       expect(result.content[0].text).toContain("Removed the following links:");
@@ -1374,6 +1374,7 @@ describe("configureWorkItemTools", () => {
 
       const result = await handler(params);
 
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, ["System.Id"], undefined, 1, "TestProject");
       expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
         null,
         [

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -1595,14 +1595,7 @@ describe("configureWorkItemTools", () => {
       const result = await handler(params);
 
       // Should remove only the matching relation at index 0
-      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
-        null,
-        [
-          { op: "remove", path: "/relations/0" },
-        ],
-        1,
-        "TestProject"
-      );
+      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(null, [{ op: "remove", path: "/relations/0" }], 1, "TestProject");
 
       expect(result.content[0].text).toContain("Removed 1 link(s) of type 'related':");
       expect(result.content[0].text).toContain("System.LinkTypes.Related");


### PR DESCRIPTION
Added tool and tests to remove a link from a work item in batch. Meaning you can remove several links at once.

## GitHub issue number #132 

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Added all new automated tests and tested manually. Will post video and prompts in follow-up commits or PR
