### PR TITLE
feat: add supportsIterations flag to repository configuration

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -175,6 +175,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
             workItemRefs: workItemRefs,
             forkSource,
             labels: labelDefinitions,
+            supportsIterations: true,
           },
           repositoryId
         );

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -898,6 +898,8 @@ describe("repos tools", () => {
           isDraft: undefined,
           workItemRefs: [],
           forkSource: undefined,
+          labels: undefined,
+          supportsIterations: true,
         },
         "repo123"
       );
@@ -974,6 +976,7 @@ describe("repos tools", () => {
             },
           },
           labels: [{ name: "enhancement" }, { name: "needs-review" }],
+          supportsIterations: true,
         },
         "repo123"
       );
@@ -4871,6 +4874,8 @@ describe("repos tools", () => {
           isDraft: undefined, // This is what actually gets passed when isDraft is not provided
           workItemRefs: [],
           forkSource: undefined, // This should be undefined when forkSourceRepositoryId is not provided
+          labels: undefined,
+          supportsIterations: true,
         },
         "repo123"
       );


### PR DESCRIPTION
This pull request introduces a new property, `supportsIterations`, to the repository configuration and updates related tests to account for this change. The addition ensures that repository objects explicitly indicate whether they support iterations, improving clarity and consistency across the codebase.

Repository configuration update:

* Added a `supportsIterations: true` property to the repository configuration object in `configureRepoTools`, ensuring that all configured repositories now include this flag.

Test updates:

* Updated multiple test cases in `repositories.test.ts` to include the `supportsIterations: true` property in the expected repository configuration, ensuring tests accurately reflect the new repository structure. [[1]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aR901-R902) [[2]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aR979) [[3]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aR4877-R4878)
* Added `labels: undefined` to some test cases for consistency with the updated repository configuration. [[1]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aR901-R902) [[2]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aR4877-R4878)

## GitHub issue number
#896 

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manual Testing and update relevant tests
