### PR TITLE
Add federated identity authentication support

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { AccessToken, AzureCliCredential, ChainedTokenCredential, ClientAssertionCredential, DefaultAzureCredential, GetTokenOptions, ManagedIdentityCredential, TokenCredential } from "@azure/identity";
 import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
 import open from "open";
 
@@ -60,6 +60,41 @@ class OAuthAuthenticator {
   }
 }
 
+/**
+ * Creates a federated application credential that uses a managed identity's
+ * access token as a signed client assertion for acquiring tokens for a primary
+ * client application.
+ */
+class FederatedApplicationCredential implements TokenCredential {
+  private managedIdentity: ManagedIdentityCredential;
+  private clientAssertion: ClientAssertionCredential;
+
+  constructor(tenantId: string, msiClientId: string, appClientId: string) {
+    this.managedIdentity = new ManagedIdentityCredential(msiClientId);
+    this.clientAssertion = new ClientAssertionCredential(
+      tenantId,
+      appClientId,
+      this.computeAssertionAsync.bind(this)
+    );
+  }
+
+  async getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null> {
+    return this.clientAssertion.getToken(scopes, options);
+  }
+
+  /**
+   * Get an exchange token from our managed identity to use as an assertion.
+   */
+  private async computeAssertionAsync(): Promise<string> {
+    const msiContext = ["api://AzureADTokenExchange/.default"];
+    const msiToken = await this.managedIdentity.getToken(msiContext);
+    if (!msiToken) {
+      throw new Error("Failed to obtain managed identity token for federated authentication.");
+    }
+    return msiToken.token;
+  }
+}
+
 function createAuthenticator(type: string, tenantId?: string): () => Promise<string> {
   switch (type) {
     case "envvar":
@@ -77,12 +112,27 @@ function createAuthenticator(type: string, tenantId?: string): () => Promise<str
       if (type !== "env") {
         process.env.AZURE_TOKEN_CREDENTIALS = "dev";
       }
-      let credential: TokenCredential = new DefaultAzureCredential(); // CodeQL [SM05138] resolved by explicitly setting AZURE_TOKEN_CREDENTIALS
-      if (tenantId) {
-        // Use Azure CLI credential if tenantId is provided for multi-tenant scenarios
-        const azureCliCredential = new AzureCliCredential({ tenantId });
-        credential = new ChainedTokenCredential(azureCliCredential, credential);
+      
+      let credential: TokenCredential;
+      
+      // Check if federated identity configuration is available
+      const federatedTenantId = tenantId || process.env["AZURE_FEDERATED_TENANT_ID"];
+      const msiClientId = process.env["AZURE_MSI_CLIENT_ID"];
+      const appClientId = process.env["AZURE_APP_CLIENT_ID"];
+      
+      if (federatedTenantId && msiClientId && appClientId) {
+        // Use federated application credential with managed identity
+        credential = new FederatedApplicationCredential(federatedTenantId, msiClientId, appClientId);
+      } else {
+        // Fall back to DefaultAzureCredential
+        credential = new DefaultAzureCredential(); // CodeQL [SM05138] resolved by explicitly setting AZURE_TOKEN_CREDENTIALS
+        if (tenantId) {
+          // Use Azure CLI credential if tenantId is provided for multi-tenant scenarios
+          const azureCliCredential = new AzureCliCredential({ tenantId });
+          credential = new ChainedTokenCredential(azureCliCredential, credential);
+        }
       }
+      
       return async () => {
         const result = await credential.getToken(scopes);
         if (!result) {


### PR DESCRIPTION
- Add FederatedApplicationCredential class to support managed identity federation
- Uses ManagedIdentityCredential token as client assertion for app registration
- Automatically uses federated auth when AZURE_MSI_CLIENT_ID and AZURE_APP_CLIENT_ID env vars are set
- Falls back to DefaultAzureCredential when federated identity is not configured
- Maintains full backward compatibility with existing authentication methods

## GitHub issue number

## **Associated Risks**

The behavior depends on the newly added environment variable. No harm for existing logic.

## ✅ **PR Checklist**

- [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [X] Title of the pull request is clear and informative.
- [X] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

_Replace_ with use cases tested and models used
