### PR TITLE
Options to filter threads (Issue #710)

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -582,7 +582,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.list_pull_request_threads,
-    "Retrieve a list of comment threads for a pull request with server-side filtering capabilities.",
+    "Retrieve a list of comment threads for a pull request.",
     {
       repositoryId: z.string().describe("The ID of the repository where the pull request is located."),
       pullRequestId: z.number().describe("The ID of the pull request for which to retrieve threads."),

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -2219,6 +2219,566 @@ describe("repos tools", () => {
 
       expect(result.content[0].text).toBe(JSON.stringify(mockThreads, null, 2));
     });
+
+    it("should filter threads by status (Active)", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "User1", uniqueName: "user1@example.com" }, content: "Active comment", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Closed,
+          comments: [{ id: 2, author: { displayName: "User2", uniqueName: "user2@example.com" }, content: "Closed comment", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Fixed,
+          comments: [{ id: 3, author: { displayName: "User3", uniqueName: "user3@example.com" }, content: "Fixed comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Active",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Active);
+    });
+
+    it("should filter threads by status (Closed)", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "User1", uniqueName: "user1@example.com" }, content: "Active comment", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Closed,
+          comments: [{ id: 2, author: { displayName: "User2", uniqueName: "user2@example.com" }, content: "Closed comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Closed",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(2);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Closed);
+    });
+
+    it("should filter threads by status (Fixed)", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "User1", uniqueName: "user1@example.com" }, content: "Active comment", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Fixed,
+          comments: [{ id: 2, author: { displayName: "User2", uniqueName: "user2@example.com" }, content: "Fixed comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Fixed",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(2);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Fixed);
+    });
+
+    it("should filter threads by author email", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Comment by John", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "Jane Doe", uniqueName: "jane@example.com" }, content: "Comment by Jane", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 3, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Another comment by John", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorEmail: "john@example.com",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(2);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[1].id).toBe(3);
+      expect(parsedResult[0].comments[0].author.uniqueName).toBe("john@example.com");
+      expect(parsedResult[1].comments[0].author.uniqueName).toBe("john@example.com");
+    });
+
+    it("should filter threads by author email (case-insensitive)", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "John@Example.COM" }, content: "Comment by John", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "Jane Doe", uniqueName: "jane@example.com" }, content: "Comment by Jane", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorEmail: "john@example.com",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+    });
+
+    it("should filter threads by author display name", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Comment by John", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "Jane Smith", uniqueName: "jane@example.com" }, content: "Comment by Jane", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 3, author: { displayName: "John Smith", uniqueName: "jsmith@example.com" }, content: "Comment by John Smith", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorDisplayName: "John",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(2);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[1].id).toBe(3);
+      expect(parsedResult[0].comments[0].author.displayName).toContain("John");
+      expect(parsedResult[1].comments[0].author.displayName).toContain("John");
+    });
+
+    it("should filter threads by author display name (case-insensitive)", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "JOHN DOE", uniqueName: "john@example.com" }, content: "Comment", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "Jane Smith", uniqueName: "jane@example.com" }, content: "Comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorDisplayName: "john",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+    });
+
+    it("should filter threads by both status and author email", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Active by John", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Closed,
+          comments: [{ id: 2, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Closed by John", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 3, author: { displayName: "Jane Doe", uniqueName: "jane@example.com" }, content: "Active by Jane", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Active",
+        authorEmail: "john@example.com",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Active);
+      expect(parsedResult[0].comments[0].author.uniqueName).toBe("john@example.com");
+    });
+
+    it("should filter threads by status and author display name", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Active by John", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Fixed,
+          comments: [{ id: 2, author: { displayName: "John Smith", uniqueName: "jsmith@example.com" }, content: "Fixed by John Smith", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 3, author: { displayName: "Jane Doe", uniqueName: "jane@example.com" }, content: "Active by Jane", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Active",
+        authorDisplayName: "John",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Active);
+      expect(parsedResult[0].comments[0].author.displayName).toContain("John");
+    });
+
+    it("should combine all filters: status, authorEmail, and authorDisplayName", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Active by John Doe", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "John Smith", uniqueName: "john@example.com" }, content: "Active by John Smith", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Closed,
+          comments: [{ id: 3, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Closed by John Doe", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Active",
+        authorEmail: "john@example.com",
+        authorDisplayName: "Doe",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(1);
+      expect(parsedResult[0].status).toBe(CommentThreadStatus.Active);
+      expect(parsedResult[0].comments[0].author.uniqueName).toBe("john@example.com");
+      expect(parsedResult[0].comments[0].author.displayName).toContain("Doe");
+    });
+
+    it("should return empty array when no threads match filters", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "John Doe", uniqueName: "john@example.com" }, content: "Comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Closed",
+        authorEmail: "nonexistent@example.com",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(0);
+    });
+
+    it("should apply pagination after filtering", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 1, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment 1", isDeleted: false }],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment 2", isDeleted: false }],
+        },
+        {
+          id: 3,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 3, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment 3", isDeleted: false }],
+        },
+        {
+          id: 4,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 4, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment 4", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        status: "Active",
+        top: 2,
+        skip: 1,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(2);
+      expect(parsedResult[0].id).toBe(2);
+      expect(parsedResult[1].id).toBe(3);
+    });
+
+    it("should handle threads with no comments when filtering by author", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: undefined,
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorEmail: "user@example.com",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(2);
+    });
+
+    it("should handle threads with empty comments array when filtering by author", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      const mockThreads = [
+        {
+          id: 1,
+          status: CommentThreadStatus.Active,
+          comments: [],
+        },
+        {
+          id: 2,
+          status: CommentThreadStatus.Active,
+          comments: [{ id: 2, author: { displayName: "User", uniqueName: "user@example.com" }, content: "Comment", isDeleted: false }],
+        },
+      ];
+      mockGitApi.getThreads.mockResolvedValue(mockThreads);
+
+      const params = {
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        authorDisplayName: "User",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult).toHaveLength(1);
+      expect(parsedResult[0].id).toBe(2);
+    });
   });
 
   describe("repo_list_pull_request_thread_comments", () => {


### PR DESCRIPTION
Adding a few options for filtering threads to `mcp_ado_repo_list_pull_request_threads`

## GitHub issue number
Fixes #710 

## **Associated Risks**
none

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manually and with added tests