### PR TITLE
feat: add MCP tool annotations to all tools

### DIFF
--- a/src/tools/advanced-security.ts
+++ b/src/tools/advanced-security.ts
@@ -49,6 +49,10 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
       orderBy: z.enum(["id", "firstSeen", "lastSeen", "fixedOn", "severity"]).optional().default("severity").describe("Order results by specified field. Defaults to 'severity'."),
       continuationToken: z.string().optional().describe("Continuation token for pagination."),
     },
+    {
+      title: "Get Security Alerts",
+      readOnlyHint: true,
+    },
     async ({ project, repository, alertType, states, severities, ruleId, ruleName, toolName, ref, onlyDefaultBranch, confidenceLevels, validity, top, orderBy, continuationToken }) => {
       try {
         const connection = await connectionProvider();
@@ -105,6 +109,10 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
       repository: z.string().describe("The name or ID of the repository containing the alert."),
       alertId: z.number().describe("The ID of the alert to retrieve details for."),
       ref: z.string().optional().describe("Git reference (branch) to filter the alert."),
+    },
+    {
+      title: "Get Alert Details",
+      readOnlyHint: true,
     },
     async ({ project, repository, alertId, ref }) => {
       try {

--- a/src/tools/core.ts
+++ b/src/tools/core.ts
@@ -30,6 +30,10 @@ function configureCoreTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.number().optional().describe("The maximum number of teams to return. Defaults to 100."),
       skip: z.number().optional().describe("The number of teams to skip for pagination. Defaults to 0."),
     },
+    {
+      title: "List Project Teams",
+      readOnlyHint: true,
+    },
     async ({ project, mine, top, skip }) => {
       try {
         const connection = await connectionProvider();
@@ -64,6 +68,10 @@ function configureCoreTools(server: McpServer, tokenProvider: () => Promise<stri
       continuationToken: z.number().optional().describe("Continuation token for pagination. Used to fetch the next set of results if available."),
       projectNameFilter: z.string().optional().describe("Filter projects by name. Supports partial matches."),
     },
+    {
+      title: "List Projects",
+      readOnlyHint: true,
+    },
     async ({ stateFilter, top, skip, continuationToken, projectNameFilter }) => {
       try {
         const connection = await connectionProvider();
@@ -95,6 +103,10 @@ function configureCoreTools(server: McpServer, tokenProvider: () => Promise<stri
     "Retrieve Azure DevOps identity IDs for a provided search filter.",
     {
       searchFilter: z.string().describe("Search filter (unique name, display name, email) to retrieve identity IDs for."),
+    },
+    {
+      title: "Get Identity IDs",
+      readOnlyHint: true,
     },
     async ({ searchFilter }) => {
       try {

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -50,6 +50,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       processType: z.number().optional().describe("Process type to filter build definitions"),
       yamlFilename: z.string().optional().describe("YAML filename to filter build definitions"),
     },
+    {
+      title: "Get Build Definitions",
+      readOnlyHint: true,
+    },
     async ({
       project,
       repositoryId,
@@ -115,6 +119,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       repositoryId: z.string().optional().describe("The ID of the repository."),
       repositoryConnectionId: z.string().optional().describe("The service connection ID for GitHub repositories. Not required for Azure Repos Git."),
     },
+    {
+      title: "Create Pipeline",
+      destructiveHint: true,
+    },
     async ({ project, name, folder, yamlPath, repositoryType, repositoryName, repositoryId, repositoryConnectionId }) => {
       const connection = await connectionProvider();
       const pipelinesApi = await connection.getPipelinesApi();
@@ -163,6 +171,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("Project ID or name to get the build definition revisions for"),
       definitionId: z.number().describe("ID of the build definition to get revisions for"),
     },
+    {
+      title: "Get Build Definition Revisions",
+      readOnlyHint: true,
+    },
     async ({ project, definitionId }) => {
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
@@ -203,6 +215,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       buildIds: z.array(z.number()).optional().describe("Array of build IDs to retrieve"),
       repositoryId: z.string().optional().describe("Repository ID to filter builds"),
       repositoryType: z.enum(["TfsGit", "GitHub", "BitbucketCloud"]).optional().describe("Type of repository to filter builds"),
+    },
+    {
+      title: "Get Builds",
+      readOnlyHint: true,
     },
     async ({
       project,
@@ -266,6 +282,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("Project ID or name to get the build log for"),
       buildId: z.number().describe("ID of the build to get the log for"),
     },
+    {
+      title: "Get Build Log",
+      readOnlyHint: true,
+    },
     async ({ project, buildId }) => {
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
@@ -286,6 +306,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       logId: z.number().describe("ID of the log to retrieve"),
       startLine: z.number().optional().describe("Starting line number for the log content, defaults to 0"),
       endLine: z.number().optional().describe("Ending line number for the log content, defaults to the end of the log"),
+    },
+    {
+      title: "Get Build Log By ID",
+      readOnlyHint: true,
     },
     async ({ project, buildId, logId, startLine, endLine }) => {
       const connection = await connectionProvider();
@@ -308,6 +332,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       top: z.number().default(100).describe("Number of changes to retrieve, defaults to 100"),
       includeSourceChange: z.boolean().optional().describe("Whether to include source changes in the results, defaults to false"),
     },
+    {
+      title: "Get Build Changes",
+      readOnlyHint: true,
+    },
     async ({ project, buildId, continuationToken, top, includeSourceChange }) => {
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
@@ -327,6 +355,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       pipelineId: z.number().describe("ID of the pipeline to run"),
       runId: z.number().describe("ID of the run to get"),
     },
+    {
+      title: "Get Pipeline Run",
+      readOnlyHint: true,
+    },
     async ({ project, pipelineId, runId }) => {
       const connection = await connectionProvider();
       const pipelinesApi = await connection.getPipelinesApi();
@@ -344,6 +376,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     {
       project: z.string().describe("Project ID or name to run the build in"),
       pipelineId: z.number().describe("ID of the pipeline to run"),
+    },
+    {
+      title: "List Pipeline Runs",
+      readOnlyHint: true,
     },
     async ({ project, pipelineId }) => {
       const connection = await connectionProvider();
@@ -415,6 +451,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       variables: z.record(z.string(), variableSchema).optional().describe("A dictionary of variables to pass to the pipeline."),
       yamlOverride: z.string().optional().describe("YAML override for the pipeline run."),
     },
+    {
+      title: "Run Pipeline",
+      destructiveHint: true,
+    },
     async ({ project, pipelineId, pipelineVersion, previewRun, resources, stagesToSkip, templateParameters, variables, yamlOverride }) => {
       if (!previewRun && yamlOverride) {
         throw new Error("Parameter 'yamlOverride' can only be specified together with parameter 'previewRun'.");
@@ -453,6 +493,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("Project ID or name to get the build status for"),
       buildId: z.number().describe("ID of the build to get the status for"),
     },
+    {
+      title: "Get Build Status",
+      readOnlyHint: true,
+    },
     async ({ project, buildId }) => {
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
@@ -473,6 +517,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       stageName: z.string().describe("Name of the stage to update"),
       status: z.enum(getEnumKeys(StageUpdateType) as [string, ...string[]]).describe("New status for the stage"),
       forceRetryAllJobs: z.boolean().default(false).describe("Whether to force retry all jobs in the stage."),
+    },
+    {
+      title: "Update Build Stage",
+      destructiveHint: true,
     },
     async ({ project, buildId, stageName, status, forceRetryAllJobs }) => {
       const connection = await connectionProvider();

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -149,6 +149,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       forkSourceRepositoryId: z.string().optional().describe("The ID of the fork repository that the pull request originates from. Optional, used when creating a pull request from a fork."),
       labels: z.array(z.string()).optional().describe("Array of label names to add to the pull request after creation."),
     },
+    {
+      title: "Create Pull Request",
+      destructiveHint: true,
+    },
     async ({ repositoryId, sourceRefName, targetRefName, title, description, isDraft, workItems, forkSourceRepositoryId, labels }) => {
       try {
         const connection = await connectionProvider();
@@ -203,6 +207,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       branchName: z.string().describe("The name of the new branch to create, e.g., 'feature-branch'."),
       sourceBranchName: z.string().optional().default("main").describe("The name of the source branch to create the new branch from. Defaults to 'main'."),
       sourceCommitId: z.string().optional().describe("The commit ID to create the branch from. If not provided, uses the latest commit of the source branch."),
+    },
+    {
+      title: "Create Branch",
+      destructiveHint: true,
     },
     async ({ repositoryId, branchName, sourceBranchName, sourceCommitId }) => {
       try {
@@ -318,6 +326,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       bypassReason: z.string().optional().describe("Reason for bypassing branch policies. When provided, branch policies will be automatically bypassed during autocompletion."),
       labels: z.array(z.string()).optional().describe("Array of label names to replace existing labels on the pull request. This will remove all current labels and add the specified ones."),
     },
+    {
+      title: "Update Pull Request",
+      destructiveHint: true,
+    },
     async ({ repositoryId, pullRequestId, title, description, isDraft, targetRefName, status, autoComplete, mergeStrategy, deleteSourceBranch, transitionWorkItems, bypassReason, labels }) => {
       try {
         const connection = await connectionProvider();
@@ -415,6 +427,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       reviewerIds: z.array(z.string()).describe("List of reviewer ids to add or remove from the pull request."),
       action: z.enum(["add", "remove"]).describe("Action to perform on the reviewers. Can be 'add' or 'remove'."),
     },
+    {
+      title: "Update Pull Request Reviewers",
+      destructiveHint: true,
+    },
     async ({ repositoryId, pullRequestId, reviewerIds, action }) => {
       try {
         const connection = await connectionProvider();
@@ -468,6 +484,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.number().default(100).describe("The maximum number of repositories to return."),
       skip: z.number().default(0).describe("The number of repositories to skip. Defaults to 0."),
       repoNameFilter: z.string().optional().describe("Optional filter to search for repositories by name. If provided, only repositories with names containing this string will be returned."),
+    },
+    {
+      title: "List Repositories",
+      readOnlyHint: true,
     },
     async ({ project, top, skip, repoNameFilter }) => {
       try {
@@ -525,6 +545,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .describe("Filter pull requests by status. Defaults to 'Active'."),
       sourceRefName: z.string().optional().describe("Filter pull requests from this source branch (e.g., 'refs/heads/feature-branch')."),
       targetRefName: z.string().optional().describe("Filter pull requests into this target branch (e.g., 'refs/heads/main')."),
+    },
+    {
+      title: "List Pull Requests",
+      readOnlyHint: true,
     },
     async ({ repositoryId, project, top, skip, created_by_me, created_by_user, i_am_reviewer, user_is_reviewer, status, sourceRefName, targetRefName }) => {
       try {
@@ -676,6 +700,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       authorEmail: z.string().optional().describe("Filter threads by the email of the thread author (first comment author)."),
       authorDisplayName: z.string().optional().describe("Filter threads by the display name of the thread author (first comment author). Case-insensitive partial matching."),
     },
+    {
+      title: "List Pull Request Threads",
+      readOnlyHint: true,
+    },
     async ({ repositoryId, pullRequestId, project, iteration, baseIteration, top, skip, fullResponse, status, authorEmail, authorDisplayName }) => {
       try {
         const connection = await connectionProvider();
@@ -742,6 +770,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       skip: z.number().default(0).describe("The number of comments to skip."),
       fullResponse: z.boolean().optional().default(false).describe("Return full comment JSON response instead of trimmed data."),
     },
+    {
+      title: "List Thread Comments",
+      readOnlyHint: true,
+    },
     async ({ repositoryId, pullRequestId, threadId, project, top, skip, fullResponse }) => {
       try {
         const connection = await connectionProvider();
@@ -783,6 +815,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.number().default(100).describe("The maximum number of branches to return. Defaults to 100."),
       filterContains: z.string().optional().describe("Filter to find branches that contain this string in their name."),
     },
+    {
+      title: "List Branches",
+      readOnlyHint: true,
+    },
     async ({ repositoryId, top, filterContains }) => {
       try {
         const connection = await connectionProvider();
@@ -813,6 +849,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.number().default(100).describe("The maximum number of branches to return."),
       filterContains: z.string().optional().describe("Filter to find branches that contain this string in their name."),
     },
+    {
+      title: "List My Branches",
+      readOnlyHint: true,
+    },
     async ({ repositoryId, top, filterContains }) => {
       try {
         const connection = await connectionProvider();
@@ -841,6 +881,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
     {
       project: z.string().describe("Project name or ID where the repository is located."),
       repositoryNameOrId: z.string().describe("Repository name or ID."),
+    },
+    {
+      title: "Get Repository",
+      readOnlyHint: true,
     },
     async ({ project, repositoryNameOrId }) => {
       try {
@@ -877,6 +921,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
     {
       repositoryId: z.string().describe("The ID of the repository where the branch is located."),
       branchName: z.string().describe("The name of the branch to retrieve, e.g., 'main' or 'feature-branch'."),
+    },
+    {
+      title: "Get Branch",
+      readOnlyHint: true,
     },
     async ({ repositoryId, branchName }) => {
       try {
@@ -917,6 +965,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       pullRequestId: z.number().describe("The ID of the pull request to retrieve."),
       includeWorkItemRefs: z.boolean().optional().default(false).describe("Whether to reference work items associated with the pull request."),
       includeLabels: z.boolean().optional().default(false).describe("Whether to include a summary of labels in the response."),
+    },
+    {
+      title: "Get Pull Request",
+      readOnlyHint: true,
     },
     async ({ repositoryId, pullRequestId, includeWorkItemRefs, includeLabels }) => {
       try {
@@ -980,6 +1032,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       content: z.string().describe("The content of the comment to be added."),
       project: z.string().optional().describe("Project ID or project name (optional)"),
       fullResponse: z.boolean().optional().default(false).describe("Return full comment JSON response instead of a simple confirmation message."),
+    },
+    {
+      title: "Reply to Comment",
+      destructiveHint: true,
     },
     async ({ repositoryId, pullRequestId, threadId, content, project, fullResponse }) => {
       try {
@@ -1048,6 +1104,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .describe(
           "Position of last character of the thread's span in right file. The character offset of a thread's position inside of a line. Must be set if rightFileEndLine is also specified. (optional)"
         ),
+    },
+    {
+      title: "Create Comment Thread",
+      destructiveHint: true,
     },
     async ({ repositoryId, pullRequestId, content, project, filePath, status, rightFileStartLine, rightFileStartOffset, rightFileEndLine, rightFileEndOffset }) => {
       try {
@@ -1176,6 +1236,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .optional()
         .describe("The new status for the comment thread."),
     },
+    {
+      title: "Update Comment Thread",
+      destructiveHint: true,
+    },
     async ({ repositoryId, pullRequestId, threadId, project, status }) => {
       try {
         const connection = await connectionProvider();
@@ -1249,6 +1313,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       toDate: z.string().optional().describe("Filter commits to this date (ISO 8601 format, e.g., '2024-12-31T23:59:59Z')"),
       commitIds: z.array(z.string()).optional().describe("Array of specific commit IDs to retrieve. When provided, other filters are ignored except top/skip."),
       historySimplificationMode: z.enum(["FirstParent", "SimplifyMerges", "FullHistory", "FullHistorySimplifyMerges"]).optional().describe("How to simplify the commit history"),
+    },
+    {
+      title: "Search Commits",
+      readOnlyHint: true,
     },
     async ({
       project,
@@ -1410,6 +1478,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .optional()
         .default(GitPullRequestQueryType[GitPullRequestQueryType.LastMergeCommit])
         .describe("Type of query to perform"),
+    },
+    {
+      title: "List Pull Requests by Commits",
+      readOnlyHint: true,
     },
     async ({ project, repository, commits, queryType }) => {
       try {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -30,6 +30,10 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<st
       skip: z.number().default(0).describe("Number of results to skip"),
       top: z.number().default(5).describe("Maximum number of results to return"),
     },
+    {
+      title: "Search Code",
+      readOnlyHint: true,
+    },
     async ({ searchText, project, repository, path, branch, includeFacets, skip, top }) => {
       const accessToken = await tokenProvider();
       const connection = await connectionProvider();
@@ -89,6 +93,10 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<st
       skip: z.number().default(0).describe("Number of results to skip"),
       top: z.number().default(10).describe("Maximum number of results to return"),
     },
+    {
+      title: "Search Wiki",
+      readOnlyHint: true,
+    },
     async ({ searchText, project, wiki, includeFacets, skip, top }) => {
       const accessToken = await tokenProvider();
       const url = `https://almsearch.dev.azure.com/${orgName}/_apis/search/wikisearchresults?api-version=${apiVersion}`;
@@ -142,6 +150,10 @@ function configureSearchTools(server: McpServer, tokenProvider: () => Promise<st
       includeFacets: z.boolean().default(false).describe("Include facets in the search results"),
       skip: z.number().default(0).describe("Number of results to skip for pagination"),
       top: z.number().default(10).describe("Number of results to return"),
+    },
+    {
+      title: "Search Work Items",
+      readOnlyHint: true,
     },
     async ({ searchText, project, areaPath, workItemType, state, assignedTo, includeFacets, skip, top }) => {
       const accessToken = await tokenProvider();

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -28,6 +28,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       includePlanDetails: z.boolean().default(false).describe("Include detailed information about each test plan."),
       continuationToken: z.string().optional().describe("Token to continue fetching test plans from a previous request."),
     },
+    {
+      title: "List Test Plans",
+      readOnlyHint: true,
+    },
     async ({ project, filterActivePlans, includePlanDetails, continuationToken }) => {
       try {
         const owner = ""; //making owner an empty string untill we can figure out how to get owner id
@@ -60,6 +64,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       startDate: z.string().optional().describe("The start date of the test plan"),
       endDate: z.string().optional().describe("The end date of the test plan"),
       areaPath: z.string().optional().describe("The area path for the test plan"),
+    },
+    {
+      title: "Create Test Plan",
+      destructiveHint: true,
     },
     async ({ project, name, iteration, description, startDate, endDate, areaPath }) => {
       try {
@@ -99,6 +107,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       parentSuiteId: z.number().describe("ID of the parent suite under which the new suite will be created, if not given by user this can be id of a root suite of the test plan"),
       name: z.string().describe("Name of the child test suite"),
     },
+    {
+      title: "Create Test Suite",
+      destructiveHint: true,
+    },
     async ({ project, planId, parentSuiteId, name }) => {
       try {
         const connection = await connectionProvider();
@@ -136,6 +148,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       planId: z.number().describe("The ID of the test plan."),
       suiteId: z.number().describe("The ID of the test suite."),
       testCaseIds: z.string().or(z.array(z.string())).describe("The ID(s) of the test case(s) to add. "),
+    },
+    {
+      title: "Add Test Cases to Suite",
+      destructiveHint: true,
     },
     async ({ project, planId, suiteId, testCaseIds }) => {
       try {
@@ -176,6 +192,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       areaPath: z.string().optional().describe("The area path for the test case."),
       iterationPath: z.string().optional().describe("The iteration path for the test case."),
       testsWorkItemId: z.number().optional().describe("Optional work item id that will be set as a Microsoft.VSTS.Common.TestedBy-Reverse link to the test case."),
+    },
+    {
+      title: "Create Test Case",
+      destructiveHint: true,
     },
     async ({ project, title, steps, priority, areaPath, iterationPath, testsWorkItemId }) => {
       try {
@@ -265,6 +285,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
           "The steps to reproduce the test case. Make sure to format each step as '1. Step one|Expected result one\n2. Step two|Expected result two. USE '|' as the delimiter between step and expected result. DO NOT use '|' in the description of the step or expected result."
         ),
     },
+    {
+      title: "Update Test Case Steps",
+      destructiveHint: true,
+    },
     async ({ id, steps }) => {
       try {
         const connection = await connectionProvider();
@@ -309,6 +333,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       planid: z.number().describe("The ID of the test plan."),
       suiteid: z.number().describe("The ID of the test suite."),
     },
+    {
+      title: "List Test Cases",
+      readOnlyHint: true,
+    },
     async ({ project, planid, suiteid }) => {
       try {
         const connection = await connectionProvider();
@@ -334,6 +362,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
     {
       project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
       buildid: z.number().describe("The ID of the build."),
+    },
+    {
+      title: "Get Test Results from Build",
+      readOnlyHint: true,
     },
     async ({ project, buildid }) => {
       try {
@@ -361,6 +393,10 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
       project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
       planId: z.number().describe("The ID of the test plan."),
       continuationToken: z.string().optional().describe("Token to continue fetching test plans from a previous request."),
+    },
+    {
+      title: "List Test Suites",
+      readOnlyHint: true,
     },
     async ({ project, planId, continuationToken }) => {
       try {

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -24,6 +24,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
       wikiIdentifier: z.string().describe("The unique identifier of the wiki."),
       project: z.string().optional().describe("The project name or ID where the wiki is located. If not provided, the default project will be used."),
     },
+    {
+      title: "Get Wiki",
+      readOnlyHint: true,
+    },
     async ({ wikiIdentifier, project }) => {
       try {
         const connection = await connectionProvider();
@@ -53,6 +57,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
     "Retrieve a list of wikis for an organization or project.",
     {
       project: z.string().optional().describe("The project name or ID to filter wikis. If not provided, all wikis in the organization will be returned."),
+    },
+    {
+      title: "List Wikis",
+      readOnlyHint: true,
     },
     async ({ project }) => {
       try {
@@ -87,6 +95,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.number().default(20).describe("The maximum number of pages to return. Defaults to 20."),
       continuationToken: z.string().optional().describe("Token for pagination to retrieve the next set of pages."),
       pageViewsForDays: z.number().optional().describe("Number of days to retrieve page views for. If not specified, page views are not included."),
+    },
+    {
+      title: "List Wiki Pages",
+      readOnlyHint: true,
     },
     async ({ wikiIdentifier, project, top = 20, continuationToken, pageViewsForDays }) => {
       try {
@@ -130,6 +142,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
         .enum(["None", "OneLevel", "OneLevelPlusNestedEmptyFolders", "Full"])
         .optional()
         .describe("Recursion level for subpages. 'None' returns only the specified page. 'OneLevel' includes direct children. 'Full' includes all descendants."),
+    },
+    {
+      title: "Get Wiki Page",
+      readOnlyHint: true,
     },
     async ({ wikiIdentifier, project, path, recursionLevel }) => {
       try {
@@ -194,6 +210,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
       wikiIdentifier: z.string().optional().describe("The unique identifier of the wiki. Required if url is not provided."),
       project: z.string().optional().describe("The project name or ID where the wiki is located. Required if url is not provided."),
       path: z.string().optional().describe("The path of the wiki page to retrieve content for. Optional, defaults to root page if not provided."),
+    },
+    {
+      title: "Get Wiki Page Content",
+      readOnlyHint: true,
     },
     async ({ url, wikiIdentifier, project, path }: { url?: string; wikiIdentifier?: string; project?: string; path?: string }) => {
       try {
@@ -289,6 +309,10 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
       project: z.string().optional().describe("The project name or ID where the wiki is located. If not provided, the default project will be used."),
       etag: z.string().optional().describe("ETag for editing existing pages (optional, will be fetched if not provided)."),
       branch: z.string().default("wikiMaster").describe("The branch name for the wiki repository. Defaults to 'wikiMaster' which is the default branch for Azure DevOps wikis."),
+    },
+    {
+      title: "Create or Update Wiki Page",
+      destructiveHint: true,
     },
     async ({ wikiIdentifier, path, content, project, etag, branch = "wikiMaster" }) => {
       try {

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -70,6 +70,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       team: z.string().describe("The name or ID of the Azure DevOps team."),
     },
+    {
+      title: "List Backlogs",
+      readOnlyHint: true,
+    },
     async ({ project, team }) => {
       try {
         const connection = await connectionProvider();
@@ -97,6 +101,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       team: z.string().describe("The name or ID of the Azure DevOps team."),
       backlogId: z.string().describe("The ID of the backlog category to retrieve work items from."),
+    },
+    {
+      title: "List Backlog Work Items",
+      readOnlyHint: true,
     },
     async ({ project, team, backlogId }) => {
       try {
@@ -128,6 +136,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       top: z.number().default(50).describe("The maximum number of work items to return. Defaults to 50."),
       includeCompleted: z.boolean().default(false).describe("Whether to include completed work items. Defaults to false."),
     },
+    {
+      title: "My Work Items",
+      readOnlyHint: true,
+    },
     async ({ project, type, top, includeCompleted }) => {
       try {
         const connection = await connectionProvider();
@@ -155,6 +167,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       ids: z.array(z.number()).describe("The IDs of the work items to retrieve."),
       fields: z.array(z.string()).optional().describe("Optional list of fields to include in the response. If not provided, a hardcoded default set of fields will be used."),
+    },
+    {
+      title: "Get Work Items Batch",
+      readOnlyHint: true,
     },
     async ({ project, ids, fields }) => {
       try {
@@ -222,6 +238,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .optional()
         .describe("Expand options include 'all', 'fields', 'links', 'none', and 'relations'. Relations can be used to get child workitems. Defaults to 'none'."),
     },
+    {
+      title: "Get Work Item",
+      readOnlyHint: true,
+    },
     async ({ id, project, fields, asOf, expand }) => {
       try {
         const connection = await connectionProvider();
@@ -250,6 +270,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       workItemId: z.number().describe("The ID of the work item to retrieve comments for."),
       top: z.number().default(50).describe("Optional number of comments to retrieve. Defaults to all comments."),
     },
+    {
+      title: "List Work Item Comments",
+      readOnlyHint: true,
+    },
     async ({ project, workItemId, top }) => {
       try {
         const connection = await connectionProvider();
@@ -277,6 +301,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       workItemId: z.number().describe("The ID of the work item to add a comment to."),
       comment: z.string().describe("The text of the comment to add to the work item."),
       format: z.enum(["markdown", "html"]).optional().default("html"),
+    },
+    {
+      title: "Add Work Item Comment",
+      destructiveHint: true,
     },
     async ({ project, workItemId, comment, format }) => {
       try {
@@ -331,6 +359,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .default("None")
         .optional()
         .describe("Optional expand parameter to include additional details. Defaults to 'None'."),
+    },
+    {
+      title: "List Work Item Revisions",
+      readOnlyHint: true,
     },
     async ({ project, workItemId, top, skip, expand }) => {
       try {
@@ -395,6 +427,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           iterationPath: z.string().optional().describe("Optional iteration path for the child work item."),
         })
       ),
+    },
+    {
+      title: "Add Child Work Items",
+      destructiveHint: true,
     },
     async ({ parentId, project, workItemType, items }) => {
       try {
@@ -523,6 +559,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       workItemId: z.number().describe("The ID of the work item to link to the pull request."),
       pullRequestProjectId: z.string().optional().describe("The project ID containing the pull request. If not provided, defaults to the work item's project ID (for same-project linking)."),
     },
+    {
+      title: "Link Work Item to PR",
+      destructiveHint: true,
+    },
     async ({ projectId, repositoryId, pullRequestId, workItemId, pullRequestProjectId }) => {
       try {
         const connection = await connectionProvider();
@@ -591,6 +631,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       team: z.string().optional().describe("The name or ID of the Azure DevOps team. If not provided, the default team will be used."),
       iterationId: z.string().describe("The ID of the iteration to retrieve work items for."),
     },
+    {
+      title: "Get Work Items for Iteration",
+      readOnlyHint: true,
+    },
     async ({ project, team, iterationId }) => {
       try {
         const connection = await connectionProvider();
@@ -632,6 +676,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         )
         .describe("An array of field updates to apply to the work item."),
     },
+    {
+      title: "Update Work Item",
+      destructiveHint: true,
+    },
     async ({ id, updates }) => {
       try {
         const connection = await connectionProvider();
@@ -664,6 +712,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     {
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       workItemType: z.string().describe("The name of the work item type to retrieve."),
+    },
+    {
+      title: "Get Work Item Type",
+      readOnlyHint: true,
     },
     async ({ project, workItemType }) => {
       try {
@@ -700,6 +752,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           })
         )
         .describe("A record of field names and values to set on the new work item. Each fild is the field name and each value is the corresponding value to set for that field."),
+    },
+    {
+      title: "Create Work Item",
+      destructiveHint: true,
     },
     async ({ project, workItemType, fields }) => {
       try {
@@ -759,6 +815,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       includeDeleted: z.boolean().default(false).describe("Whether to include deleted items in the query results. Defaults to false."),
       useIsoDateFormat: z.boolean().default(false).describe("Whether to use ISO date format in the response. Defaults to false."),
     },
+    {
+      title: "Get Query",
+      readOnlyHint: true,
+    },
     async ({ project, query, expand, depth, includeDeleted, useIsoDateFormat }) => {
       try {
         const connection = await connectionProvider();
@@ -789,6 +849,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       timePrecision: z.boolean().optional().describe("Whether to include time precision in the results. Defaults to false."),
       top: z.number().default(50).describe("The maximum number of results to return. Defaults to 50."),
       responseType: z.enum(["full", "ids"]).default("full").describe("Response type: 'full' returns complete query results (default), 'ids' returns only work item IDs for reduced payload size."),
+    },
+    {
+      title: "Get Query Results",
+      readOnlyHint: true,
     },
     async ({ id, project, team, timePrecision, top, responseType }) => {
       try {
@@ -834,6 +898,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           })
         )
         .describe("An array of updates to apply to work items. Each update should include the operation (op), work item ID (id), field path (path), and new value (value)."),
+    },
+    {
+      title: "Update Work Items Batch",
+      destructiveHint: true,
     },
     async ({ updates }) => {
       try {
@@ -923,6 +991,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         )
         .describe(""),
     },
+    {
+      title: "Link Work Items",
+      destructiveHint: true,
+    },
     async ({ project, updates }) => {
       try {
         const connection = await connectionProvider();
@@ -995,6 +1067,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           "Type of link to remove. Options include 'parent', 'child', 'duplicate', 'duplicate of', 'related', 'successor', 'predecessor', 'tested by', 'tests', 'affects', 'affected by', and 'artifact'. Defaults to 'related'."
         ),
       url: z.string().optional().describe("Optional URL to match for the link to remove. If not provided, all links of the specified type will be removed."),
+    },
+    {
+      title: "Unlink Work Item",
+      destructiveHint: true,
     },
     async ({ project, id, type, url }) => {
       try {
@@ -1099,6 +1175,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .default("Branch")
         .describe("Type of artifact link, defaults to 'Branch'. This determines both the link type and how to build the VSTFS URI from individual components."),
       comment: z.string().optional().describe("Comment to include with the artifact link."),
+    },
+    {
+      title: "Add Artifact Link",
+      destructiveHint: true,
     },
     async ({ workItemId, project, artifactUri, projectId, repositoryId, branchName, commitId, pullRequestId, buildId, linkType, comment }) => {
       try {

--- a/src/tools/work.ts
+++ b/src/tools/work.ts
@@ -25,6 +25,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
       team: z.string().describe("The name or ID of the Azure DevOps team."),
       timeframe: z.enum(["current"]).optional().describe("The timeframe for which to retrieve iterations. Currently, only 'current' is supported."),
     },
+    {
+      title: "List Team Iterations",
+      readOnlyHint: true,
+    },
     async ({ project, team, timeframe }) => {
       try {
         const connection = await connectionProvider();
@@ -63,6 +67,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
           })
         )
         .describe("An array of iterations to create. Each iteration must have a name and can optionally have start and finish dates in ISO format."),
+    },
+    {
+      title: "Create Iterations",
+      destructiveHint: true,
     },
     async ({ project, iterations }) => {
       try {
@@ -114,6 +122,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       depth: z.number().default(2).describe("Depth of children to fetch."),
       excludedIds: z.array(z.number()).optional().describe("An optional array of iteration IDs, and thier children, that should not be returned."),
+    },
+    {
+      title: "List Iterations",
+      readOnlyHint: true,
     },
     async ({ project, depth, excludedIds: ids }) => {
       try {
@@ -187,6 +199,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
         )
         .describe("An array of iterations to assign. Each iteration must have an identifier and a path."),
     },
+    {
+      title: "Assign Iterations",
+      destructiveHint: true,
+    },
     async ({ project, team, iterations }) => {
       try {
         const connection = await connectionProvider();
@@ -227,6 +243,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
       project: z.string().describe("The name or Id of the Azure DevOps project."),
       team: z.string().describe("The name or Id of the Azure DevOps team."),
       iterationId: z.string().describe("The Iteration Id to get capacity for."),
+    },
+    {
+      title: "Get Team Capacity",
+      readOnlyHint: true,
     },
     async ({ project, team, iterationId }) => {
       try {
@@ -299,6 +319,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
         .optional()
         .describe("Array of days off for the team member, each with a start and end date in ISO format."),
     },
+    {
+      title: "Update Team Capacity",
+      destructiveHint: true,
+    },
     async ({ project, team, teamMemberId, iterationId, activities, daysOff }) => {
       try {
         const connection = await connectionProvider();
@@ -362,6 +386,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
     {
       project: z.string().describe("The name or Id of the Azure DevOps project."),
       iterationId: z.string().describe("The Iteration Id to get capacity for."),
+    },
+    {
+      title: "Get Iteration Capacities",
+      readOnlyHint: true,
     },
     async ({ project, iterationId }) => {
       try {

--- a/test/src/tools/advanced-security.test.ts
+++ b/test/src/tools/advanced-security.test.ts
@@ -52,7 +52,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [
         {
@@ -148,7 +148,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // First call - returns first page (simulating PagedList without continuation token in response)
       const firstPageMockResult: PagedList<Alert> = [
@@ -308,7 +308,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to retrieve alerts");
       (mockAlertApi.getAlerts as jest.Mock).mockRejectedValue(testError);
@@ -330,7 +330,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue(null);
 
@@ -350,7 +350,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [
         {
@@ -446,7 +446,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [];
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue(mockResult);
@@ -476,7 +476,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [];
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue(mockResult);
@@ -537,7 +537,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [];
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue(mockResult);
@@ -590,7 +590,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: PagedList<Alert> = [];
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue(mockResult);
@@ -617,7 +617,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
       if (!call) throw new Error("advsec_get_alerts tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Test with non-Error exception (string)
       (mockAlertApi.getAlerts as jest.Mock).mockRejectedValue("String error");
@@ -640,7 +640,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alert_details");
       if (!call) throw new Error("advsec_get_alert_details tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: Alert = {
         alertId: 1,
@@ -686,7 +686,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alert_details");
       if (!call) throw new Error("advsec_get_alert_details tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResult: Alert = {
         alertId: 1,
@@ -724,7 +724,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alert_details");
       if (!call) throw new Error("advsec_get_alert_details tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Alert not found");
       (mockAlertApi.getAlert as jest.Mock).mockRejectedValue(testError);
@@ -747,7 +747,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alert_details");
       if (!call) throw new Error("advsec_get_alert_details tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Test with non-Error exception (string)
       (mockAlertApi.getAlert as jest.Mock).mockRejectedValue("String error");
@@ -769,7 +769,7 @@ describe("configureAdvSecTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alert_details");
       if (!call) throw new Error("advsec_get_alert_details tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockAlertApi.getAlert as jest.Mock).mockResolvedValue(null);
 

--- a/test/src/tools/core.test.ts
+++ b/test/src/tools/core.test.ts
@@ -53,7 +53,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([
         {
@@ -126,7 +126,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("API connection failed");
       (mockCoreApi.getProjects as jest.Mock).mockRejectedValue(testError);
@@ -151,7 +151,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue(null);
 
@@ -175,7 +175,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockRejectedValue("string error");
 
@@ -199,7 +199,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([
         {
@@ -248,7 +248,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_projects");
 
       if (!call) throw new Error("core_list_projects tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([
         {
@@ -289,7 +289,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
 
       if (!call) throw new Error("core_list_project_teams tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([
         {
@@ -350,7 +350,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
 
       if (!call) throw new Error("core_list_project_teams tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Team not found");
       (mockCoreApi.getTeams as jest.Mock).mockRejectedValue(testError);
@@ -375,7 +375,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
 
       if (!call) throw new Error("core_list_project_teams tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue(null);
 
@@ -399,7 +399,7 @@ describe("configureCoreTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
 
       if (!call) throw new Error("core_list_project_teams tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockCoreApi.getTeams as jest.Mock).mockRejectedValue("string error");
 
@@ -433,7 +433,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock token provider
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -499,7 +499,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
@@ -527,7 +527,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
@@ -554,7 +554,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
@@ -581,7 +581,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
@@ -605,7 +605,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
       const mockConnectionWithUrl = {
@@ -629,7 +629,7 @@ describe("configureCoreTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_get_identity_ids");
       if (!call) throw new Error("core_get_identity_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock token provider error
       (tokenProvider as jest.Mock).mockRejectedValue(new Error("Token acquisition failed"));

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -47,7 +47,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
       if (!call) throw new Error("pipelines_update_build_stage tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock the token provider
       (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
@@ -89,7 +89,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
       if (!call) throw new Error("pipelines_update_build_stage tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock the token provider
       (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
@@ -130,7 +130,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
       if (!call) throw new Error("pipelines_update_build_stage tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock the token provider
       (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
@@ -167,7 +167,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
       if (!call) throw new Error("pipelines_update_build_stage tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock token provider error
       const tokenError = new Error("Failed to get access token");
@@ -191,7 +191,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
       if (!call) throw new Error("pipelines_update_build_stage tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
 
@@ -228,7 +228,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
       if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getDefinitions: jest.fn().mockResolvedValue([
@@ -284,7 +284,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
       if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getDefinitions: jest.fn().mockRejectedValue(new Error("API Error")),
@@ -302,7 +302,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definition_revisions");
       if (!call) throw new Error("pipelines_get_build_definition_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getDefinitionRevisions: jest.fn().mockResolvedValue([
@@ -336,7 +336,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definition_revisions");
       if (!call) throw new Error("pipelines_get_build_definition_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getDefinitionRevisions: jest.fn().mockRejectedValue(new Error("Definition not found")),
@@ -357,7 +357,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_builds");
       if (!call) throw new Error("pipelines_get_builds tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuilds: jest.fn().mockResolvedValue([
@@ -416,7 +416,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_builds");
       if (!call) throw new Error("pipelines_get_builds tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuilds: jest.fn().mockRejectedValue(new Error("Project not found")),
@@ -434,7 +434,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_log");
       if (!call) throw new Error("pipelines_get_build_log tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildLogs: jest.fn().mockResolvedValue([
@@ -468,7 +468,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_log");
       if (!call) throw new Error("pipelines_get_build_log tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildLogs: jest.fn().mockRejectedValue(new Error("Build not found")),
@@ -489,7 +489,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_log_by_id");
       if (!call) throw new Error("pipelines_get_build_log_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildLogLines: jest.fn().mockResolvedValue(["2024-12-01T10:00:00.000Z Starting build...", "2024-12-01T10:01:00.000Z Build completed successfully"]),
@@ -514,7 +514,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_log_by_id");
       if (!call) throw new Error("pipelines_get_build_log_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildLogLines: jest.fn().mockRejectedValue(new Error("Log not found")),
@@ -536,7 +536,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_changes");
       if (!call) throw new Error("pipelines_get_build_changes tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildChanges: jest.fn().mockResolvedValue([
@@ -573,7 +573,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_changes");
       if (!call) throw new Error("pipelines_get_build_changes tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildChanges: jest.fn().mockResolvedValue([]),
@@ -594,7 +594,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_changes");
       if (!call) throw new Error("pipelines_get_build_changes tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBuildApi = {
         getBuildChanges: jest.fn().mockRejectedValue(new Error("Changes not available")),
@@ -615,7 +615,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_run");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         getRun: jest.fn().mockResolvedValue({ id: 1, name: "run-1" }),
@@ -638,7 +638,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_run");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         getRun: jest.fn().mockRejectedValue(new Error("Run not found")),
@@ -660,7 +660,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
       if (!call) throw new Error("pipelines_create_pipeline tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         createPipeline: jest.fn().mockResolvedValue({ id: 100, name: "Pipeline Definition Name" }),
@@ -703,7 +703,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
       if (!call) throw new Error("pipelines_create_pipeline tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         createPipeline: jest.fn().mockResolvedValue({ id: 200, name: "GH Pipeline" }),
@@ -744,7 +744,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
       if (!call) throw new Error("pipelines_create_pipeline tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         project: "ProjectName",
@@ -762,7 +762,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_create_pipeline");
       if (!call) throw new Error("pipelines_create_pipeline tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         createPipeline: jest.fn().mockRejectedValue(new Error("API failure")),
@@ -788,7 +788,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_list_runs");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         listRuns: jest.fn().mockResolvedValue([{ id: 1, name: "run-1" }]),
@@ -810,7 +810,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_list_runs");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         listRuns: jest.fn().mockRejectedValue(new Error("Pipeline not found")),
@@ -831,7 +831,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_run_pipeline");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         runPipeline: jest.fn().mockResolvedValue({ id: 456 }),
@@ -879,7 +879,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_run_pipeline");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         runPipeline: jest.fn().mockResolvedValue({ id: 456, finalYaml: "final yaml" }),
@@ -908,7 +908,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_run_pipeline");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         project: "test-project",
@@ -924,7 +924,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_run_pipeline");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         runPipeline: jest.fn().mockResolvedValue({}),
@@ -943,7 +943,7 @@ describe("configurePipelineTools", () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_run_pipeline");
       if (!call) fail("Tool not found");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPipelinesApi = {
         runPipeline: jest.fn().mockRejectedValue(new Error("API Error")),

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -91,7 +91,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -158,7 +158,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -218,7 +218,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -278,7 +278,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -338,7 +338,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -400,7 +400,7 @@ describe("repos tools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
 
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -419,7 +419,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -473,7 +473,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -508,7 +508,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -553,7 +553,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdatedPR = {
         pullRequestId: 123,
@@ -600,7 +600,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const longDescription = "a".repeat(4001);
 
@@ -626,7 +626,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock existing labels
       const existingLabels = [
@@ -691,7 +691,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock existing labels
       const existingLabels = [{ id: "label1", name: "old-label", active: true }];
@@ -753,7 +753,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock existing labels
       const existingLabels = [
@@ -810,7 +810,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
       if (!call) throw new Error("repo_update_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock no existing labels
       mockGitApi.getPullRequestLabels.mockResolvedValue([]);
@@ -861,7 +861,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreatedPR = {
         pullRequestId: 456,
@@ -926,7 +926,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreatedPR = {
         pullRequestId: 456,
@@ -1002,7 +1002,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const longDescription = "a".repeat(4001);
 
@@ -1026,7 +1026,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1072,7 +1072,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1118,7 +1118,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockUpdateResult = [
         {
@@ -1159,7 +1159,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getRefs.mockResolvedValue([]);
 
@@ -1180,7 +1180,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockError = new Error("API Error");
       mockGitApi.getRefs.mockRejectedValue(mockError);
@@ -1202,7 +1202,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1237,7 +1237,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1271,7 +1271,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1301,7 +1301,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
       if (!call) throw new Error("repo_create_branch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockSourceBranch = [
         {
@@ -1331,7 +1331,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_reviewers);
       if (!call) throw new Error("repo_update_pull_request_reviewers tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockReviewers = [{ id: "reviewer1" }, { id: "reviewer2" }];
       mockGitApi.createPullRequestReviewers.mockResolvedValue(mockReviewers);
@@ -1355,7 +1355,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_reviewers);
       if (!call) throw new Error("repo_update_pull_request_reviewers tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.deletePullRequestReviewer.mockResolvedValue({});
 
@@ -1382,7 +1382,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
       if (!call) throw new Error("repo_list_repos_by_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         {
@@ -1434,7 +1434,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
       if (!call) throw new Error("repo_list_repos_by_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         { id: "repo1", name: "frontend-app", isDisabled: false, isFork: false, isInMaintenance: false, webUrl: "url1", size: 1024 },
@@ -1464,7 +1464,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPRs = [
         {
@@ -1502,7 +1502,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1525,7 +1525,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1548,7 +1548,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1579,7 +1579,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock successful user lookup
       mockGetUserIdFromEmail.mockResolvedValue("specific-user-123");
@@ -1604,7 +1604,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1637,7 +1637,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1670,7 +1670,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1705,7 +1705,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -1745,7 +1745,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock successful user lookup
       mockGetUserIdFromEmail.mockResolvedValue("reviewer-user-123");
@@ -1770,7 +1770,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock successful user lookup
       mockGetUserIdFromEmail.mockResolvedValue("specific-reviewer-123");
@@ -1804,7 +1804,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock user lookup failure
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
@@ -1832,7 +1832,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPRs = [
         {
@@ -1884,7 +1884,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPRs = [
         {
@@ -1938,7 +1938,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPRs = [
         {
@@ -1992,7 +1992,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPRs = [
         {
@@ -2047,7 +2047,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock getUserIdFromEmail to return a specific user ID
       mockGetUserIdFromEmail.mockResolvedValue("specific-user-123");
@@ -2106,7 +2106,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestsByProject.mockResolvedValue([]);
 
@@ -2137,7 +2137,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestsByProject.mockResolvedValue([]);
 
@@ -2168,7 +2168,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestsByProject.mockResolvedValue([]);
 
@@ -2201,7 +2201,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestsByProject.mockResolvedValue([]);
 
@@ -2237,7 +2237,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock successful user lookup
       mockGetUserIdFromEmail.mockResolvedValue("reviewer-user-123");
@@ -2293,7 +2293,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock successful user lookup
       mockGetUserIdFromEmail.mockResolvedValue("specific-reviewer-123");
@@ -2320,7 +2320,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock user lookup failure
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
@@ -2346,7 +2346,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock both user lookups
       mockGetUserIdFromEmail
@@ -2388,7 +2388,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2449,7 +2449,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [{ id: 1, fullData: "complete" }];
       mockGitApi.getThreads.mockResolvedValue(mockThreads);
@@ -2472,7 +2472,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2514,7 +2514,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2551,7 +2551,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2588,7 +2588,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2632,7 +2632,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2668,7 +2668,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2712,7 +2712,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2748,7 +2748,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2792,7 +2792,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2836,7 +2836,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2882,7 +2882,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2913,7 +2913,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2960,7 +2960,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -2996,7 +2996,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThreads = [
         {
@@ -3034,7 +3034,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_thread_comments);
       if (!call) throw new Error("repo_list_pull_request_thread_comments tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockComments = [
         {
@@ -3087,7 +3087,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_thread_comments);
       if (!call) throw new Error("repo_list_pull_request_thread_comments tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockComments = [
         {
@@ -3140,7 +3140,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_branches_by_repo);
       if (!call) throw new Error("repo_list_branches_by_repo tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBranches = [
         { name: "refs/heads/main" },
@@ -3170,7 +3170,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_my_branches_by_repo);
       if (!call) throw new Error("repo_list_my_branches_by_repo tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBranches = [{ name: "refs/heads/main" }, { name: "refs/heads/my-feature" }];
       mockGitApi.getRefs.mockResolvedValue(mockBranches);
@@ -3195,7 +3195,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_repo_by_name_or_id);
       if (!call) throw new Error("repo_get_repo_by_name_or_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         { id: "repo1", name: "test-repo" },
@@ -3219,7 +3219,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_repo_by_name_or_id);
       if (!call) throw new Error("repo_get_repo_by_name_or_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         { id: "repo1", name: "test-repo" },
@@ -3242,7 +3242,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_repo_by_name_or_id);
       if (!call) throw new Error("repo_get_repo_by_name_or_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getRepositories.mockResolvedValue([]);
 
@@ -3265,7 +3265,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_branch_by_name);
       if (!call) throw new Error("repo_get_branch_by_name tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockBranches = [
         { name: "refs/heads/main", objectId: "abc123" },
@@ -3289,7 +3289,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_branch_by_name);
       if (!call) throw new Error("repo_get_branch_by_name tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getRefs.mockResolvedValue([]);
 
@@ -3310,7 +3310,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3336,7 +3336,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequest.mockResolvedValue({});
 
@@ -3356,7 +3356,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3405,7 +3405,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3434,7 +3434,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3480,7 +3480,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3509,7 +3509,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3553,7 +3553,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3599,7 +3599,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3646,7 +3646,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
       if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -3694,7 +3694,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
       if (!call) throw new Error("repo_reply_to_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockComment = { id: 789, content: "Reply content" };
       mockGitApi.createComment.mockResolvedValue(mockComment);
@@ -3717,7 +3717,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
       if (!call) throw new Error("repo_reply_to_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockComment = { id: 789, content: "Reply content" };
       mockGitApi.createComment.mockResolvedValue(mockComment);
@@ -3740,7 +3740,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
       if (!call) throw new Error("repo_reply_to_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.createComment.mockResolvedValue(null);
 
@@ -3764,7 +3764,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123, status: 1 };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -3796,7 +3796,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123 };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -3837,7 +3837,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123 };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -3872,7 +3872,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123 };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -3907,7 +3907,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -3930,7 +3930,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 123,
@@ -3982,7 +3982,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 456,
@@ -4022,7 +4022,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 789,
@@ -4062,7 +4062,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 100,
@@ -4102,7 +4102,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 200,
@@ -4142,7 +4142,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 300,
@@ -4182,7 +4182,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4203,7 +4203,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.updateThread.mockResolvedValue(null);
 
@@ -4226,7 +4226,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
       if (!call) throw new Error("repo_update_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = {
         id: 123,
@@ -4266,7 +4266,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCommits = [
         { commitId: "abc123", comment: "Initial commit" },
@@ -4310,7 +4310,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getCommits.mockRejectedValue(new Error("API Error"));
 
@@ -4332,7 +4332,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
       if (!call) throw new Error("repo_list_pull_requests_by_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockQueryResult = {
         results: [
@@ -4374,7 +4374,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
       if (!call) throw new Error("repo_list_pull_requests_by_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestQuery.mockRejectedValue(new Error("Query Error"));
 
@@ -4397,7 +4397,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGetCurrentUserDetails.mockResolvedValue({
         authenticatedUser: { id: "user123" },
@@ -4422,7 +4422,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -4443,7 +4443,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -4464,7 +4464,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -4485,7 +4485,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4506,7 +4506,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock getUserIdFromEmail to throw an error
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
@@ -4530,7 +4530,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock getUserIdFromEmail to throw an error
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
@@ -4554,7 +4554,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getCommits.mockRejectedValue(new Error("API Error"));
 
@@ -4574,7 +4574,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.createThread.mockRejectedValue(new Error("Thread creation failed"));
 
@@ -4596,7 +4596,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
       if (!call) throw new Error("repo_reply_to_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.createComment.mockRejectedValue(new Error("Comment creation failed"));
 
@@ -4621,7 +4621,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4643,7 +4643,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4666,7 +4666,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4688,7 +4688,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4712,7 +4712,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4735,7 +4735,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4759,7 +4759,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4782,7 +4782,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4806,7 +4806,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -4831,7 +4831,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = {
         pullRequestId: 123,
@@ -4899,7 +4899,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock threads with undefined comments to test the trimComments function
       const mockThreads = [
@@ -4941,7 +4941,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock threads with deleted comments to test the trimComments function
       const mockThreads = [
@@ -4989,7 +4989,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
       if (!call) throw new Error("repo_list_repos_by_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         { id: "1", name: "repo1", isDisabled: false, isFork: false, isInMaintenance: false, webUrl: "http://example.com/repo1", size: 100 },
@@ -5018,7 +5018,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_branch_by_name);
       if (!call) throw new Error("repo_get_branch_by_name tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock branches that don't match the requested branch name
       const mockBranches = [
@@ -5044,7 +5044,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_branch_by_name);
       if (!call) throw new Error("repo_get_branch_by_name tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock branches where one matches exactly with the branchName (second condition in the find)
       const mockBranches = [
@@ -5070,7 +5070,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequests.mockResolvedValue([]);
 
@@ -5103,7 +5103,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestsByProject.mockResolvedValue([]);
 
@@ -5135,7 +5135,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_branches_by_repo);
       if (!call) throw new Error("repo_list_branches_by_repo tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock branches with some having null/undefined names to test the flatMap filter
       const mockBranches = [
@@ -5164,7 +5164,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123, status: 1, comments: [] };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -5206,7 +5206,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 123, status: 1, comments: [] };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -5247,7 +5247,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCommits = [{ commitId: "abc123", comment: "Test commit" }];
       mockGitApi.getCommits.mockResolvedValue(mockCommits);
@@ -5290,7 +5290,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCommits = [{ commitId: "abc123", comment: "Test commit" }];
       mockGitApi.getCommits.mockResolvedValue(mockCommits);
@@ -5329,7 +5329,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5351,7 +5351,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5374,7 +5374,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5397,7 +5397,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5421,7 +5421,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5440,7 +5440,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
       if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock threads with undefined/null id values to test the sort function
       const mockThreads = [
@@ -5487,7 +5487,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_thread_comments);
       if (!call) throw new Error("repo_list_pull_request_thread_comments tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock comments with undefined/null id values to test the sort function
       const mockComments = [
@@ -5532,7 +5532,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = { pullRequestId: 123, title: "Test PR" };
       mockGitApi.createPullRequest.mockResolvedValue(mockPR);
@@ -5560,7 +5560,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
       if (!call) throw new Error("repo_create_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPR = { pullRequestId: 123, title: "Test PR" };
       mockGitApi.createPullRequest.mockResolvedValue(mockPR);
@@ -5588,7 +5588,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
       if (!call) throw new Error("repo_list_repos_by_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [{ id: "repo1", name: "Repository 1", isDisabled: false, isFork: false, isInMaintenance: false, webUrl: "url1", size: 1024 }];
       mockGitApi.getRepositories.mockResolvedValue(mockRepos);
@@ -5613,7 +5613,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
 
@@ -5636,7 +5636,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGetUserIdFromEmail.mockRejectedValue(new Error("User not found"));
 
@@ -5659,7 +5659,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5683,7 +5683,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
       if (!call) throw new Error("repo_list_pull_requests_by_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestQuery.mockRejectedValue(new Error("API error"));
 
@@ -5705,7 +5705,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
       if (!call) throw new Error("repo_list_pull_requests_by_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockQueryResult = { results: [] };
       mockGitApi.getPullRequestQuery.mockResolvedValue(mockQueryResult);
@@ -5739,7 +5739,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
       if (!call) throw new Error("repo_list_repos_by_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRepos = [
         { id: "repo1", name: undefined, isDisabled: false, isFork: false, isInMaintenance: false, webUrl: "url1", size: 1024 },
@@ -5766,7 +5766,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGetUserIdFromEmail.mockRejectedValue("String error"); // Non-Error exception
 
@@ -5789,7 +5789,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
       if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGetUserIdFromEmail.mockRejectedValue("String error"); // Non-Error exception
 
@@ -5812,7 +5812,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
       if (!call) throw new Error("repo_list_pull_requests_by_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getPullRequestQuery.mockRejectedValue("String error"); // Non-Error exception
 
@@ -5834,7 +5834,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const params = {
         repositoryId: "repo123",
@@ -5858,7 +5858,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockGitApi.getCommits.mockRejectedValue("String error"); // Non-Error exception
 
@@ -5880,7 +5880,7 @@ describe("repos tools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
       if (!call) throw new Error("repo_create_pull_request_thread tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockThread = { id: 1, status: CommentThreadStatus.Active };
       mockGitApi.createThread.mockResolvedValue(mockThread);
@@ -5921,7 +5921,7 @@ describe("repos tools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
         if (!call) throw new Error("repo_search_commits tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockCommits = [
           {
@@ -5966,7 +5966,7 @@ describe("repos tools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
         if (!call) throw new Error("repo_search_commits tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockCommit1 = { commitId: "abc123", comment: "First commit" };
         const mockCommit2 = { commitId: "def456", comment: "Second commit" };
@@ -6021,7 +6021,7 @@ describe("repos tools", () => {
       it("should handle connection errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         connectionProvider.mockRejectedValue(new Error("Connection failed"));
 
@@ -6043,7 +6043,7 @@ describe("repos tools", () => {
       it("should handle API errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.createPullRequest.mockRejectedValue(new Error("API error: Invalid branch"));
 
@@ -6067,7 +6067,7 @@ describe("repos tools", () => {
       it("should handle connection errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         connectionProvider.mockRejectedValue(new Error("Connection timeout"));
 
@@ -6087,7 +6087,7 @@ describe("repos tools", () => {
       it("should handle updateRefs API errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_branch);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         // Mock successful source branch lookup
         mockGitApi.getRefs.mockResolvedValue([{ name: "refs/heads/main", objectId: "abc123" }]);
@@ -6114,7 +6114,7 @@ describe("repos tools", () => {
       it("should handle API errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.updatePullRequest.mockRejectedValue(new Error("Pull request not found"));
 
@@ -6137,7 +6137,7 @@ describe("repos tools", () => {
       it("should handle add reviewers error", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_reviewers);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.createPullRequestReviewers.mockRejectedValue(new Error("Invalid reviewer ID"));
 
@@ -6159,7 +6159,7 @@ describe("repos tools", () => {
       it("should handle remove reviewers error", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_reviewers);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.deletePullRequestReviewer.mockRejectedValue(new Error("Reviewer not found"));
 
@@ -6183,7 +6183,7 @@ describe("repos tools", () => {
       it("should handle repository listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_repos_by_project);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getRepositories.mockRejectedValue(new Error("Project not found"));
 
@@ -6204,7 +6204,7 @@ describe("repos tools", () => {
       it("should handle pull request listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getPullRequests.mockRejectedValue(new Error("Repository access denied"));
 
@@ -6226,7 +6226,7 @@ describe("repos tools", () => {
       it("should handle thread listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getThreads.mockRejectedValue(new Error("Pull request not found"));
 
@@ -6248,7 +6248,7 @@ describe("repos tools", () => {
       it("should handle comment listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_thread_comments);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getComments.mockRejectedValue(new Error("Thread not found"));
 
@@ -6271,7 +6271,7 @@ describe("repos tools", () => {
       it("should handle branch listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_branches_by_repo);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getRefs.mockRejectedValue(new Error("Repository not found"));
 
@@ -6292,7 +6292,7 @@ describe("repos tools", () => {
       it("should handle my branches listing errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_my_branches_by_repo);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getRefs.mockRejectedValue(new Error("Access denied"));
 
@@ -6313,7 +6313,7 @@ describe("repos tools", () => {
       it("should handle repository fetch errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_repo_by_name_or_id);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getRepositories.mockRejectedValue(new Error("Project not accessible"));
 
@@ -6335,7 +6335,7 @@ describe("repos tools", () => {
       it("should handle branch fetch errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_branch_by_name);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getRefs.mockRejectedValue(new Error("Branch access denied"));
 
@@ -6357,7 +6357,7 @@ describe("repos tools", () => {
       it("should handle pull request fetch errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getPullRequest.mockRejectedValue(new Error("Pull request not found"));
 
@@ -6379,7 +6379,7 @@ describe("repos tools", () => {
       it("should handle comment creation errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.createComment.mockRejectedValue(new Error("Thread is locked"));
 
@@ -6403,7 +6403,7 @@ describe("repos tools", () => {
       it("should handle thread creation errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.createThread.mockRejectedValue(new Error("Invalid file path"));
 
@@ -6424,7 +6424,7 @@ describe("repos tools", () => {
       it("should handle validation errors for line numbers", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           repositoryId: "repo123",
@@ -6446,7 +6446,7 @@ describe("repos tools", () => {
       it("should handle thread update errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.updateThread.mockRejectedValue(new Error("Thread not found"));
 
@@ -6469,7 +6469,7 @@ describe("repos tools", () => {
       it("should handle API connection errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.updateThread.mockRejectedValue(new Error("Network connection failed"));
 
@@ -6492,7 +6492,7 @@ describe("repos tools", () => {
       it("should handle non-Error thrown objects", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request_thread);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.updateThread.mockRejectedValue("String error");
 
@@ -6517,7 +6517,7 @@ describe("repos tools", () => {
       it("should handle commit search errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getCommits.mockRejectedValue(new Error("Repository access denied"));
 
@@ -6544,7 +6544,7 @@ describe("repos tools", () => {
       it("should handle pull request query errors", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_commits);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.getPullRequestQuery.mockRejectedValue(new Error("Invalid commit ID"));
 
@@ -6567,7 +6567,7 @@ describe("repos tools", () => {
       it("should handle non-Error thrown objects", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockGitApi.createPullRequest.mockRejectedValue("String error");
 

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -83,7 +83,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
       if (!call) throw new Error("testplan_list_test_plans tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.getTestPlans as jest.Mock).mockResolvedValue([{ id: 1, name: "Test Plan 1" }]);
       const params = {
@@ -102,7 +102,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
       if (!call) throw new Error("testplan_list_test_plans tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.getTestPlans as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -128,7 +128,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock API response with flat list including nested suites
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([
@@ -197,7 +197,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([
         {
@@ -225,7 +225,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([]);
 
@@ -243,7 +243,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock a deeply nested structure
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([
@@ -309,7 +309,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -327,7 +327,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([
         {
@@ -350,7 +350,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
       if (!call) throw new Error("testplan_list_test_suites tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       ((mockTestPlanApi as any).getTestSuitesForPlan as jest.Mock).mockResolvedValue([
         {
@@ -387,7 +387,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_plan");
       if (!call) throw new Error("testplan_create_test_plan tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestPlan as jest.Mock).mockResolvedValue({ id: 1, name: "New Test Plan" });
       const params = {
@@ -419,7 +419,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_plan");
       if (!call) throw new Error("testplan_create_test_plan tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestPlan as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -441,7 +441,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
       if (!call) throw new Error("testplan_create_test_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue({ id: 10, name: "New Test Suite" });
       const params = {
@@ -471,7 +471,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
       if (!call) throw new Error("testplan_create_test_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -492,7 +492,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
       if (!call) throw new Error("testplan_create_test_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue({
         id: 15,
@@ -536,7 +536,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
       if (!call) throw new Error("testplan_create_test_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue(null);
       const params = {
@@ -556,7 +556,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
       if (!call) throw new Error("testplan_list_test_cases tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.getTestCaseList as jest.Mock).mockResolvedValue([{ id: 1, name: "Test Case 1" }]);
       const params = {
@@ -574,7 +574,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
       if (!call) throw new Error("testplan_list_test_cases tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestPlanApi.getTestCaseList as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -596,7 +596,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({ results: ["Result 1"] });
       const params = {
@@ -613,7 +613,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -634,7 +634,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1001,
@@ -671,7 +671,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1001,
@@ -708,7 +708,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1002,
@@ -742,7 +742,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -762,7 +762,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1004,
@@ -829,7 +829,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1005,
@@ -886,7 +886,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1006,
@@ -921,7 +921,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1007,
@@ -966,7 +966,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1008,
@@ -1011,7 +1011,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1009,
@@ -1045,7 +1045,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1010,
@@ -1079,7 +1079,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1011,
@@ -1129,7 +1129,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1012,
@@ -1171,7 +1171,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1013,
@@ -1225,7 +1225,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1014,
@@ -1267,7 +1267,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1015,
@@ -1309,7 +1309,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1016,
@@ -1363,7 +1363,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1017,
@@ -1413,7 +1413,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 1018,
@@ -1467,7 +1467,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 2001,
@@ -1533,7 +1533,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 2002,
@@ -1583,7 +1583,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
       if (!call) throw new Error("testplan_create_test_case tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
         id: 2003,
@@ -1652,7 +1652,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136717,
@@ -1690,7 +1690,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136718,
@@ -1735,7 +1735,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136719,
@@ -1780,7 +1780,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136720,
@@ -1817,7 +1817,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136721,
@@ -1854,7 +1854,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -1873,7 +1873,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136723,
@@ -1922,7 +1922,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136724,
@@ -1959,7 +1959,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
       if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
         id: 136725,
@@ -2002,7 +2002,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
       if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([{ testCase: { id: 1001 } }, { testCase: { id: 1002 } }]);
 
@@ -2022,7 +2022,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
       if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([{ testCase: { id: 1003 } }, { testCase: { id: 1004 } }]);
 
@@ -2042,7 +2042,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
       if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([]);
 
@@ -2061,7 +2061,7 @@ describe("configureTestPlanTools", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
       if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockRejectedValue(new Error("API Error"));
 

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -55,7 +55,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_wiki");
       if (!call) throw new Error("wiki_get_wiki tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWiki = { id: "wiki1", name: "Test Wiki" };
       mockWikiApi.getWiki.mockResolvedValue(mockWiki);
@@ -76,7 +76,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_wiki");
       if (!call) throw new Error("wiki_get_wiki tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Wiki not found");
       mockWikiApi.getWiki.mockRejectedValue(testError);
@@ -97,7 +97,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_wiki");
       if (!call) throw new Error("wiki_get_wiki tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getWiki.mockResolvedValue(null);
 
@@ -117,7 +117,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_wiki");
       if (!call) throw new Error("wiki_get_wiki tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getWiki.mockRejectedValue("string error");
 
@@ -139,7 +139,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_wikis");
       if (!call) throw new Error("wiki_list_wikis tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWikis = [
         { id: "wiki1", name: "Wiki 1" },
@@ -162,7 +162,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_wikis");
       if (!call) throw new Error("wiki_list_wikis tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to fetch wikis");
       mockWikiApi.getAllWikis.mockRejectedValue(testError);
@@ -182,7 +182,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_wikis");
       if (!call) throw new Error("wiki_list_wikis tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getAllWikis.mockResolvedValue(null);
 
@@ -201,7 +201,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_wikis");
       if (!call) throw new Error("wiki_list_wikis tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getAllWikis.mockRejectedValue("string error");
 
@@ -222,7 +222,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_pages");
       if (!call) throw new Error("wiki_list_pages tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       mockWikiApi.getPagesBatch.mockResolvedValue({ value: ["page1", "page2"] });
 
       const params = {
@@ -252,7 +252,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_pages");
       if (!call) throw new Error("wiki_list_pages tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       mockWikiApi.getPagesBatch.mockResolvedValue({ value: ["page1", "page2"] });
 
       const params = {
@@ -277,7 +277,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_pages");
       if (!call) throw new Error("wiki_list_pages tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to fetch wiki pages");
       mockWikiApi.getPagesBatch.mockRejectedValue(testError);
@@ -299,7 +299,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_pages");
       if (!call) throw new Error("wiki_list_pages tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getPagesBatch.mockResolvedValue(null);
 
@@ -320,7 +320,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_list_pages");
       if (!call) throw new Error("wiki_list_pages tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getPagesBatch.mockRejectedValue("string error");
 
@@ -351,7 +351,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page");
       if (!call) throw new Error("wiki_get_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPageData = {
         id: 123,
@@ -390,7 +390,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page");
       if (!call) throw new Error("wiki_get_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockPageData = { id: 456, path: "/Documentation" };
 
@@ -415,7 +415,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page");
       if (!call) throw new Error("wiki_get_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockFetch.mockResolvedValue({
         ok: true,
@@ -439,7 +439,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page");
       if (!call) throw new Error("wiki_get_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockFetch.mockResolvedValue({
         ok: false,
@@ -464,7 +464,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page");
       if (!call) throw new Error("wiki_get_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockFetch.mockRejectedValue(new Error("Network error"));
 
@@ -486,7 +486,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock a stream-like object for getPageText
       const mockStream = {
@@ -520,7 +520,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Page not found");
       mockWikiApi.getPageText.mockRejectedValue(testError);
@@ -542,7 +542,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getPageText.mockResolvedValue(null);
 
@@ -563,7 +563,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock a stream that emits an error
       const mockStream = {
@@ -594,7 +594,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWikiApi.getPageText.mockRejectedValue("string error");
 
@@ -615,7 +615,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockStream = {
         setEncoding: jest.fn(),
@@ -638,7 +638,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       // Ensure token is returned
       (tokenProvider as jest.Mock).mockResolvedValueOnce("abc");
       const mockStream = {
@@ -672,7 +672,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       (tokenProvider as jest.Mock).mockResolvedValueOnce("abc");
 
       const mockFetch = jest.fn();
@@ -704,7 +704,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       const result = await handler({ url: "https://dev.azure.com/org/project/_wiki/wikis/wiki1?pagePath=%2FHome", wikiIdentifier: "wiki1", project: "project" });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Provide either 'url' OR 'wikiIdentifier'");
@@ -714,7 +714,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       const result = await handler({ path: "/Home" });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("You must provide either 'url' OR both 'wikiIdentifier' and 'project'");
@@ -724,7 +724,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const result = await handler({ url: "https://dev.azure.com/org/project/notwiki/wikis/wiki1?pagePath=%2FHome" });
       expect(result.isError).toBe(true);
@@ -735,7 +735,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const result = await handler({ url: "not-a-valid-url" });
       expect(result.isError).toBe(true);
@@ -746,7 +746,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValueOnce({ token: "abc", expiresOnTimestamp: Date.now() + 10000 });
 
@@ -768,7 +768,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const url = "https://dev.azure.com/org//_wiki/wikis/?pagePath=%2FHome";
       const result = await handler({ url });
@@ -781,7 +781,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockStream = {
         setEncoding: jest.fn(),
@@ -804,7 +804,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockStream = {
         setEncoding: jest.fn(),
@@ -827,7 +827,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (tokenProvider as jest.Mock).mockResolvedValueOnce({ token: "abc", expiresOnTimestamp: Date.now() + 10000 });
 
@@ -873,7 +873,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResponse = {
         path: "/Home",
@@ -918,7 +918,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -964,7 +964,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -989,7 +989,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockFetch.mockRejectedValue(new Error("Network error"));
 
@@ -1010,7 +1010,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1059,7 +1059,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1109,7 +1109,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1150,7 +1150,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1200,7 +1200,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1238,7 +1238,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1280,7 +1280,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Throw a non-Error object
       mockFetch.mockRejectedValue("String error message");
@@ -1302,7 +1302,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResponse = {
         ok: true,
@@ -1335,7 +1335,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResponse = {
         ok: true,
@@ -1368,7 +1368,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockCreateResponse = {
         ok: false,
@@ -1401,7 +1401,7 @@ describe("configureWikiTools", () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_create_or_update_page");
       if (!call) throw new Error("wiki_create_or_update_page tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockResponse = {
         path: "/Home",

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -106,7 +106,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
       if (!call) throw new Error("wit_list_backlogs tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getBacklogs as jest.Mock).mockResolvedValue([_mockBacklogs]);
 
@@ -132,7 +132,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
       if (!call) throw new Error("wit_list_backlog_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getBacklogLevelWorkItems as jest.Mock).mockResolvedValue([
         {
@@ -200,7 +200,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_my_work_items");
       if (!call) throw new Error("wit_my_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getPredefinedQueryResults as jest.Mock).mockResolvedValue([
         {
@@ -276,7 +276,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemsBatch as jest.Mock).mockResolvedValue([_mockWorkItems]);
 
@@ -304,7 +304,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemsWithCustomFields = [
         {
@@ -343,7 +343,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemsBatch as jest.Mock).mockResolvedValue([_mockWorkItems]);
 
@@ -372,7 +372,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock work items with System.AssignedTo as objects
       const mockWorkItemsWithAssignedTo = [
@@ -426,7 +426,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemsWithPartialAssignedTo = [
         {
@@ -462,7 +462,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemsWithPartialAssignedTo = [
         {
@@ -498,7 +498,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemsWithStringAssignedTo = [
         {
@@ -531,7 +531,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemsWithoutAssignedTo = [
         {
@@ -563,7 +563,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemsBatch as jest.Mock).mockResolvedValue(null);
 
@@ -583,7 +583,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
 
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock work items with all user fields as objects
       const mockWorkItemsWithUserFields = [
@@ -662,7 +662,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
 
       if (!call) throw new Error("wit_get_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
@@ -689,7 +689,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_comments");
 
       if (!call) throw new Error("wit_list_work_item_comments tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getComments as jest.Mock).mockResolvedValue([_mockWorkItemComments]);
 
@@ -714,7 +714,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_work_item_comment");
 
       if (!call) throw new Error("wit_add_work_item_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -754,7 +754,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_work_item_comment");
 
       if (!call) throw new Error("wit_add_work_item_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -795,7 +795,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_work_item_comment");
 
       if (!call) throw new Error("wit_add_work_item_comment tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -827,7 +827,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
 
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
@@ -878,7 +878,7 @@ describe("configureWorkItemTools", () => {
 
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
 
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("API failure"));
 
       const params = {
@@ -898,7 +898,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
 
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
       const params = {
@@ -931,7 +931,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
 
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
       const params = {
@@ -970,7 +970,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
 
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
       // Testing with empty string for pullRequestProjectId
@@ -1009,7 +1009,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Simulate an unknown error type (not an Error instance)
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue("String error");
@@ -1036,7 +1036,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_for_iteration");
 
       if (!call) throw new Error("wit_get_work_items_for_iterationt tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getIterationWorkItems as jest.Mock).mockResolvedValue([_mockWorkItemsForIteration]);
 
@@ -1067,7 +1067,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
 
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(_mockWorkItemRevisions);
 
@@ -1090,7 +1090,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
 
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(_mockWorkItemRevisions);
 
@@ -1115,7 +1115,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
 
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Create a deep copy of mock data to avoid mutating the original
       const mockDataWithIdentities = JSON.parse(JSON.stringify(_mockWorkItemRevisions));
@@ -1149,7 +1149,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
 
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockRevisionsWithoutIdentities = [
         {
@@ -1183,7 +1183,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
 
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(_mockWorkItemRevisions);
 
@@ -1206,7 +1206,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item");
 
       if (!call) throw new Error("wit_update_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
@@ -1245,7 +1245,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_type");
 
       if (!call) throw new Error("wit_get_work_item_type tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemType as jest.Mock).mockResolvedValue([_mockWorkItemType]);
 
@@ -1269,7 +1269,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
 
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
 
@@ -1302,7 +1302,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
 
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
 
@@ -1336,7 +1336,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
 
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(null);
 
@@ -1358,7 +1358,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
 
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue(new Error("API failure"));
 
@@ -1380,7 +1380,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
 
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue("String error");
 
@@ -1404,7 +1404,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query");
 
       if (!call) throw new Error("wit_get_query tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getQuery as jest.Mock).mockResolvedValue([_mockQuery]);
 
@@ -1432,7 +1432,7 @@ describe("configureWorkItemTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query_results_by_id");
 
       if (!call) throw new Error("wit_get_query_results_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.queryById as jest.Mock).mockResolvedValue([_mockQueryResults]);
 
@@ -1458,7 +1458,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock the connection and serverUrl
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
@@ -1499,7 +1499,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
 
@@ -1528,7 +1528,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_items_batch");
       if (!call) throw new Error("wit_update_work_items_batch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -1593,7 +1593,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_items_batch");
       if (!call) throw new Error("wit_update_work_items_batch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -1663,7 +1663,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_items_batch");
       if (!call) throw new Error("wit_update_work_items_batch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -1697,7 +1697,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -1740,7 +1740,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -1775,7 +1775,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock work item with relations
       const mockWorkItemWithRelations = {
@@ -1831,7 +1831,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock work item with multiple related links
       const mockWorkItemWithRelations = {
@@ -1898,7 +1898,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemWithRelations = {
         id: 1,
@@ -1951,7 +1951,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemWithRelations = {
         id: 1,
@@ -1985,7 +1985,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemWithRelations = {
         id: 1,
@@ -2019,7 +2019,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockRejectedValue(new Error("Work item not found"));
 
@@ -2040,7 +2040,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemWithNoRelations = {
         id: 1,
@@ -2066,7 +2066,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockWorkItemWithRelations = {
         id: 1,
@@ -2118,7 +2118,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Mock a work item with some relations (this won't matter since we'll hit the error before processing them)
       const mockWorkItemWithRelations = {
@@ -2145,7 +2145,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
       if (!call) throw new Error("wit_work_item_unlink tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Simulate an unknown error type (not an Error instance)
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockRejectedValue("String error");
@@ -2170,7 +2170,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2194,7 +2194,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(null);
 
@@ -2215,7 +2215,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("Linking failed"));
 
@@ -2238,7 +2238,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_link_work_item_to_pull_request");
       if (!call) throw new Error("wit_link_work_item_to_pull_request tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue(null);
 
@@ -2261,7 +2261,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
       if (!call) throw new Error("wit_create_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       // Simulate an unknown error type (not an Error instance)
       (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockRejectedValue({ message: "Complex error object" });
@@ -2283,7 +2283,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2319,7 +2319,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2365,7 +2365,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2414,7 +2414,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2443,7 +2443,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2491,7 +2491,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
@@ -2526,7 +2526,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
       if (!call) throw new Error("wit_add_child_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
 
@@ -2558,7 +2558,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
       if (!call) throw new Error("wit_list_backlogs tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getBacklogs as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2578,7 +2578,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
       if (!call) throw new Error("wit_list_backlog_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getBacklogLevelWorkItems as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2599,7 +2599,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_my_work_items");
       if (!call) throw new Error("wit_my_work_items tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getPredefinedQueryResults as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2621,7 +2621,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
       if (!call) throw new Error("wit_get_work_items_batch_by_ids tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemsBatch as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2641,7 +2641,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
       if (!call) throw new Error("wit_get_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2661,7 +2661,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_comments");
       if (!call) throw new Error("wit_list_work_item_comments tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getComments as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2682,7 +2682,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
       if (!call) throw new Error("wit_list_work_item_revisions tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2703,7 +2703,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_for_iteration");
       if (!call) throw new Error("wit_get_work_items_for_iteration tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getIterationWorkItems as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2724,7 +2724,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item");
       if (!call) throw new Error("wit_update_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2750,7 +2750,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item");
       if (!call) throw new Error("wit_update_work_item tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue([_mockWorkItem]);
 
@@ -2778,7 +2778,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_type");
       if (!call) throw new Error("wit_get_work_item_type tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getWorkItemType as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2798,7 +2798,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query");
       if (!call) throw new Error("wit_get_query tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getQuery as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2821,7 +2821,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query_results_by_id");
       if (!call) throw new Error("wit_get_query_results_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.queryById as jest.Mock).mockRejectedValue(new Error("API Error"));
 
@@ -2844,7 +2844,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query_results_by_id");
       if (!call) throw new Error("wit_get_query_results_by_id tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const mockQueryResultsWithIds = {
         workItems: [{ id: 1 }, { id: 2 }, { id: 3 }],
@@ -2870,7 +2870,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_items_batch");
       if (!call) throw new Error("wit_update_work_items_batch tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockRejectedValue(new Error("Token error"));
@@ -2897,7 +2897,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
       if (!call) throw new Error("wit_work_items_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockConnection.serverUrl = "https://dev.azure.com/contoso";
       (tokenProvider as jest.Mock).mockRejectedValue(new Error("Token error"));
@@ -2924,7 +2924,7 @@ describe("configureWorkItemTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
       if (!call) throw new Error("wit_add_artifact_link tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       mockWorkItemTrackingApi.updateWorkItem.mockRejectedValue("String error");
 
@@ -2949,7 +2949,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -2997,7 +2997,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3039,7 +3039,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         mockWorkItemTrackingApi.updateWorkItem.mockRejectedValue(new Error("API Error"));
 
@@ -3062,7 +3062,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3106,7 +3106,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           workItemId: 1234,
@@ -3127,7 +3127,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3173,7 +3173,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           workItemId: 1234,
@@ -3194,7 +3194,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3238,7 +3238,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           workItemId: 1234,
@@ -3260,7 +3260,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3302,7 +3302,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3344,7 +3344,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
@@ -3386,7 +3386,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           workItemId: 1234,
@@ -3406,7 +3406,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         const params = {
           workItemId: 1234,
@@ -3425,7 +3425,7 @@ describe("configureWorkItemTools", () => {
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
         if (!call) throw new Error("wit_add_artifact_link tool not registered");
-        const [, , , handler] = call;
+        const [, , , , handler] = call;
 
         // Mock updateWorkItem to return null
         mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(null);

--- a/test/src/tools/work.test.ts
+++ b/test/src/tools/work.test.ts
@@ -69,7 +69,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
       if (!call) throw new Error("work_list_team_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockResolvedValue([
         {
@@ -117,7 +117,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
       if (!call) throw new Error("work_list_team_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to retrieve iterations");
       (mockWorkApi.getTeamIterations as jest.Mock).mockRejectedValue(testError);
@@ -140,7 +140,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
       if (!call) throw new Error("work_list_team_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockResolvedValue(null);
 
@@ -162,7 +162,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
       if (!call) throw new Error("work_list_team_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockRejectedValue("string error");
 
@@ -186,7 +186,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -295,7 +295,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -339,7 +339,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -395,7 +395,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -427,7 +427,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([]);
 
@@ -448,7 +448,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue(null);
 
@@ -469,7 +469,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -513,7 +513,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to retrieve iterations");
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockRejectedValue(testError);
@@ -535,7 +535,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockRejectedValue("string error");
 
@@ -556,7 +556,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -615,7 +615,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -702,7 +702,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -814,7 +814,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -881,7 +881,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -927,7 +927,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
       if (!call) throw new Error("work_list_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
         {
@@ -988,7 +988,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
 
       if (!call) throw new Error("work_assign_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockResolvedValue({
         id: "a589a806-bf11-4d4f-a031-c19813331553",
@@ -1051,7 +1051,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
 
       if (!call) throw new Error("work_assign_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to assign iteration");
       (mockWorkApi.postTeamIteration as jest.Mock).mockRejectedValue(testError);
@@ -1080,7 +1080,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
 
       if (!call) throw new Error("work_assign_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockResolvedValue(null);
 
@@ -1108,7 +1108,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
 
       if (!call) throw new Error("work_assign_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockRejectedValue("string error");
 
@@ -1138,7 +1138,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
 
       if (!call) throw new Error("work_create_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue({
         id: 126391,
@@ -1216,7 +1216,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
 
       if (!call) throw new Error("work_create_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to create iteration");
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockRejectedValue(testError);
@@ -1245,7 +1245,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
 
       if (!call) throw new Error("work_create_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue(null);
 
@@ -1273,7 +1273,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
 
       if (!call) throw new Error("work_create_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockRejectedValue("string error");
 
@@ -1301,7 +1301,7 @@ describe("configureWorkTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
 
       if (!call) throw new Error("work_create_iterations tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue({
         id: 126391,
@@ -1360,7 +1360,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
         teamMembers: [
@@ -1478,7 +1478,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
         teamMembers: [],
@@ -1505,7 +1505,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue(null);
 
@@ -1527,7 +1527,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
         teamMembers: undefined,
@@ -1560,7 +1560,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
         teamMembers: [
@@ -1615,7 +1615,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to retrieve team capacity");
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockRejectedValue(testError);
@@ -1638,7 +1638,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockRejectedValue("string error");
 
@@ -1660,7 +1660,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
       if (!call) throw new Error("work_get_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
         teamMembers: [
@@ -1753,7 +1753,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
         teamMember: {
@@ -1852,7 +1852,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
         teamMember: {
@@ -1922,7 +1922,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
         teamMember: {
@@ -2024,7 +2024,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
         teamMember: {
@@ -2115,7 +2115,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue(null);
 
@@ -2144,7 +2144,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
         teamMember: undefined,
@@ -2191,7 +2191,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to update capacity");
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockRejectedValue(testError);
@@ -2221,7 +2221,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
       if (!call) throw new Error("work_update_team_capacity tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockRejectedValue("string error");
 
@@ -2252,7 +2252,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
         teams: [
@@ -2329,7 +2329,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
         teams: [],
@@ -2355,7 +2355,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue(null);
 
@@ -2376,7 +2376,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
         teams: undefined,
@@ -2401,7 +2401,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
         teams: [
@@ -2456,7 +2456,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       const testError = new Error("Failed to retrieve iteration capacities");
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockRejectedValue(testError);
@@ -2478,7 +2478,7 @@ describe("configureWorkTools", () => {
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
       if (!call) throw new Error("work_get_iteration_capacities tool not registered");
-      const [, , , handler] = call;
+      const [, , , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockRejectedValue("string error");
 


### PR DESCRIPTION
## Summary

- Add `readOnlyHint` and `destructiveHint` annotations to all 80 tools across 9 tool modules
- These annotations help LLMs understand tool behavior and make better decisions about tool usage
- All 665 tests pass with updated test infrastructure

## Tool Annotation Summary

| File | Read-Only | Destructive | Total |
|------|-----------|-------------|-------|
| core.ts | 3 | 0 | 3 |
| pipelines.ts | 9 | 3 | 12 |
| repositories.ts | 11 | 7 | 18 |
| work-items.ts | 11 | 9 | 20 |
| wiki.ts | 5 | 1 | 6 |
| test-plans.ts | 4 | 5 | 9 |
| search.ts | 3 | 0 | 3 |
| advanced-security.ts | 2 | 0 | 2 |
| work.ts | 4 | 3 | 7 |
| **Total** | **52** | **28** | **80** |

## Changes

- Added `title`, `readOnlyHint`, or `destructiveHint` annotations to each `server.tool()` call
- Updated tests to account for new annotation parameter position
- No functional changes to tool implementations

## Test plan

- [x] All 665 existing tests pass
- [x] Build succeeds without errors
- [x] Annotations verified in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)