### PR TITLE
Use explicit tenant (if provided) when requesting a token in the env/azcli mode

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
+import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential, GetTokenOptions, TokenCredential } from "@azure/identity";
 import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
 import open from "open";
 
@@ -78,13 +78,17 @@ function createAuthenticator(type: string, tenantId?: string): () => Promise<str
         process.env.AZURE_TOKEN_CREDENTIALS = "dev";
       }
       let credential: TokenCredential = new DefaultAzureCredential(); // CodeQL [SM05138] resolved by explicitly setting AZURE_TOKEN_CREDENTIALS
+      let options: GetTokenOptions = {};
+
       if (tenantId) {
         // Use Azure CLI credential if tenantId is provided for multi-tenant scenarios
         const azureCliCredential = new AzureCliCredential({ tenantId });
         credential = new ChainedTokenCredential(azureCliCredential, credential);
+        options = { tenantId };
       }
+
       return async () => {
-        const result = await credential.getToken(scopes);
+        const result = await credential.getToken(scopes, options);
         if (!result) {
           throw new Error("Failed to obtain Azure DevOps token. Ensure you have Azure CLI logged or use interactive type of authentication.");
         }


### PR DESCRIPTION
Today, some environment credentials can interact with the `DefaultAzureCredentials` which is used in the `ChainedTokenCredential` for `env` and `azcli` authentication options (`-a`, `--authentication`). Even if `AzureCliCredential` is injected as the first credential in the chain, and it has a tenant set to the provided tenant, it can happen that the token issued will be against a different tenant. This pull request fixes that by requesting a token against a specific tenant, completely ignoring the default tenant set and read by any of the credentials in the chain.

## GitHub issue number

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or **N/A**
- [ ] 📄 Documentation added, updated, or **N/A**
- [ ] 🛡️ Automated tests added, or **N/A**

## 🧪 **How did you test it?**

Inspector, with this setup that was broken.
