### PR TITLE
feat: add tools for updating team capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Interact with these Azure DevOps services:
 - **work_create_iterations**: Create new iterations in a specified Azure DevOps project.
 - **work_assign_iterations**: Assign existing iterations to a specific team in a project.
 - **work_get_team_capacity**: Get the team capacity of a specific team and iteration in a project.
+- **work_update_team_capacity**: Update the team capacity of a team member for a specific iteration in a project.
+- **work_get_iteration_capacities**: Get an iteration's capacity for all teams in iteration and project.
 
 ### 📅 Work Items
 


### PR DESCRIPTION
Added two tools. One for getting iteration capacities across teams. The other to update team capacity per member

## GitHub issue number
#521 

## **Associated Risks**
No Risks

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Automated tests and ran through several scenarios manually
