### PR TITLE
feat: interactive OAuth flow added

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,81 @@
+import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
+import open from "open";
+
+const scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"];
+
+class OAuthAuthenticator {
+  static clientId = "ac9c72b1-86e4-4849-be22-eaae7731117a";
+  static authority = "https://login.microsoftonline.com/common";
+
+  private accountId: AccountInfo | null;
+  private publicClientApp: PublicClientApplication;
+
+  constructor() {
+    this.accountId = null;
+    this.publicClientApp = new PublicClientApplication({
+      auth: {
+        clientId: OAuthAuthenticator.clientId,
+        authority: OAuthAuthenticator.authority,
+      },
+    });
+  }
+
+  public async getToken(): Promise<string> {
+    let authResult: AuthenticationResult | null = null;
+    if (this.accountId) {
+      try {
+        authResult = await this.publicClientApp.acquireTokenSilent({
+          scopes,
+          account: this.accountId,
+        });
+      } catch (error) {
+        authResult = null;
+      }
+    }
+    if (!authResult) {
+      authResult = await this.publicClientApp.acquireTokenInteractive({
+        scopes,
+        openBrowser: async (url) => {
+          open(url);
+        },
+      });
+      this.accountId = authResult.account;
+    }
+
+    if (!authResult.accessToken) {
+      throw new Error("Failed to obtain Azure DevOps OAuth token.");
+    }
+    return authResult.accessToken;
+  }
+}
+
+function createAuthenticator(type: string, tenantId?: string): () => Promise<string> {
+  switch (type) {
+    case "azcli":
+    case "env":
+      if (type !== "env") {
+        process.env.AZURE_TOKEN_CREDENTIALS = "dev";
+      }
+      let credential: TokenCredential = new DefaultAzureCredential(); // CodeQL [SM05138] resolved by explicitly setting AZURE_TOKEN_CREDENTIALS
+      if (tenantId) {
+        // Use Azure CLI credential if tenantId is provided for multi-tenant scenarios
+        const azureCliCredential = new AzureCliCredential({ tenantId });
+        credential = new ChainedTokenCredential(azureCliCredential, credential);
+      }
+      return async () => {
+        const result = await credential.getToken(scopes);
+        if (!result) {
+          throw new Error("Failed to obtain Azure DevOps token. Ensure you have Azure CLI logged or use interactive type of authentication.");
+        }
+        return result.token;
+      };
+
+    default:
+      const authenticator = new OAuthAuthenticator();
+      return () => {
+        return authenticator.getToken();
+      };
+  }
+}
+export { createAuthenticator };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { AccessToken } from "@azure/identity";
 import { WebApi } from "azure-devops-node-api";
 
 import { configureCoreTools } from "./tools/core.js";
@@ -15,7 +14,7 @@ import { configureWikiTools } from "./tools/wiki.js";
 import { configureTestPlanTools } from "./tools/testplans.js";
 import { configureSearchTools } from "./tools/search.js";
 
-function configureAllTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
+function configureAllTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   configureCoreTools(server, tokenProvider, connectionProvider);
   configureWorkTools(server, tokenProvider, connectionProvider);
   configureBuildTools(server, tokenProvider, connectionProvider);

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -4,10 +4,10 @@
 import { AccessToken } from "@azure/identity";
 import { WebApi } from "azure-devops-node-api";
 
