### PR TITLE
Include threadContext in trimPullRequestThread for PR threads

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -63,6 +63,7 @@ function trimPullRequestThread(thread: GitPullRequestCommentThread) {
     lastUpdatedDate: thread.lastUpdatedDate,
     status: thread.status,
     comments: trimComments(thread.comments),
+    threadContext: thread.threadContext,
   };
 }
 


### PR DESCRIPTION
This PR adds the threadContext property to the trimPullRequestThread function to preserve essential file location information when retrieving pull request comment threads. 

## GitHub issue number
[609](https://github.com/microsoft/azure-devops-mcp/issues/609)

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [N/A] 🔭 Telemetry added, updated, or N/A
- [N/A] 📄 Documentation added, updated, or N/A
- [N/A] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

E2E with MCP and VS Code
