### PR TITLE
Users/danhellem/test plans concurrency fix 2

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -142,6 +142,12 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
           };
         }
       }
+
+      // This should never be reached, but TypeScript requires a return value
+      return {
+        content: [{ type: "text", text: "Error creating test suite: Maximum retries exceeded" }],
+        isError: true,
+      };
     }
   );
 


### PR DESCRIPTION
This pull request introduces a retry mechanism with exponential backoff for handling concurrency conflicts when creating a child test suite in the `configureTestPlanTools` function. The main goal is to make the test suite creation process more robust in the face of transient concurrency errors.

**Enhancements to error handling and robustness:**

* Added a retry loop with exponential backoff and jitter when a concurrency conflict is detected during test suite creation in `src/tools/test-plans.ts` (`configureTestPlanTools`). This helps to automatically recover from temporary conflicts such as "TF26071" or "changed by someone else" errors. [[1]](diffhunk://#diff-a0b0566c24c8b1026d147328b10955e0d92de054eaace3d1b988111eeaac77ddR103-R106) [[2]](diffhunk://#diff-a0b0566c24c8b1026d147328b10955e0d92de054eaace3d1b988111eeaac77ddR127-R151)
* Ensured that after all retries are exhausted, a clear error message is returned to indicate that the maximum number of retries has been exceeded.

## GitHub issue number #839

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested with both tests and manual