-async function getCurrentUserDetails(tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+async function getCurrentUserDetails(tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   const connection = await connectionProvider();
   const url = `${connection.serverUrl}/_apis/connectionData`;
-  const token = (await tokenProvider()).token;
+  const token = await tokenProvider();
   const response = await fetch(url, {
     method: "GET",
     headers: {

--- a/src/tools/builds.ts
+++ b/src/tools/builds.ts
@@ -21,7 +21,7 @@ const BUILD_TOOLS = {
   update_build_stage: "build_update_build_stage",
 };
 
-function configureBuildTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureBuildTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     BUILD_TOOLS.get_definitions,
     "Retrieves a list of build definitions for a given project.",
@@ -339,7 +339,7 @@ function configureBuildTools(server: McpServer, tokenProvider: () => Promise<Acc
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${token.token}`,
+          "Authorization": `Bearer ${token}`,
         },
         body: JSON.stringify(body),
       });

--- a/src/tools/core.ts
+++ b/src/tools/core.ts
@@ -21,7 +21,7 @@ function filterProjectsByName(projects: ProjectInfo[], projectNameFilter: string
   return projects.filter((project) => project.name?.toLowerCase().includes(lowerCaseFilter));
 }
 
-function configureCoreTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureCoreTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     CORE_TOOLS.list_project_teams,
     "Retrieve a list of teams for the specified Azure DevOps project.",
@@ -112,7 +112,7 @@ function configureCoreTools(server: McpServer, tokenProvider: () => Promise<Acce
 
         const response = await fetch(`${baseUrl}?${params}`, {
           headers: {
-            "Authorization": `Bearer ${token.token}`,
+            "Authorization": `Bearer ${token}`,
             "Content-Type": "application/json",
           },
         });

--- a/src/tools/releases.ts
+++ b/src/tools/releases.ts
@@ -13,7 +13,7 @@ const RELEASE_TOOLS = {
   get_releases: "release_get_releases",
 };
 
-function configureReleaseTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureReleaseTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     RELEASE_TOOLS.get_release_definitions,
     "Retrieves list of release definitions for a given project.",

--- a/src/tools/repos.ts
+++ b/src/tools/repos.ts
@@ -97,7 +97,7 @@ function filterReposByName(repositories: GitRepository[], repoNameFilter: string
   return filteredByName;
 }
 
-function configureRepoTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureRepoTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     REPO_TOOLS.create_pull_request,
     "Create a new pull request.",

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -17,7 +17,7 @@ const SEARCH_TOOLS = {
   search_workitem: "search_workitem",
 };
 
-function configureSearchTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
+function configureSearchTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     SEARCH_TOOLS.search_code,
     "Search Azure DevOps Repositories for a given search text",
@@ -57,7 +57,7 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<Ac
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "User-Agent": userAgentProvider(),
         },
         body: JSON.stringify(requestBody),
@@ -113,7 +113,7 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<Ac
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "User-Agent": userAgentProvider(),
         },
         body: JSON.stringify(requestBody),
@@ -170,7 +170,7 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<Ac
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "User-Agent": userAgentProvider(),
         },
         body: JSON.stringify(requestBody),

--- a/src/tools/testplans.ts
+++ b/src/tools/testplans.ts
@@ -16,7 +16,7 @@ const Test_Plan_Tools = {
   list_test_plans: "testplan_list_test_plans",
 };
 
-function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureTestPlanTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   /*
     LIST OF TEST PLANS
     get list of test plans by project

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -14,7 +14,7 @@ const WIKI_TOOLS = {
   get_wiki_page_content: "wiki_get_page_content",
 };
 
-function configureWikiTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureWikiTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     WIKI_TOOLS.get_wiki,
     "Get the wiki by wikiIdentifier",

--- a/src/tools/work.ts
+++ b/src/tools/work.ts
@@ -13,7 +13,7 @@ const WORK_TOOLS = {
   assign_iterations: "work_assign_iterations",
 };
 
-function configureWorkTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>) {
+function configureWorkTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     WORK_TOOLS.list_team_iterations,
     "Retrieve a list of iterations for a specific team in a project.",

--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -58,7 +58,7 @@ function getLinkTypeFromName(name: string) {
   }
 }
 
-function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<AccessToken>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
+function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     WORKITEM_TOOLS.list_backlogs,
     "Revieve a list of backlogs for a given project and team.",
@@ -205,7 +205,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       const response = await fetch(`${orgUrl}/${project}/_apis/wit/workItems/${workItemId}/comments?format=${formatParameter}&api-version=${markdownCommentsApiVersion}`, {
         method: "POST",
         headers: {
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "Content-Type": "application/json",
           "User-Agent": userAgentProvider(),
         },
@@ -329,7 +329,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         const response = await fetch(`${orgUrl}/_apis/wit/$batch?api-version=${batchApiVersion}`, {
           method: "PATCH",
           headers: {
-            "Authorization": `Bearer ${accessToken.token}`,
+            "Authorization": `Bearer ${accessToken}`,
             "Content-Type": "application/json",
             "User-Agent": userAgentProvider(),
           },
@@ -668,7 +668,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       const response = await fetch(`${orgUrl}/_apis/wit/$batch?api-version=${batchApiVersion}`, {
         method: "PATCH",
         headers: {
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "Content-Type": "application/json",
           "User-Agent": userAgentProvider(),
         },
@@ -740,7 +740,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       const response = await fetch(`${orgUrl}/_apis/wit/$batch?api-version=${batchApiVersion}`, {
         method: "PATCH",
         headers: {
-          "Authorization": `Bearer ${accessToken.token}`,
+          "Authorization": `Bearer ${accessToken}`,
           "Content-Type": "application/json",
           "User-Agent": userAgentProvider(),
         },

--- a/test/src/tools/builds.test.ts
+++ b/test/src/tools/builds.test.ts
@@ -10,7 +10,7 @@ import { mockUpdateBuildStageResponse } from "../../mocks/builds";
 // Mock fetch globally
 global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 
 describe("configureBuildTools", () => {
@@ -46,8 +46,7 @@ describe("configureBuildTools", () => {
       const [, , , handler] = call;
 
       // Mock the token provider
-      const mockToken = { token: "mock-token" };
-      (tokenProvider as jest.Mock).mockResolvedValue(mockToken);
+      (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
 
       // Mock successful fetch response
       const mockResponse = {
@@ -88,8 +87,7 @@ describe("configureBuildTools", () => {
       const [, , , handler] = call;
 
       // Mock the token provider
-      const mockToken = { token: "mock-token" };
-      (tokenProvider as jest.Mock).mockResolvedValue(mockToken);
+      (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
 
       // Mock failed fetch response
       const mockResponse = {
@@ -129,8 +127,7 @@ describe("configureBuildTools", () => {
       const [, , , handler] = call;
 
       // Mock the token provider
-      const mockToken = { token: "mock-token" };
-      (tokenProvider as jest.Mock).mockResolvedValue(mockToken);
+      (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
 
       // Mock network error
       const networkError = new Error("Network connection failed");
@@ -189,8 +186,7 @@ describe("configureBuildTools", () => {
       if (!call) throw new Error("build_update_build_stage tool not registered");
       const [, , , handler] = call;
 
-      const mockToken = { token: "mock-token" };
-      (tokenProvider as jest.Mock).mockResolvedValue(mockToken);
+      (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
 
       const mockResponse = {
         ok: true,

--- a/test/src/tools/core.test.ts
+++ b/test/src/tools/core.test.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { configureCoreTools } from "../../../src/tools/core";
 import { WebApi } from "azure-devops-node-api";
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 
 interface CoreApiMock {
@@ -432,7 +432,7 @@ describe("configureCoreTools", () => {
       const [, , , handler] = call;
 
       // Mock token provider
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock connection with serverUrl
       const mockConnectionWithUrl = {
@@ -496,7 +496,7 @@ describe("configureCoreTools", () => {
       if (!call) throw new Error("core_get_identity_ids tool not registered");
       const [, , , handler] = call;
 
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
         ...mockConnection,
         serverUrl: "https://dev.azure.com/test-org",
@@ -524,7 +524,7 @@ describe("configureCoreTools", () => {
       if (!call) throw new Error("core_get_identity_ids tool not registered");
       const [, , , handler] = call;
 
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
         ...mockConnection,
         serverUrl: "https://dev.azure.com/test-org",
@@ -551,7 +551,7 @@ describe("configureCoreTools", () => {
       if (!call) throw new Error("core_get_identity_ids tool not registered");
       const [, , , handler] = call;
 
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
         ...mockConnection,
         serverUrl: "https://dev.azure.com/test-org",
@@ -578,7 +578,7 @@ describe("configureCoreTools", () => {
       if (!call) throw new Error("core_get_identity_ids tool not registered");
       const [, , , handler] = call;
 
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
         ...mockConnection,
         serverUrl: "https://dev.azure.com/test-org",
@@ -602,7 +602,7 @@ describe("configureCoreTools", () => {
       if (!call) throw new Error("core_get_identity_ids tool not registered");
       const [, , , handler] = call;
 
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
         ...mockConnection,
         serverUrl: "https://dev.azure.com/test-org",

--- a/test/src/tools/testplan.test.ts
+++ b/test/src/tools/testplan.test.ts
@@ -8,7 +8,7 @@ import { ITestResultsApi } from "azure-devops-node-api/TestResultsApi";
 import { IWorkItemTrackingApi } from "azure-devops-node-api/WorkItemTrackingApi";
 import { ITestApi } from "azure-devops-node-api/TestApi";
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 
 describe("configureTestPlanTools", () => {

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -4,7 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { configureWikiTools } from "../../../src/tools/wiki";
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 interface WikiApiMock {
   getWiki: jest.Mock;

--- a/test/src/tools/work.test.ts
+++ b/test/src/tools/work.test.ts
@@ -5,7 +5,7 @@ import { configureWorkTools } from "../../../src/tools/work";
 import { WebApi } from "azure-devops-node-api";
 import { TreeStructureGroup } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces";
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 
 interface WorkApiMock {

--- a/test/src/tools/workitems.test.ts
+++ b/test/src/tools/workitems.test.ts
@@ -16,7 +16,7 @@ import {
   _mockWorkItemType,
 } from "../../mocks/work-items";
 
-type TokenProviderMock = () => Promise<AccessToken>;
+type TokenProviderMock = () => Promise<string>;
 type ConnectionProviderMock = () => Promise<WebApi>;
 
 interface WorkApiMock {
@@ -356,7 +356,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -396,7 +396,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -437,7 +437,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -961,7 +961,7 @@ describe("configureWorkItemTools", () => {
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
 
       // Mock tokenProvider for this test
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for successful response
       global.fetch = jest.fn().mockResolvedValue({
@@ -1025,7 +1025,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -1090,7 +1090,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -1160,7 +1160,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: false,
@@ -1191,7 +1191,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -1234,7 +1234,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: false,
@@ -1380,7 +1380,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
@@ -1416,7 +1416,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the batch API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -1462,7 +1462,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the batch API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -1511,7 +1511,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Create 51 items to exceed the limit
       const items = Array.from({ length: 51 }, (_, i) => ({
@@ -1540,7 +1540,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for the batch API call
       const mockFetch = jest.fn().mockResolvedValue({
@@ -1588,7 +1588,7 @@ describe("configureWorkItemTools", () => {
       const [, , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
-      (tokenProvider as jest.Mock).mockResolvedValue({ token: "fake-token" });
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
 
       // Mock fetch for a failed response
       const mockFetch = jest.fn().mockResolvedValue({


### PR DESCRIPTION
PR adds OAuth interactive authentication flow as a default token retrieval mechanism.
Original credentials flows are kept but need to be opted-in via command line args.

This is still WIP. ClientID needs to be replaced with a "ADO trusted" app once it is available.
Readme and Troubleshooting need to be updated as well.

## GitHub issue number

## **Associated Risks**


## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manually via inspector, all authentication options
