### PR TITLE
fix: OAuth login authority for MSA-based orgs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-devops/mcp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-devops/mcp",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-devops/mcp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCP server for interacting with Azure DevOps",
   "license": "MIT",
   "author": "Microsoft Corporation",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -7,16 +7,23 @@ const scopes = ["499b84ac-1321-427f-aa17-267ca6975798/.default"];
 class OAuthAuthenticator {
   static clientId = "0d50963b-7bb9-4fe7-94c7-a99af00b5136";
   static defaultAuthority = "https://login.microsoftonline.com/common";
+  static zeroTenantId = "00000000-0000-0000-0000-000000000000";
 
   private accountId: AccountInfo | null;
   private publicClientApp: PublicClientApplication;
 
   constructor(tenantId?: string) {
     this.accountId = null;
+
+    let authority = OAuthAuthenticator.defaultAuthority;
+    if (tenantId && tenantId !== OAuthAuthenticator.zeroTenantId) {
+      authority = `https://login.microsoftonline.com/${tenantId}`;
+    }
+
     this.publicClientApp = new PublicClientApplication({
       auth: {
         clientId: OAuthAuthenticator.clientId,
-        authority: tenantId ? `https://login.microsoftonline.com/${tenantId}` : OAuthAuthenticator.defaultAuthority,
+        authority,
       },
     });
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const packageVersion = "2.2.0";
+export const packageVersion = "2.2.1";


### PR DESCRIPTION
OAuth login requires special treatment for ADO orgs that are not hosted under MS tenants.
The mapping for such orgs resolves tenant value as zero GUID `00000000-0000-0000-0000-000000000000`.
And such orgs require "common" authority for issuing the auth token.

## GitHub issue number

https://github.com/microsoft/azure-devops-mcp/issues/587

## **Associated Risks**

None

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

E2E using VSCode as MCP Client
