### PR TITLE
docs: add FAQ entry about remote Azure DevOps MCP Server availability

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,3 +27,7 @@ At this time, only the local version of the MCP Server is supported.
 Unfortunately, personal accounts are not supported. To maintain a higher level of authentication and security, your account must be backed by Entra ID. If you receive an error message like this, it means you are using a personal account.
 
 ![image of login error for personal accounts](./media/personal-accounts-error.png)
+
+## When will a remote Azure DevOps MCP Server be availble?
+
+We receive this question frequently. The good news is that work is currently underway. Development began in early January 2026. Once we can provide a reliable timeline, we will publish it on the public [Azure DevOps roadmap](https://learn.microsoft.com/en-us/azure/devops/release-notes/features-timeline).


### PR DESCRIPTION
This pull request adds a frequently asked question to the documentation regarding the availability of a remote Azure DevOps MCP Server. The update clarifies that development is underway and provides guidance on where to find future updates.

Documentation update:

* Added a new FAQ entry in `docs/FAQ.md` explaining that work on a remote Azure DevOps MCP Server began in January 2026 and that updates will be posted on the public Azure DevOps roadmap.

## GitHub issue number
N/A

## **Associated Risks**

Zero

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

N/A
