### PR TITLE
feat: enhance project team retrieval tool with project selection prompt

### DIFF
--- a/src/tools/core.ts
+++ b/src/tools/core.ts
@@ -23,9 +23,9 @@ function filterProjectsByName(projects: ProjectInfo[], projectNameFilter: string
 function configureCoreTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     CORE_TOOLS.list_project_teams,
-    "Retrieve a list of teams for the specified Azure DevOps project.",
+    "Retrieve a list of teams for an Azure DevOps project. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. If not provided, a project selection prompt will be shown."),
       mine: z.boolean().optional().describe("If true, only return teams that the authenticated user is a member of."),
       top: z.number().optional().describe("The maximum number of teams to return. Defaults to 100."),
       skip: z.number().optional().describe("The number of teams to skip for pagination. Defaults to 0."),
@@ -34,7 +34,44 @@ function configureCoreTools(server: McpServer, tokenProvider: () => Promise<stri
       try {
         const connection = await connectionProvider();
         const coreApi = await connection.getCoreApi();
-        const teams = await coreApi.getTeams(project, mine, top, skip, false);
+
+        let resolvedProject = project;
+
+        if (!resolvedProject) {
+          const projects = await coreApi.getProjects("wellFormed", 100, 0, undefined, false);
+
+          if (!projects || projects.length === 0) {
+            return { content: [{ type: "text", text: "No projects found to select from." }], isError: true };
+          }
+
+          const result = await server.server.elicitInput({
+            mode: "form",
+            message: "Select the Azure DevOps project to list teams for.",
+            requestedSchema: {
+              type: "object",
+              properties: {
+                project: {
+                  type: "string",
+                  title: "Project",
+                  description: "The Azure DevOps project to list teams for.",
+                  oneOf: projects.map((p) => ({
+                    const: p.name ?? p.id ?? "",
+                    title: p.name ?? p.id ?? "Unknown project",
+                  })),
+                },
+              },
+              required: ["project"],
+            },
+          });
+
+          if (result.action !== "accept" || !result.content?.project) {
+            return { content: [{ type: "text", text: "Project selection cancelled." }] };
+          }
+
+          resolvedProject = String(result.content.project);
+        }
+
+        const teams = await coreApi.getTeams(resolvedProject, mine, top, skip, false);
 
         if (!teams) {
           return { content: [{ type: "text", text: "No teams found" }], isError: true };

--- a/test/src/tools/core.test.ts
+++ b/test/src/tools/core.test.ts
@@ -23,7 +23,7 @@ describe("configureCoreTools", () => {
   let mockCoreApi: CoreApiMock;
 
   beforeEach(() => {
-    server = { tool: jest.fn() } as unknown as McpServer;
+    server = { tool: jest.fn(), server: { elicitInput: jest.fn() } } as unknown as McpServer;
     tokenProvider = jest.fn();
     userAgentProvider = () => "Jest";
 
@@ -415,6 +415,108 @@ describe("configureCoreTools", () => {
       expect(mockCoreApi.getTeams).toHaveBeenCalled();
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error fetching project teams: Unknown error occurred");
+    });
+
+    it("should elicit project when project is not provided and user accepts", async () => {
+      configureCoreTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
+      if (!call) throw new Error("core_list_project_teams tool not registered");
+      const [, , , handler] = call;
+
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([
+        { id: "proj-1", name: "ProjectAlpha" },
+        { id: "proj-2", name: "ProjectBeta" },
+      ]);
+
+      ((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock).mockResolvedValue({
+        action: "accept",
+        content: { project: "ProjectAlpha" },
+      });
+
+      (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
+
+      const params = { project: undefined, mine: undefined, top: undefined, skip: undefined };
+      const result = await handler(params);
+
+      expect(mockCoreApi.getProjects).toHaveBeenCalledWith("wellFormed", 100, 0, undefined, false);
+      expect((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput).toHaveBeenCalled();
+      expect(mockCoreApi.getTeams).toHaveBeenCalledWith("ProjectAlpha", undefined, undefined, undefined, false);
+      expect(result.content[0].text).toContain("Team One");
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should return cancellation message when user declines elicitation", async () => {
+      configureCoreTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
+      if (!call) throw new Error("core_list_project_teams tool not registered");
+      const [, , , handler] = call;
+
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
+
+      ((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock).mockResolvedValue({
+        action: "decline",
+      });
+
+      const params = { project: undefined, mine: undefined, top: undefined, skip: undefined };
+      const result = await handler(params);
+
+      expect(mockCoreApi.getTeams).not.toHaveBeenCalled();
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("should fall back to project id when name is missing in elicitation options", async () => {
+      configureCoreTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
+      if (!call) throw new Error("core_list_project_teams tool not registered");
+      const [, , , handler] = call;
+
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([
+        { id: "proj-1", name: undefined },
+        { id: undefined, name: undefined },
+      ]);
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      elicitMock.mockResolvedValue({
+        action: "accept",
+        content: { project: "proj-1" },
+      });
+
+      (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
+
+      const params = { project: undefined, mine: undefined, top: undefined, skip: undefined };
+      const result = await handler(params);
+
+      const schema = elicitMock.mock.calls[0][0].requestedSchema;
+      const oneOf = schema.properties.project.oneOf;
+
+      // Project with no name falls back to id
+      expect(oneOf[0]).toEqual({ const: "proj-1", title: "proj-1" });
+      // Project with neither name nor id falls back to "" and "Unknown project"
+      expect(oneOf[1]).toEqual({ const: "", title: "Unknown project" });
+
+      expect(mockCoreApi.getTeams).toHaveBeenCalledWith("proj-1", undefined, undefined, undefined, false);
+      expect(result.content[0].text).toContain("Team One");
+    });
+
+    it("should return error when no projects are available for elicitation", async () => {
+      configureCoreTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "core_list_project_teams");
+      if (!call) throw new Error("core_list_project_teams tool not registered");
+      const [, , , handler] = call;
+
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([]);
+
+      const params = { project: undefined, mine: undefined, top: undefined, skip: undefined };
+      const result = await handler(params);
+
+      expect((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput).not.toHaveBeenCalled();
+      expect(mockCoreApi.getTeams).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("No projects found to select from.");
     });
   });
 


### PR DESCRIPTION
This pull request enhances the usability of the `core_list_project_teams` tool in the Azure DevOps integration by allowing users to select a project interactively when one is not specified. It also adds comprehensive tests to verify the new user interaction flow and edge cases. The most important changes are grouped below by theme.

## GitHub issue number
N/A

## **Associated Risks**

Should be low risk

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested manually and updated manual tests
