### PR TITLE
Adding `/` by default to filepaths when creating threads (Issue 494)

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -763,7 +763,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
       const connection = await connectionProvider();
       const gitApi = await connection.getGitApi();
 
-      const normalizedFilePath = filePath && !filePath.startsWith('/') ? `/${filePath}` : filePath;
+      const normalizedFilePath = filePath && !filePath.startsWith("/") ? `/${filePath}` : filePath;
       const threadContext: CommentThreadContext = { filePath: normalizedFilePath };
 
       if (rightFileStartLine !== undefined) {

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -763,7 +763,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<Acce
       const connection = await connectionProvider();
       const gitApi = await connection.getGitApi();
 
-      const threadContext: CommentThreadContext = { filePath: filePath };
+      const normalizedFilePath = filePath && !filePath.startsWith('/') ? `/${filePath}` : filePath;
+      const threadContext: CommentThreadContext = { filePath: normalizedFilePath };
 
       if (rightFileStartLine !== undefined) {
         if (rightFileStartLine < 1) {


### PR DESCRIPTION
Adding `/` by default to filepaths when creating threads.

## GitHub issue number
Fixes #494 

## **Associated Risks**
/
## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Fixes and added tests, manually tested.