### PR TITLE
fix: correct link in Getting Started guide for Visual Studio 2022

### DIFF
--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -4,7 +4,7 @@ This guide will help you get started with the Azure DevOps MCP Server in differe
 
 - [Prerequisites](#-prerequisites)
 - [Getting started with Visual Studio Code & GitHub Copilot](#️-visual-studio-code--github-copilot)
-- [Getting started with Visual Studio 2022 & GitHub Copilot](#-visual-studio-2022--github-copilot-1)
+- [Getting started with Visual Studio 2022 & GitHub Copilot](#-visual-studio-2022--github-copilot)
 - [Getting started with Claude Code](#-using-mcp-server-with-claude-code)
 - [Getting started with Claude Desktop](#️-using-mcp-server-with-claude-desktop)
 - [Getting started with Cursor](#-using-mcp-server-with-cursor)

--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -4,7 +4,7 @@ This guide will help you get started with the Azure DevOps MCP Server in differe
 
 - [Prerequisites](#-prerequisites)
 - [Getting started with Visual Studio Code & GitHub Copilot](#️-visual-studio-code--github-copilot)
-- [Getting started with Visual Studio 2022 & GitHub Copilot](#-visual-studio-2022--github-copilot)
+- [Getting started with Visual Studio 2022 & GitHub Copilot](#%EF%B8%8F-visual-studio-2022--github-copilot)
 - [Getting started with Claude Code](#-using-mcp-server-with-claude-code)
 - [Getting started with Claude Desktop](#️-using-mcp-server-with-claude-desktop)
 - [Getting started with Cursor](#-using-mcp-server-with-cursor)


### PR DESCRIPTION
This pull request makes a minor update to the table of contents in the `docs/GETTINGSTARTED.md` file to fix the anchor link for the Visual Studio 2022 & GitHub Copilot section. The change ensures the link matches the correct section heading.

## GitHub issue number

n/a

## **Associated Risks**

N/a

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manual testing
