### PR TITLE
[Feature]: Add tool to retrieve list of commits for a pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Interact with these Azure DevOps services:
 - **repo_resolve_comment**: Resolves a specific comment thread on a pull request.
 - **repo_search_commits**: Searches for commits.
 - **repo_create_pull_request_thread**: Creates a new comment thread on a pull request.
+- **repo_list_pull_request_commits**: Retrieve a list of commits for a pull request.
 
 ### 🚀 Pipelines
 


### PR DESCRIPTION
Tools Request: Get Pull Request Commits #338
add tool get_pull_request_commits with full parameter support, including optional ones:

Get commits for specified pull request id
Endpoint: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-commits/get-pull-request-commits?view=azure-devops-rest-7.1
## GitHub issue number
#338


## ✅ **PR Checklist**

- ✅ **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- ✅ **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- ✅ Title of the pull request is clear and informative.
- ✅ 👌 Code hygiene
- ✅ 🔭 Telemetry added, updated, or N/A
- ✅ 📄 Documentation added, updated, or N/A
- ✅ 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Manually and added new tests.

_Replace_ with use cases tested and models used
