### PR TITLE
Add errorOnly filter for get_timeline tool (Issue 448)

### DIFF
--- a/src/tools/builds.ts
+++ b/src/tools/builds.ts
@@ -375,27 +375,27 @@ function configureBuildTools(server: McpServer, tokenProvider: () => Promise<Acc
       const buildApi = await connection.getBuildApi();
       const timeline = await buildApi.getBuildTimeline(project, buildId, timelineId, changeId, planId);
 
-      if(!errorsOnly)
-      {
+      if (!errorsOnly) {
+        return {
+          content: [{ type: "text", text: JSON.stringify(timeline, null, 2) }],
+        };
+      }
+
+      // If errorsOnly is true, filter the timeline to only include records with errors
+      if (errorsOnly && timeline.records) {
+        const failedRecords = timeline.records.filter((record) => record.errorCount && record.errorCount > 0);
+        const filteredTimeline = { ...timeline, records: failedRecords };
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(filteredTimeline, null, 2) }],
+        };
+      }
+
       return {
         content: [{ type: "text", text: JSON.stringify(timeline, null, 2) }],
       };
     }
-
-    // If errorsOnly is true, filter the timeline to only include records with errors
-    if (errorsOnly && timeline.records) {
-      const failedRecords = timeline.records.filter(record => record.errorCount && record.errorCount > 0);
-      const filteredTimeline = { ...timeline, records: failedRecords };
-
-      return {
-        content: [{ type: "text", text: JSON.stringify(filteredTimeline, null, 2) }],
-      };
-    }
-
-    return {
-      content: [{ type: "text", text: JSON.stringify(timeline, null, 2) }],
-    };
-  });
+  );
 }
 
 export { BUILD_TOOLS, configureBuildTools };


### PR DESCRIPTION
Add `errorOnly` option to `get_timeline` tool, to view only records with errors.

## GitHub issue number
Fixes #448 

## **Associated Risks**
/ 

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Manually tested and updated tests.