### PR TITLE
feat: add work_list_iterations tool to list all iterations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Interact with these Azure DevOps services:
 ### ⚒️ Work
 
 - **work_list_team_iterations**: Retrieve a list of iterations for a specific team in a project.
+- **work_list_iterations**: List all iterations in a specified Azure DevOps project.
 - **work_create_iterations**: Create new iterations in a specified Azure DevOps project.
 - **work_assign_iterations**: Assign existing iterations to a specific team in a project.
 - **work_get_team_capacity**: Get the team capacity of a specific team and iteration in a project.


### PR DESCRIPTION
Added new tool to list all iterations by depth. This will allow agents/users to pull all the iterations and assign them to multiple teams.

## GitHub issue number
#660

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Added automated tests and manually checked
