### PR TITLE
Update workitems.ts to make getting child workitems clearer for LLMs

### DIFF
--- a/src/tools/workitems.ts
+++ b/src/tools/workitems.ts
@@ -172,7 +172,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .enum(["all", "fields", "links", "none", "relations"])
         .describe("Optional expand parameter to include additional details in the response.")
         .optional()
-        .describe("Expand options include 'all', 'fields', 'links', 'none', and 'relations'. Defaults to 'none'."),
+        .describe("Expand options include 'all', 'fields', 'links', 'none', and 'relations'. Relations can be used to get child workitems. Defaults to 'none'."),
     },
     async ({ id, project, fields, asOf, expand }) => {
       const connection = await connectionProvider();


### PR DESCRIPTION
In my experience GPT5 (and other models I presume) don't know expanding relations gives you the ability to get child items. 

Expanding on the description of a tool's parameter might help guide it better.

I think it deserves explicit callout as getting child items (of e.g. an epic) is a very useful and potentially common operation.


## GitHub issue number #415 (#414)

## **Associated Risks**

Making tool arg description longer uses more context window. Plus prioritizing one value might make others less likely to be used by LLM. 

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manually asking GPT5 to summarize child items of an epic. 