### PR TITLE
chore: rename contributor 'ykholodkov' to 'YevheniiKholodkov'

### DIFF
--- a/.github/acl/access.yml
+++ b/.github/acl/access.yml
@@ -28,5 +28,5 @@ configuration:
       role: Write
     - member: mkonjikovac
       role: Write
-    - member: ykholodkov
+    - member: YevheniiKholodkov
       role: Write


### PR DESCRIPTION
Fix account name of contributor