### PR TITLE
Support outcome filtering option in test results

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -452,10 +452,10 @@ Update an existing test case work item.
 
 ### mcp_ado_testplan_show_test_results_from_build_id
 
-Gets a list of test results for a given project and build ID.
+Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes.
 
 - **Required**: `project`, `buildid`
-- **Optional**: None
+- **Optional**: `outcomes`
 
 ## Wiki
 

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -4,7 +4,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { SuiteExpand, TestPlanCreateParams } from "azure-devops-node-api/interfaces/TestPlanInterfaces.js";
-import { TestOutcome } from "azure-devops-node-api/interfaces/TestInterfaces.js";
 import { z } from "zod";
 
 const Test_Plan_Tools = {
@@ -354,7 +353,7 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
 
   server.tool(
     Test_Plan_Tools.test_results_from_build_id,
-    "Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes.",
+    "Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes. Efficiently handles builds with large numbers of test runs.",
     {
       project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
       buildid: z.number().describe("The ID of the build."),
@@ -363,34 +362,35 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
     async ({ project, buildid, outcomes }) => {
       try {
         const connection = await connectionProvider();
-        const coreApi = await connection.getTestResultsApi();
+        const testResultsApi = await connection.getTestResultsApi();
 
-        // Step 1: Get test runs for this build
-        const buildUri = `vstfs:///Build/Build/${buildid}`;
-        const testRuns = await coreApi.getTestRuns(project, buildUri);
+        // Build filter expression for outcomes if specified
+        const outcomeFilter = outcomes?.map((o) => `Outcome eq '${o}'`).join(" or ");
 
-        // Map outcome strings to TestOutcome enum values for server-side filtering
-        const outcomeEnums = outcomes?.map((o) => TestOutcome[o as keyof typeof TestOutcome]);
+        // Fetch test result details for the build in a single API call
+        // This is more efficient than getTestRuns + getTestResults per run,
+        // especially for builds with many test runs (e.g., cloud testing with one run per test case)
+        const testResultDetails = await testResultsApi.getTestResultDetailsForBuild(
+          project,
+          buildid,
+          undefined, // publishContext
+          undefined, // groupBy
+          outcomeFilter, // filter by outcome
+          undefined, // orderby
+          true // shouldIncludeResults - get individual test results, not just aggregates
+        );
 
-        // Step 2: Fetch detailed results per run with server-side outcome filtering
-        const allResults = (
-          await Promise.all(
-            testRuns
-              .filter((run) => run.id !== undefined)
-              .map((run) =>
-                coreApi.getTestResults(
-                  project,
-                  run.id as number,
-                  undefined, // detailsToInclude
-                  undefined, // skip
-                  undefined, // top
-                  outcomeEnums
-                )
-              )
-          )
-        ).flat();
+        // Extract individual test results from the grouped response
+        const allResults: any[] = [];
+        if (testResultDetails.resultsForGroup) {
+          for (const group of testResultDetails.resultsForGroup) {
+            if (group.results) {
+              allResults.push(...group.results);
+            }
+          }
+        }
 
-        // Extract useful fields from the results
+        // Format results to extract useful fields
         const formattedResults = allResults.map((r) => ({
           id: r.id,
           testCaseTitle: r.testCaseTitle,

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -4,6 +4,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { SuiteExpand, TestPlanCreateParams } from "azure-devops-node-api/interfaces/TestPlanInterfaces.js";
+import { TestOutcome } from "azure-devops-node-api/interfaces/TestInterfaces.js";
 import { z } from "zod";
 
 const Test_Plan_Tools = {
@@ -353,19 +354,57 @@ function configureTestPlanTools(server: McpServer, _: () => Promise<string>, con
 
   server.tool(
     Test_Plan_Tools.test_results_from_build_id,
-    "Gets a list of test results for a given project and build ID.",
+    "Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes.",
     {
       project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
       buildid: z.number().describe("The ID of the build."),
+      outcomes: z.array(z.string()).optional().describe("Filter results by test outcome, e.g. ['Failed', 'Passed', 'Aborted']."),
     },
-    async ({ project, buildid }) => {
+    async ({ project, buildid, outcomes }) => {
       try {
         const connection = await connectionProvider();
         const coreApi = await connection.getTestResultsApi();
-        const testResults = await coreApi.getTestResultDetailsForBuild(project, buildid);
+
+        // Step 1: Get test runs for this build
+        const buildUri = `vstfs:///Build/Build/${buildid}`;
+        const testRuns = await coreApi.getTestRuns(project, buildUri);
+
+        // Map outcome strings to TestOutcome enum values for server-side filtering
+        const outcomeEnums = outcomes?.map((o) => TestOutcome[o as keyof typeof TestOutcome]);
+
+        // Step 2: Fetch detailed results per run with server-side outcome filtering
+        const allResults = (
+          await Promise.all(
+            testRuns
+              .filter((run) => run.id !== undefined)
+              .map((run) =>
+                coreApi.getTestResults(
+                  project,
+                  run.id as number,
+                  undefined, // detailsToInclude
+                  undefined, // skip
+                  undefined, // top
+                  outcomeEnums
+                )
+              )
+          )
+        ).flat();
+
+        // Extract useful fields from the results
+        const formattedResults = allResults.map((r) => ({
+          id: r.id,
+          testCaseTitle: r.testCaseTitle,
+          outcome: r.outcome,
+          errorMessage: r.errorMessage,
+          stackTrace: r.stackTrace,
+          automatedTestName: r.automatedTestName,
+          automatedTestStorage: r.automatedTestStorage,
+          durationInMs: r.durationInMs,
+          runId: r.testRun?.id,
+        }));
 
         return {
-          content: [{ type: "text", text: JSON.stringify(testResults, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(formattedResults, null, 2) }],
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -594,43 +594,44 @@ describe("configureTestPlanTools", () => {
   });
 
   describe("test_results_from_build_id tool", () => {
-    it("should fetch test runs then get detailed results and return formatted output", async () => {
+    it("should fetch test result details for build and return formatted output", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
-      (mockTestResultsApi.getTestRuns as jest.Mock).mockResolvedValue([{ id: 100 }, { id: 200 }]);
-      (mockTestResultsApi.getTestResults as jest.Mock)
-        .mockResolvedValueOnce([
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [
           {
-            id: 1,
-            testCaseTitle: "TestHello",
-            outcome: "Failed",
-            errorMessage: "Assert.Equal() failed",
-            stackTrace: "at TestClass.TestHello() line 42",
-            automatedTestName: "Namespace.TestClass.TestHello",
-            automatedTestStorage: "test.dll",
-            durationInMs: 1500,
-            testRun: { id: "100" },
+            results: [
+              {
+                id: 1,
+                testCaseTitle: "TestHello",
+                outcome: "Failed",
+                errorMessage: "Assert.Equal() failed",
+                stackTrace: "at TestClass.TestHello() line 42",
+                automatedTestName: "Namespace.TestClass.TestHello",
+                automatedTestStorage: "test.dll",
+                durationInMs: 1500,
+                testRun: { id: "100" },
+              },
+              {
+                id: 2,
+                testCaseTitle: "TestWorld",
+                outcome: "Passed",
+                automatedTestName: "Namespace.TestClass.TestWorld",
+                automatedTestStorage: "test.dll",
+                durationInMs: 200,
+                testRun: { id: "200" },
+              },
+            ],
           },
-        ])
-        .mockResolvedValueOnce([
-          {
-            id: 2,
-            testCaseTitle: "TestWorld",
-            outcome: "Passed",
-            automatedTestName: "Namespace.TestClass.TestWorld",
-            automatedTestStorage: "test.dll",
-            durationInMs: 200,
-            testRun: { id: "200" },
-          },
-        ]);
+        ],
+      });
 
       const result = await handler({ project: "proj1", buildid: 123 });
 
-      expect(mockTestResultsApi.getTestRuns).toHaveBeenCalledWith("proj1", "vstfs:///Build/Build/123");
-      expect(mockTestResultsApi.getTestResults).toHaveBeenCalledTimes(2);
+      expect(mockTestResultsApi.getTestResultDetailsForBuild).toHaveBeenCalledWith("proj1", 123, undefined, undefined, undefined, undefined, true);
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toHaveLength(2);
       expect(parsed[0].testCaseTitle).toBe("TestHello");
@@ -641,19 +642,31 @@ describe("configureTestPlanTools", () => {
       expect(parsed[1].outcome).toBe("Passed");
     });
 
-    it("should pass outcome enum values for server-side filtering", async () => {
+    it("should pass outcome filter expression for server-side filtering", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
-      (mockTestResultsApi.getTestRuns as jest.Mock).mockResolvedValue([{ id: 100 }]);
-      (mockTestResultsApi.getTestResults as jest.Mock).mockResolvedValue([{ id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" }]);
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [
+          {
+            results: [{ id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" }],
+          },
+        ],
+      });
 
       await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
 
-      // TestOutcome.Failed = 3, TestOutcome.Aborted = 6
-      expect(mockTestResultsApi.getTestResults).toHaveBeenCalledWith("proj1", 100, undefined, undefined, undefined, [3, 6]);
+      expect(mockTestResultsApi.getTestResultDetailsForBuild).toHaveBeenCalledWith(
+        "proj1",
+        123,
+        undefined, // publishContext
+        undefined, // groupBy
+        "Outcome eq 'Failed' or Outcome eq 'Aborted'", // filter expression
+        undefined, // orderby
+        true // shouldIncludeResults
+      );
     });
 
     it("should handle API errors when fetching test results", async () => {
@@ -662,12 +675,158 @@ describe("configureTestPlanTools", () => {
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
-      (mockTestResultsApi.getTestRuns as jest.Mock).mockRejectedValue(new Error("API Error"));
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const result = await handler({ project: "proj1", buildid: 123 });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error fetching test results");
       expect(result.content[0].text).toContain("API Error");
+    });
+
+    it("should return test case titles for all results across multiple groups", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      // Simulate multiple groups (e.g., grouped by configuration or test suite)
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [
+          {
+            groupByValue: "Configuration1",
+            results: [
+              {
+                id: 1,
+                testCaseTitle: "Test Case Alpha",
+                outcome: "Passed",
+                durationInMs: 100,
+              },
+              {
+                id: 2,
+                testCaseTitle: "Test Case Beta",
+                outcome: "Failed",
+                errorMessage: "Assertion failed",
+              },
+            ],
+          },
+          {
+            groupByValue: "Configuration2",
+            results: [
+              {
+                id: 3,
+                testCaseTitle: "Test Case Gamma",
+                outcome: "Passed",
+                durationInMs: 150,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await handler({ project: "proj1", buildid: 456 });
+
+      const parsed = JSON.parse(result.content[0].text);
+
+      // Verify all 3 results are present
+      expect(parsed).toHaveLength(3);
+
+      // Explicitly verify each test case title is present and correct
+      expect(parsed[0].testCaseTitle).toBe("Test Case Alpha");
+      expect(parsed[0].id).toBe(1);
+      expect(parsed[1].testCaseTitle).toBe("Test Case Beta");
+      expect(parsed[1].id).toBe(2);
+      expect(parsed[2].testCaseTitle).toBe("Test Case Gamma");
+      expect(parsed[2].id).toBe(3);
+
+      // Verify testCaseTitle field exists in all results
+      parsed.forEach((result: any, index: number) => {
+        expect(result).toHaveProperty("testCaseTitle");
+        expect(result.testCaseTitle).toBeTruthy();
+      });
+    });
+
+    it("should handle empty results groups without errors", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [
+          {
+            groupByValue: "EmptyGroup",
+            results: [],
+          },
+          {
+            groupByValue: "GroupWithResults",
+            results: [
+              {
+                id: 1,
+                testCaseTitle: "Only Test",
+                outcome: "Passed",
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await handler({ project: "proj1", buildid: 789 });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].testCaseTitle).toBe("Only Test");
+    });
+
+    it("should return test case titles when present and handle missing titles gracefully", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [
+          {
+            results: [
+              {
+                id: 1,
+                testCaseTitle: "Manual Test Case Title",
+                automatedTestName: "Namespace.TestClass.TestMethod",
+                outcome: "Passed",
+              },
+              {
+                id: 2,
+                testCaseTitle: undefined, // Missing testCaseTitle
+                automatedTestName: "Namespace.TestClass.AnotherTest",
+                outcome: "Failed",
+              },
+              {
+                id: 3,
+                testCaseTitle: "Another Manual Test Case",
+                automatedTestName: "Namespace.TestClass.ThirdTest",
+                outcome: "Passed",
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await handler({ project: "proj1", buildid: 999 });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(3);
+
+      // Verify testCaseTitle is present when provided by the API
+      expect(parsed[0]).toHaveProperty("testCaseTitle");
+      expect(parsed[0].testCaseTitle).toBe("Manual Test Case Title");
+
+      // When testCaseTitle is undefined, JSON.stringify omits it (expected behavior)
+      // but automatedTestName should still be available
+      expect(parsed[1].id).toBe(2);
+      expect(parsed[1].automatedTestName).toBe("Namespace.TestClass.AnotherTest");
+
+      // Third result also has testCaseTitle
+      expect(parsed[2]).toHaveProperty("testCaseTitle");
+      expect(parsed[2].testCaseTitle).toBe("Another Manual Test Case");
     });
   });
 

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -41,6 +41,8 @@ describe("configureTestPlanTools", () => {
     } as unknown as ITestPlanApi;
     mockTestResultsApi = {
       getTestResultDetailsForBuild: jest.fn(),
+      getTestRuns: jest.fn(),
+      getTestResults: jest.fn(),
     } as unknown as ITestResultsApi;
     mockWitApi = {
       createWorkItem: jest.fn(),
@@ -592,21 +594,66 @@ describe("configureTestPlanTools", () => {
   });
 
   describe("test_results_from_build_id tool", () => {
-    it("should call getTestResultDetailsForBuild with the correct parameters and return the expected result", async () => {
+    it("should fetch test runs then get detailed results and return formatted output", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
-      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({ results: ["Result 1"] });
-      const params = {
-        project: "proj1",
-        buildid: 123,
-      };
-      const result = await handler(params);
+      (mockTestResultsApi.getTestRuns as jest.Mock).mockResolvedValue([{ id: 100 }, { id: 200 }]);
+      (mockTestResultsApi.getTestResults as jest.Mock)
+        .mockResolvedValueOnce([
+          {
+            id: 1,
+            testCaseTitle: "TestHello",
+            outcome: "Failed",
+            errorMessage: "Assert.Equal() failed",
+            stackTrace: "at TestClass.TestHello() line 42",
+            automatedTestName: "Namespace.TestClass.TestHello",
+            automatedTestStorage: "test.dll",
+            durationInMs: 1500,
+            testRun: { id: "100" },
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 2,
+            testCaseTitle: "TestWorld",
+            outcome: "Passed",
+            automatedTestName: "Namespace.TestClass.TestWorld",
+            automatedTestStorage: "test.dll",
+            durationInMs: 200,
+            testRun: { id: "200" },
+          },
+        ]);
 
-      expect(mockTestResultsApi.getTestResultDetailsForBuild).toHaveBeenCalledWith("proj1", 123);
-      expect(result.content[0].text).toBe(JSON.stringify({ results: ["Result 1"] }, null, 2));
+      const result = await handler({ project: "proj1", buildid: 123 });
+
+      expect(mockTestResultsApi.getTestRuns).toHaveBeenCalledWith("proj1", "vstfs:///Build/Build/123");
+      expect(mockTestResultsApi.getTestResults).toHaveBeenCalledTimes(2);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].testCaseTitle).toBe("TestHello");
+      expect(parsed[0].errorMessage).toBe("Assert.Equal() failed");
+      expect(parsed[0].stackTrace).toBe("at TestClass.TestHello() line 42");
+      expect(parsed[0].outcome).toBe("Failed");
+      expect(parsed[1].testCaseTitle).toBe("TestWorld");
+      expect(parsed[1].outcome).toBe("Passed");
+    });
+
+    it("should pass outcome enum values for server-side filtering", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestRuns as jest.Mock).mockResolvedValue([{ id: 100 }]);
+      (mockTestResultsApi.getTestResults as jest.Mock).mockResolvedValue([{ id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" }]);
+
+      await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
+
+      // TestOutcome.Failed = 3, TestOutcome.Aborted = 6
+      expect(mockTestResultsApi.getTestResults).toHaveBeenCalledWith("proj1", 100, undefined, undefined, undefined, [3, 6]);
     });
 
     it("should handle API errors when fetching test results", async () => {
@@ -615,14 +662,9 @@ describe("configureTestPlanTools", () => {
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
-      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockRejectedValue(new Error("API Error"));
+      (mockTestResultsApi.getTestRuns as jest.Mock).mockRejectedValue(new Error("API Error"));
 
-      const params = {
-        project: "proj1",
-        buildid: 123,
-      };
-
-      const result = await handler(params);
+      const result = await handler({ project: "proj1", buildid: 123 });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error fetching test results");
       expect(result.content[0].text).toContain("API Error");

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -739,7 +739,7 @@ describe("configureTestPlanTools", () => {
       expect(parsed[2].id).toBe(3);
 
       // Verify testCaseTitle field exists in all results
-      parsed.forEach((result: any, index: number) => {
+      parsed.forEach((result: any) => {
         expect(result).toHaveProperty("testCaseTitle");
         expect(result.testCaseTitle).toBeTruthy();
       });


### PR DESCRIPTION
**Summary**
Returns useful fields from test results, including testCaseTitle, errorMessage, stackTrace.
Adds optional outcomes parameter for server-side filtering (e.g. ["Failed", "Aborted"])
Why switch from getTestResultDetailsForBuild to getTestRuns + getTestResults
The previous API (getTestResultDetailsForBuild) returns lightweight result entries even with shouldIncludeResults=true — they contain only id, outcome, durationInMs, and testCaseReferenceId, but not testCaseTitle, errorMessage, or stackTrace. Its $filter parameter supports OData-style outcome filtering, but the results lack the detail fields that make them actionable.

getTestResults (per run) returns full TestCaseResult objects with all fields populated, and natively supports an outcomes parameter for server-side filtering. This avoids fetching all results when only failed test cases are needed.

## GitHub issue number  887 and 985

Before the changes 

<img width="1355" height="1287" alt="image" src="https://github.com/user-attachments/assets/30b92a5a-219c-4879-b35c-1536b9d98e30" />


After the changes - focused only on the failed test by using the filter logic 

<img width="1435" height="1117" alt="image" src="https://github.com/user-attachments/assets/4b56890e-9500-4bfe-a69d-a4e988010b56" />


## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Local mcp testing

_Replace_ with use cases tested and models used
