### PR TITLE
Add repository file content retrieval tools

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -39,6 +39,9 @@
 | Repositories      | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request            |
 | Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread           |
 | Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                          |
+| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get contents of a file from a repository                 |
+| Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                    |
+| Repositories      | [mcp_ado_repo_get_items_batch](#mcp_ado_repo_get_items_batch)                                             | Get contents of multiple files in a single request       |
 | Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                      |
 | Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                            |
 | Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                    |
@@ -350,6 +353,27 @@ Replies to a specific comment on a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `threadId`, `content`
 - **Optional**: `fullResponse`, `project`
+
+### mcp_ado_repo_get_file_content
+
+Get the contents of a file from a repository.
+
+- **Required**: `repositoryId`, `path`
+- **Optional**: `project`, `version`, `versionType`, `maxLines`
+
+### mcp_ado_repo_list_directory
+
+List files and folders in a directory within a repository.
+
+- **Required**: `repositoryId`
+- **Optional**: `path`, `project`, `version`, `versionType`, `recursive`, `recursionDepth`
+
+### mcp_ado_repo_get_items_batch
+
+Get contents of multiple files from a repository in a single request.
+
+- **Required**: `repositoryId`, `paths`
+- **Optional**: `project`, `version`, `versionType`, `maxLines`, `maxFiles`
 
 ## Search
 


### PR DESCRIPTION
Add three new tools for retrieving file contents from Azure DevOps Git repositories:

- repo_get_file_content: Retrieve contents of a single file
- repo_list_directory: List files and folders in a directory
- repo_get_items_batch: Retrieve multiple files in a single request

Features include branch/commit/tag support, binary file detection, content truncation, and encoding detection. Includes comprehensive unit tests and documentation updates.

## Description

These tools enable agents to read source code and configuration files directly from Azure DevOps repositories. Key use cases include:
- Investigating CodeQL/SARIF security alerts by retrieving referenced source files
- Navigating codebases to understand dependencies and function definitions
- Pulling pipeline definitions and config files for CI/CD troubleshooting
- Supporting code review workflows by accessing unchanged files referenced by PRs

## GitHub issue number

#888

## **Associated Risks**

- **Large file responses**: Mitigated by `maxLines` parameter to truncate content
- **Batch request overload**: Mitigated by `maxFiles` parameter (capped at 50)
- **Binary file handling**: Binary files are detected and return metadata only, preventing garbled output

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

**Unit Tests:**
- 17 new tests covering all 3 tools (689 total tests pass)
- Tests cover: successful retrieval, file not found, content truncation, binary detection, API errors, commit SHA support, recursive directory listing, depth clamping, batch partial failures, maxFiles limits

**Live Testing:**
- Tested against internal Azure DevOps organizations
- `repo_list_directory`: Listed files in multiple repos
- `repo_get_file_content`: Retrieved individual file content successfully
- `repo_get_items_batch`: Retrieved 4 files in single batch request with proper encoding detection

**Validation:**
- `npm run build` ✅
- `npm run eslint` ✅
- `npm run validate-tools` ✅ (83 tools)
- `npm run format` ✅