### PR TITLE
fix: add explicit dependency on @azure/msal-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.10.0",
+        "@azure/msal-node": "^3.6.0",
         "@modelcontextprotocol/sdk": "1.20.2",
         "azure-devops-extension-api": "^4.252.0",
         "azure-devops-extension-sdk": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@azure/identity": "^4.10.0",
+    "@azure/msal-node": "^3.6.0",
     "@modelcontextprotocol/sdk": "1.20.2",
     "azure-devops-extension-api": "^4.252.0",
     "azure-devops-extension-sdk": "^4.0.2",


### PR DESCRIPTION
This is a no change for majority of the users because there is a transitive dependency on `@azure/msal-node` package via `@azure/identity`.

But for stricter runtime envs an explicit reference maybe required.
The package is directly used from [here](https://github.com/microsoft/azure-devops-mcp/blob/c34c0455a4ada999b6beb3dd47065283e9b38249/src/auth.ts#L5)


## GitHub issue number
#639 

## **Associated Risks**

None

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Smoke test via inspector