### PR TITLE
add branch parameter to configureWikiTools for wiki page operations

### DIFF
--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -220,8 +220,9 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<Acce
       content: z.string().describe("The content of the wiki page in markdown format."),
       project: z.string().optional().describe("The project name or ID where the wiki is located. If not provided, the default project will be used."),
       etag: z.string().optional().describe("ETag for editing existing pages (optional, will be fetched if not provided)."),
+      branch: z.string().default("wikiMaster").describe("The branch name for the wiki repository. Defaults to 'wikiMaster' which is the default branch for Azure DevOps wikis."),
     },
-    async ({ wikiIdentifier, path, content, project, etag }) => {
+    async ({ wikiIdentifier, path, content, project, etag, branch = "wikiMaster" }) => {
       try {
         const connection = await connectionProvider();
         const accessToken = await tokenProvider();
@@ -230,10 +231,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<Acce
         const normalizedPath = path.startsWith("/") ? path : `/${path}`;
         const encodedPath = encodeURIComponent(normalizedPath);
 
-        // Build the URL for the wiki page API
+        // Build the URL for the wiki page API with version descriptor
         const baseUrl = connection.serverUrl;
         const projectParam = project || "";
-        const url = `${baseUrl}/${projectParam}/_apis/wiki/wikis/${wikiIdentifier}/pages?path=${encodedPath}&api-version=7.1`;
+        const url = `${baseUrl}/${projectParam}/_apis/wiki/wikis/${wikiIdentifier}/pages?path=${encodedPath}&versionDescriptor.versionType=branch&versionDescriptor.version=${encodeURIComponent(branch)}&api-version=7.1`;
 
         // First, try to create a new page (PUT without ETag)
         try {

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -755,14 +755,17 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", {
-        method: "PUT",
-        headers: {
-          "Authorization": "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ content: "# Welcome\nThis is the home page." }),
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1",
+        {
+          method: "PUT",
+          headers: {
+            "Authorization": "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ content: "# Welcome\nThis is the home page." }),
+        }
+      );
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
       expect(result.isError).toBeUndefined();
     });
@@ -1176,7 +1179,10 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1",
+        expect.any(Object)
+      );
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
     });
 
@@ -1206,7 +1212,10 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg//_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.azure.com/testorg//_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1",
+        expect.any(Object)
+      );
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
     });
 
@@ -1270,14 +1279,17 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=main&api-version=7.1", {
-        method: "PUT",
-        headers: {
-          "Authorization": "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ content: "# Welcome" }),
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=main&api-version=7.1",
+        {
+          method: "PUT",
+          headers: {
+            "Authorization": "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ content: "# Welcome" }),
+        }
+      );
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
       expect(result.isError).toBeUndefined();
     });

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -755,7 +755,7 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&api-version=7.1", {
+      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", {
         method: "PUT",
         headers: {
           "Authorization": "Bearer test-token",
@@ -1176,7 +1176,7 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&api-version=7.1", expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", expect.any(Object));
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
     });
 
@@ -1206,7 +1206,7 @@ describe("configureWikiTools", () => {
 
       const result = await handler(params);
 
-      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg//_apis/wiki/wikis/wiki1/pages?path=%2FHome&api-version=7.1", expect.any(Object));
+      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg//_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=wikiMaster&api-version=7.1", expect.any(Object));
       expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
     });
 
@@ -1241,6 +1241,45 @@ describe("configureWikiTools", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error creating/updating wiki page: Could not retrieve ETag for existing page");
+    });
+
+    it("should use custom branch when specified", async () => {
+      configureWikiTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
+      if (!call) throw new Error("wiki_create_or_update_page tool not registered");
+      const [, , , handler] = call;
+
+      const mockResponse = {
+        path: "/Home",
+        id: 123,
+        content: "# Welcome",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const params = {
+        wikiIdentifier: "wiki1",
+        path: "/Home",
+        content: "# Welcome",
+        project: "proj1",
+        branch: "main",
+      };
+
+      const result = await handler(params);
+
+      expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/testorg/proj1/_apis/wiki/wikis/wiki1/pages?path=%2FHome&versionDescriptor.versionType=branch&versionDescriptor.version=main&api-version=7.1", {
+        method: "PUT",
+        headers: {
+          "Authorization": "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ content: "# Welcome" }),
+      });
+      expect(result.content[0].text).toContain("Successfully created wiki page at path: /Home");
+      expect(result.isError).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
According to the official documentation (https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/create-or-update?view=azure-devops-rest-7.1&tabs=HTTP) following fields are required;

- versionDescriptor.versionType
- versionDescriptor.version

`versionType` field could be `branch` and `version` field could be the name of the `branch` that wiki is published to.

Default branch name for wikis is; `wikiMaster`

## GitHub issue number

Fixes #490 

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Run `npm test`