### PR TITLE
Trimming the results of some repo tools

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -130,7 +130,6 @@ function trimPullRequest(pr: GitPullRequest, includeDescription = false) {
   };
 }
 
-
 function configureRepoTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     REPO_TOOLS.create_pull_request,

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -3204,7 +3204,8 @@ describe("repos tools", () => {
         sourceRefName: "refs/heads/feature",
         targetRefName: "refs/heads/main",
       };
-      mockGitApi.createPullRequest.mockResolvedValue(mockPR);      const params = {
+      mockGitApi.createPullRequest.mockResolvedValue(mockPR);
+      const params = {
         repositoryId: "repo123",
         sourceRefName: "refs/heads/feature",
         targetRefName: "refs/heads/main",


### PR DESCRIPTION
Some repo tools returns full REST API responses with a lot of data that isn't that useful, and all of that would need to be processed by the LLM.

This PR reduces the data to something that is actually useful, and also reduces the load on the LLM.

## GitHub issue number
none

## **Associated Risks**
none

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Tested manually, and updated some tests.