### PR TITLE
Transform all possible identity fields to formatted strings in wit_get_work_items_batch_by_ids

### DIFF
--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -141,15 +141,30 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
       const workitems = await workItemApi.getWorkItemsBatch({ ids, fields: fieldsToUse }, project);
 
-      // Format the assignedTo field to include displayName and uniqueName
+      // List of identity fields that need to be transformed from objects to formatted strings
+      const identityFields = [
+        "System.AssignedTo",
+        "System.CreatedBy",
+        "System.ChangedBy",
+        "System.AuthorizedAs",
+        "Microsoft.VSTS.Common.ActivatedBy",
+        "Microsoft.VSTS.Common.ResolvedBy",
+        "Microsoft.VSTS.Common.ClosedBy",
+      ];
+
+      // Format identity fields to include displayName and uniqueName
       // Removing the identity object as the response. It's too much and not needed
       if (workitems && Array.isArray(workitems)) {
         workitems.forEach((item) => {
-          if (item.fields && item.fields["System.AssignedTo"] && typeof item.fields["System.AssignedTo"] === "object") {
-            const assignedTo = item.fields["System.AssignedTo"];
-            const name = assignedTo.displayName || "";
-            const email = assignedTo.uniqueName || "";
-            item.fields["System.AssignedTo"] = `${name} <${email}>`.trim();
+          if (item.fields) {
+            identityFields.forEach((fieldName) => {
+              if (item.fields && item.fields[fieldName] && typeof item.fields[fieldName] === "object") {
+                const identityField = item.fields[fieldName];
+                const name = identityField.displayName || "";
+                const email = identityField.uniqueName || "";
+                item.fields[fieldName] = `${name} <${email}>`.trim();
+              }
+            });
           }
         });
       }


### PR DESCRIPTION
The function `get_work_items_batch_by_ids` transforms the field `System.AssignedTo` to contain a simple `name <email>`. With pull request #385 , users can choose returned fields. It would be great to transform all possible identity fields:

- System.AssignedTo
- System.CreatedBy
- System.ChangedBy
- System.AuthorizedAs
- Microsoft.VSTS.Common.ActivatedBy
- Microsoft.VSTS.Common.ResolvedBy
- Microsoft.VSTS.Common.ClosedBy

The proposed implementation leverages a list of known identity fields. An alternative would be to detect if the field looks like an identity. The risk is that it might find false positives.

## GitHub issue number

#409 

## **Associated Risks**

_Replace_ by possible risks this pull request can bring you might have thought of

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- Added new unit test
