### PR TITLE
Fix error message in the build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,11 @@ jobs:
       - name: Check code formatting
         run: npm run format-check
 
-      - name: Build the project
-        run: npm run build
-
       - name: Verify package version is synced
         run: |
           git diff --exit-code ./src/version.ts
           if (!$?) {
-            Write-Host "Version mismatch detected. Please run 'npm run build' to update version.ts and add changes to the commit."
+            Write-Host "Version mismatch detected. Please make sure the version information in version.ts is up-to-date with package.json."
             exit 1
           }
           git diff --exit-code ./package-lock.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,9 @@ jobs:
       - name: Check code formatting
         run: npm run format-check
 
+      - name: Build the project
+        run: npm run build
+
       - name: Verify package version is synced
         run: |
           git diff --exit-code ./src/version.ts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           git diff --exit-code ./src/version.ts
           if (!$?) {
-            Write-Host "Version mismatch detected. Please make sure the version information in version.ts is up-to-date with package.json."
+            Write-Host "Version mismatch detected. Please ensure that the version information in version.ts is up to date with package.json."
             exit 1
           }
           git diff --exit-code ./package-lock.json


### PR DESCRIPTION
Build pipeline fails when the version information in the `version.ts` mismatches with the version information in the `package.json`

_Example error can be seen here; https://github.com/microsoft/azure-devops-mcp/actions/runs/16681842913/job/47222110601?pr=387#step:9:21_

Error message reads `Version mismatch detected. Please run 'npm run build' to update version.ts and add changes to the commit.`

But, there is no `npm run build` command in the `static-code-analysis` job, and also, `npm run build` would not fix this issue.

Error message fails to inform user to update version information in the `version.ts` file.

This PR fixes it.

## GitHub issue number

N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Ran the commands on local computer