### PR TITLE
Add tool for pipeline creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Interact with these Azure DevOps services:
 - **pipelines_get_build_changes**: Get the changes associated with a specific build.
 - **pipelines_get_build_status**: Fetch the status of a specific build.
 - **pipelines_update_build_stage**: Update the stage of a specific build.
-- **pipelines_create_pipeline**: Create a pipeline definition for a given project.
+- **pipelines_create_pipeline**: Creates a pipeline definition with YAML configuration for a given project.
 - **pipelines_get_run**: Gets a run for a particular pipeline.
 - **pipelines_list_runs**: Gets top 10000 runs for a particular pipeline.
 - **pipelines_run_pipeline**: Starts a new run of a pipeline.

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -656,26 +656,6 @@ describe("configurePipelineTools", () => {
   });
 
   describe("pipelines_create_pipeline tool", () => {
-    it("should reject non-YAML configuration types", async () => {
-      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
-      if (!call) throw new Error("pipelines_create_pipeline tool not registered");
-      const [, , , handler] = call;
-
-      const params = {
-        project: "ProjectName",
-        name: "NonYaml Pipeline",
-        folder: "\\",
-        configurationType: "DesignerJson" as const, // non-Yaml
-        yamlPath: "pipeline-definition.yml",
-        repositoryType: "AzureReposGit" as const,
-        repositoryName: "RepositoryName",
-        repositoryId: "46DEE968-EAE5-41AA-97B1-E8B71DC287C2",
-      };
-
-      await expect(handler(params)).rejects.toThrow("Only 'yaml' pipeline configuration type is supported.");
-    });
-
     it("should create a YAML pipeline for AzureReposGit and return created pipeline", async () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
@@ -690,8 +670,6 @@ describe("configurePipelineTools", () => {
       const params = {
         project: "ProjectName",
         name: "Pipeline Definition Name",
-        folder: "\\",
-        configurationType: "Yaml" as const,
         yamlPath: "pipeline-definition.yml",
         repositoryType: "AzureReposGit" as const,
         repositoryName: "RepositoryName",
@@ -736,7 +714,6 @@ describe("configurePipelineTools", () => {
         project: "ProjectName",
         name: "GH Pipeline",
         folder: "\\",
-        configurationType: "Yaml" as const,
         yamlPath: "pipeline-definition.yml",
         repositoryType: "GitHub" as const,
         repositoryName: "RepositoryName",
@@ -773,7 +750,6 @@ describe("configurePipelineTools", () => {
         project: "ProjectName",
         name: "Pipeline Definition Name",
         folder: "\\",
-        configurationType: "Yaml" as const,
         yamlPath: "pipeline-definition.yml",
         repositoryType: "GitHub" as const,
         repositoryName: "RepositoryName",
@@ -797,7 +773,6 @@ describe("configurePipelineTools", () => {
         project: "ProjectName",
         name: "Pipeline Definition Name",
         folder: "\\",
-        configurationType: "Yaml" as const,
         yamlPath: "pipeline-definition.yml",
         repositoryType: "AzureReposGit" as const,
         repositoryName: "RepositoryName",


### PR DESCRIPTION
A new tool pipelines_create_pipeline is added to the collection of pipeline tools.
It creates a pipeline definition of YAML type for a given project and placed under specified folder (or root if not specified). YAML file must be stored either in Azure DevOps or GitHub repository.

## GitHub issue number
Fixes issue #700

## **Associated Risks**
There are no apparent risks other than another increasing the API usage and therefore resource consumption.

## ✅ **PR Checklist**

- [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [X] Title of the pull request is clear and informative.
- [X] 👌 Code hygiene
- [X] 🔭 Telemetry added, updated, or N/A
- [X] 📄 Documentation added, updated, or N/A
- [X] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
- Tested via prompts for pipeline creation in test organization. This was done for YAML and non-YAML pipeline types with AzureGitRepo & GitHub repository types.
- Added unit tests for the new tool.
