### PR TITLE
chore: switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,7 @@
-import pluginHeader from "eslint-plugin-header";
+import pluginHeader from "@tony.ganchev/eslint-plugin-header";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 import validateToolNamesRule from "./eslint-rules/tool-name-lint-rule.js";
-
-pluginHeader.rules.header.meta.schema = false; // workaround for https://github.com/Stuk/eslint-plugin-header/issues/57
 
 export default tseslint.config(
   // Global ignores

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,10 @@
         "mcp-server-azuredevops": "dist/index.js"
       },
       "devDependencies": {
+        "@tony.ganchev/eslint-plugin-header": "^3.3.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.1",
         "eslint-config-prettier": "10.1.8",
-        "eslint-plugin-header": "^3.1.1",
         "glob": "^13.0.0",
         "husky": "^9.1.7",
         "jest": "^30.0.2",
@@ -1779,6 +1779,16 @@
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.3.1.tgz",
+      "integrity": "sha512-/Fj0+DaXbBfrlXmd3wBZkB8TIwGT3N++y/oTYxRABK/gzNxjgcBjt63xBpuHCYIXmH1EwuALd6XS1fzNG4S0zg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3788,16 +3798,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
+    "@tony.ganchev/eslint-plugin-header": "^3.3.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.1",
     "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-header": "^3.1.1",
     "glob": "^13.0.0",
     "husky": "^9.1.7",
     "jest": "^30.0.2",


### PR DESCRIPTION
Hi, team,

I noticed you are using _eslint-plugin-header_ with the schema-turn-off
workaround to support ESLint 9.

I forked _@tony.ganchev/eslint-plugin-header_ mid-2024 to address this
issue and hoped it would be a temporary measure but since the original
has not been updated for five years I decided to continue improving the
new plugin and have been doing so for the last two years.

Specific improvements include:
- full JSON schema for validating the configuration.
- fixed multiple bugs with the behavior of the plugin on Windows.
- many other bug-fixes.
- improved autofixing and error-reporting behavior.
- added support for leading pragma comments before the header such as
  `@jest-environment`.

This fork is already widely used by other Microsoft projects especially
in the VSCode plugin ecosystem (and I have sent a similar PR proposal
to the core VSCode maintainers).

Looking forward to your feedback.

## GitHub issue number

## **Associated Risks**

_Replace_ by possible risks this pull request can bring you might have thought of

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

```
npm run eslint
```
