### PR TITLE
fix: add project parameter to repo_get_pull_request_by_id

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -946,16 +946,19 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
     REPO_TOOLS.get_pull_request_by_id,
     "Get a pull request by its ID.",
     {
-      repositoryId: z.string().describe("The ID of the repository where the pull request is located."),
+      repositoryId: z
+        .string()
+        .describe("The ID or name of the repository where the pull request is located. When using a repository name instead of a GUID, the project parameter must also be provided."),
       pullRequestId: z.number().describe("The ID of the pull request to retrieve."),
+      project: z.string().optional().describe("Project ID or project name. Required when repositoryId is a repository name instead of a GUID."),
       includeWorkItemRefs: z.boolean().optional().default(false).describe("Whether to reference work items associated with the pull request."),
       includeLabels: z.boolean().optional().default(false).describe("Whether to include a summary of labels in the response."),
     },
-    async ({ repositoryId, pullRequestId, includeWorkItemRefs, includeLabels }) => {
+    async ({ repositoryId, pullRequestId, project, includeWorkItemRefs, includeLabels }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
-        const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, undefined, undefined, undefined, undefined, undefined, includeWorkItemRefs);
+        const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, project, undefined, undefined, undefined, undefined, includeWorkItemRefs);
 
         if (includeLabels) {
           try {

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -3426,6 +3426,33 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
     });
 
+    it("should pass project parameter when provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_pull_request_by_id);
+      if (!call) throw new Error("repo_get_pull_request_by_id tool not registered");
+      const [, , , handler] = call;
+
+      const mockPR = {
+        pullRequestId: 456,
+        title: "Test PR with project",
+        status: 1,
+      };
+      mockGitApi.getPullRequest.mockResolvedValue(mockPR);
+
+      const params = {
+        repositoryId: "my-repo-name",
+        pullRequestId: 456,
+        project: "my-project",
+        includeWorkItemRefs: false,
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.getPullRequest).toHaveBeenCalledWith("my-repo-name", 456, "my-project", undefined, undefined, undefined, undefined, false);
+      expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
+    });
+
     it("should include work item refs when requested", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 


### PR DESCRIPTION
## Summary

- Adds an optional `project` parameter to `repo_get_pull_request_by_id`, consistent with other repo-scoped tools (`list_pull_request_threads`, `reply_to_comment`, `create_pull_request_thread`, etc.)
- Passes `project` through to `gitApi.getPullRequest()` so the Azure DevOps API can resolve repository **names** (not just GUIDs)
- Adds a test case verifying the project parameter is forwarded correctly

## Problem

When `repositoryId` is a repo name (e.g., `"yammer-clients"`) instead of a GUID, the API returns:

> `Error: A project name is required in order to reference a Git repository by name.`

The tool schema had no `project` parameter, so callers had to make an extra roundtrip via `repo_list_repos_by_project` to resolve the GUID first.

## Fix

The underlying `azure-devops-node-api` `getPullRequest()` already accepts `project` as its 3rd parameter — this change simply exposes it in the tool schema and passes it through.

## Test plan

- [x] Existing 203 tests pass unchanged
- [x] New test: `should pass project parameter when provided` — verifies `getPullRequest` receives the project arg
- [x] Build passes (`npm run build`)

Closes #774 