### PR TITLE
Harden pipelines_download_artifact file path handling

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -42,19 +42,8 @@ function sanitizeFileName(fileName: string): string {
 
 function resolveAndValidateDestinationPath(destinationPath: string): string {
   const configuredBaseDir = process.env.ADO_MCP_ARTIFACTS_DIR;
-
-  const cwd = resolve(process.cwd());
   const baseDirName = configuredBaseDir && configuredBaseDir.trim().length > 0 ? configuredBaseDir.trim() : DEFAULT_ARTIFACTS_BASE_DIR;
-
-  if (isAbsolute(baseDirName)) {
-    throw new Error("Invalid ADO_MCP_ARTIFACTS_DIR: must be a relative directory within the server working directory.");
-  }
-
-  const baseDirAbs = resolve(cwd, baseDirName);
-  const relBaseToCwd = relative(cwd, baseDirAbs);
-  if (relBaseToCwd === ".." || relBaseToCwd.startsWith(`..${sep}`) || isAbsolute(relBaseToCwd)) {
-    throw new Error("Invalid ADO_MCP_ARTIFACTS_DIR: must not escape the server working directory.");
-  }
+  const baseDirAbs = resolve(baseDirName);
 
   if (isAbsolute(destinationPath)) {
     throw new Error("Absolute 'destinationPath' is not allowed.");
@@ -63,7 +52,7 @@ function resolveAndValidateDestinationPath(destinationPath: string): string {
   const destinationAbs = resolve(baseDirAbs, destinationPath);
   const relToBase = relative(baseDirAbs, destinationAbs);
   if (relToBase === ".." || relToBase.startsWith(`..${sep}`) || isAbsolute(relToBase)) {
-    throw new Error(`Invalid 'destinationPath': must be within ./${baseDirName.replace(/\\/g, "/")}.`);
+    throw new Error(`Invalid 'destinationPath': must be within the base directory.`);
   }
 
   return destinationAbs;
@@ -592,7 +581,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
         .string()
         .optional()
         .describe(
-          `Local directory to download the artifact into. For security, downloads are restricted to a base directory under the server working directory (ADO_MCP_ARTIFACTS_DIR if set, otherwise ./${DEFAULT_ARTIFACTS_BASE_DIR}). If not provided, returns binary content as base64.`
+          `Relative directory path to download the artifact into. Must be a relative path within the base directory (ADO_MCP_ARTIFACTS_DIR env var if set, otherwise ./${DEFAULT_ARTIFACTS_BASE_DIR}). Absolute paths and path traversal (e.g. '../') are not allowed. If not provided, returns binary content as base64.`
         ),
     },
     async ({ project, buildId, artifactName, destinationPath }) => {

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { StageUpdateType } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
 import { ConfigurationType, RepositoryType } from "azure-devops-node-api/interfaces/PipelinesInterfaces.js";
 import { mkdirSync, createWriteStream } from "fs";
-import { join, resolve } from "path";
+import { isAbsolute, join, relative, resolve, sep } from "path";
 
 const PIPELINE_TOOLS = {
   pipelines_get_builds: "pipelines_get_builds",
@@ -27,6 +27,57 @@ const PIPELINE_TOOLS = {
   pipelines_list_artifacts: "pipelines_list_artifacts",
   pipelines_download_artifact: "pipelines_download_artifact",
 };
+
+const DEFAULT_ARTIFACTS_BASE_DIR = ".ado-mcp-artifacts";
+
+function sanitizeFileName(fileName: string): string {
+  const trimmed = fileName.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Invalid 'artifactName': must not be empty or whitespace-only.");
+  }
+
+  const sanitized = trimmed.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/_+/g, "_");
+  return sanitized.slice(0, 128);
+}
+
+function resolveAndValidateDestinationPath(destinationPath: string): string {
+  const configuredBaseDir = process.env.ADO_MCP_ARTIFACTS_DIR;
+
+  const cwd = resolve(process.cwd());
+  const baseDirName = configuredBaseDir && configuredBaseDir.trim().length > 0 ? configuredBaseDir.trim() : DEFAULT_ARTIFACTS_BASE_DIR;
+
+  if (isAbsolute(baseDirName)) {
+    throw new Error("Invalid ADO_MCP_ARTIFACTS_DIR: must be a relative directory within the server working directory.");
+  }
+
+  const baseDirAbs = resolve(cwd, baseDirName);
+  const relBaseToCwd = relative(cwd, baseDirAbs);
+  if (relBaseToCwd === ".." || relBaseToCwd.startsWith(`..${sep}`) || isAbsolute(relBaseToCwd)) {
+    throw new Error("Invalid ADO_MCP_ARTIFACTS_DIR: must not escape the server working directory.");
+  }
+
+  if (isAbsolute(destinationPath)) {
+    throw new Error("Absolute 'destinationPath' is not allowed.");
+  }
+
+  const destinationAbs = resolve(baseDirAbs, destinationPath);
+  const relToBase = relative(baseDirAbs, destinationAbs);
+  if (relToBase === ".." || relToBase.startsWith(`..${sep}`) || isAbsolute(relToBase)) {
+    throw new Error(`Invalid 'destinationPath': must be within ./${baseDirName.replace(/\\/g, "/")}.`);
+  }
+
+  return destinationAbs;
+}
+
+function ensurePathWithinDirectory(directoryPath: string, candidatePath: string): void {
+  const resolvedDirectory = resolve(directoryPath);
+  const resolvedCandidate = resolve(candidatePath);
+  const rel = relative(resolvedDirectory, resolvedCandidate);
+
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    throw new Error("Invalid download path: resolved file path must be within the destination directory.");
+  }
+}
 
 function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
@@ -537,9 +588,22 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("The name or ID of the project."),
       buildId: z.number().describe("The ID of the build."),
       artifactName: z.string().describe("The name of the artifact to download."),
-      destinationPath: z.string().optional().describe("The local path to download the artifact to. If not provided, returns binary content as base64."),
+      destinationPath: z
+        .string()
+        .optional()
+        .describe(
+          `Local directory to download the artifact into. For security, downloads are restricted to a base directory under the server working directory (ADO_MCP_ARTIFACTS_DIR if set, otherwise ./${DEFAULT_ARTIFACTS_BASE_DIR}). If not provided, returns binary content as base64.`
+        ),
     },
     async ({ project, buildId, artifactName, destinationPath }) => {
+      if (artifactName.length === 0) {
+        throw new Error("Invalid 'artifactName': must not be empty.");
+      }
+
+      if (/[\\/\0]/.test(artifactName)) {
+        throw new Error("Invalid 'artifactName': must not contain path separators or null bytes.");
+      }
+
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
       const artifact = await buildApi.getArtifact(project, buildId, artifactName);
@@ -550,24 +614,32 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
         };
       }
 
+      if (artifact.id === undefined || artifact.id === null) {
+        throw new Error("Failed to determine artifact id for downloaded file name.");
+      }
+
       const fileStream = await buildApi.getArtifactContentZip(project, buildId, artifactName);
 
       // If destinationPath is provided, save to disk
       if (destinationPath) {
-        const fullDestinationPath = resolve(destinationPath);
+        const safeArtifactFileName = sanitizeFileName(artifactName);
+        const fullDestinationPath = resolveAndValidateDestinationPath(destinationPath);
 
         mkdirSync(fullDestinationPath, { recursive: true });
-        const fileDestinationPath = join(fullDestinationPath, `${artifactName}.zip`);
+        const fileDestinationPath = join(fullDestinationPath, `${safeArtifactFileName}.zip`);
 
-        const writeStream = createWriteStream(fileDestinationPath);
+        ensurePathWithinDirectory(fullDestinationPath, fileDestinationPath);
+
+        const writeStream = createWriteStream(fileDestinationPath, { flags: "wx" });
         await new Promise<void>((resolve, reject) => {
           fileStream.pipe(writeStream);
           fileStream.on("end", () => resolve());
           fileStream.on("error", (err) => reject(err));
+          writeStream.on("error", (err) => reject(err));
         });
 
         return {
-          content: [{ type: "text", text: `Artifact ${artifactName} downloaded to ${destinationPath}.` }],
+          content: [{ type: "text", text: `Artifact ${artifactName} downloaded to ${fullDestinationPath}.` }],
         };
       }
 

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -9,7 +9,7 @@ import { configurePipelineTools } from "../../../src/tools/pipelines";
 import { apiVersion } from "../../../src/utils.js";
 import { mockUpdateBuildStageResponse, mockMultipleArtifacts, mockArtifact } from "../../mocks/pipelines";
 import { Readable } from "stream";
-import { resolve } from "path";
+import { resolve, join } from "path";
 import { mkdirSync, createWriteStream } from "fs";
 
 // Mock fetch globally
@@ -1017,8 +1017,10 @@ describe("configurePipelineTools", () => {
   describe("pipelines_download_artifact", () => {
     let mockWriteStream: any;
     let mockFileStream: Readable;
+    const originalEnv = process.env;
 
     beforeEach(() => {
+      process.env = { ...originalEnv };
       mockWriteStream = {
         write: jest.fn(),
         end: jest.fn(),
@@ -1036,6 +1038,10 @@ describe("configurePipelineTools", () => {
           this.push(null);
         },
       });
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
     });
 
     it("should download and save an artifact", async () => {
@@ -1056,16 +1062,114 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:\\temp\\artifacts",
+        destinationPath: "artifacts",
       };
+
+      // Configure a base directory within process.cwd().
+      process.env.ADO_MCP_ARTIFACTS_DIR = "temp";
 
       const result = await handler(params);
 
       expect(mockGetArtifact).toHaveBeenCalledWith("test-project", 12345, "drop");
       expect(mockGetArtifactContentZip).toHaveBeenCalledWith("test-project", 12345, "drop");
-      expect(mkdirSync).toHaveBeenCalledWith(resolve("D:\\temp\\artifacts"), { recursive: true });
-      expect(createWriteStream).toHaveBeenCalledWith(expect.stringContaining("drop.zip"));
+      expect(mkdirSync).toHaveBeenCalledWith(resolve(process.cwd(), "temp", "artifacts"), { recursive: true });
+      expect(createWriteStream).toHaveBeenCalledWith(expect.stringContaining("drop.zip"), { flags: "wx" });
       expect(result.content[0].text).toContain("Artifact drop downloaded");
+    });
+
+    it("should reject destinationPath traversal outside base dir", async () => {
+      const mockGetArtifact = jest.fn().mockResolvedValue(mockArtifact);
+      const mockGetArtifactContentZip = jest.fn().mockResolvedValue(mockFileStream);
+
+      mockConnection.getBuildApi.mockResolvedValue({
+        getArtifact: mockGetArtifact,
+        getArtifactContentZip: mockGetArtifactContentZip,
+      } as any);
+
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      process.env.ADO_MCP_ARTIFACTS_DIR = "base";
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "..\\..\\artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("destinationPath");
+    });
+
+    it("should reject absolute destinationPath when base dir is not configured", async () => {
+      const mockGetArtifact = jest.fn().mockResolvedValue(mockArtifact);
+      const mockGetArtifactContentZip = jest.fn().mockResolvedValue(mockFileStream);
+
+      mockConnection.getBuildApi.mockResolvedValue({
+        getArtifact: mockGetArtifact,
+        getArtifactContentZip: mockGetArtifactContentZip,
+      } as any);
+
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      delete process.env.ADO_MCP_ARTIFACTS_DIR;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "D:\\temp\\artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Absolute 'destinationPath' is not allowed");
+    });
+
+    it("should reject artifactName containing path separators or null bytes", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      await expect(handler({ project: "test-project", buildId: 12345, artifactName: "..\\temp", destinationPath: "artifacts" })).rejects.toThrow("must not contain path separators or null bytes");
+
+      await expect(handler({ project: "test-project", buildId: 12345, artifactName: "../temp", destinationPath: "artifacts" })).rejects.toThrow("must not contain path separators or null bytes");
+
+      await expect(handler({ project: "test-project", buildId: 12345, artifactName: "temp\0name", destinationPath: "artifacts" })).rejects.toThrow("must not contain path separators or null bytes");
+    });
+
+    it("should default downloads under ./.ado-mcp-artifacts when base dir is not configured", async () => {
+      const mockGetArtifact = jest.fn().mockResolvedValue(mockArtifact);
+      const mockGetArtifactContentZip = jest.fn().mockResolvedValue(mockFileStream);
+
+      mockConnection.getBuildApi.mockResolvedValue({
+        getArtifact: mockGetArtifact,
+        getArtifactContentZip: mockGetArtifactContentZip,
+      } as any);
+
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      delete process.env.ADO_MCP_ARTIFACTS_DIR;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "artifacts",
+      };
+
+      const result = await handler(params);
+
+      const expectedDir = resolve(process.cwd(), ".ado-mcp-artifacts", "artifacts");
+      expect(mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
+      expect(result.content[0].text).toContain(expectedDir);
     });
 
     it("should handle artifact not found", async () => {
@@ -1084,7 +1188,7 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:\\temp\\artifacts",
+        destinationPath: "artifacts",
       };
 
       const result = await handler(params);


### PR DESCRIPTION
Adds strict path validation and input sanitization to [pipelines_download_artifact](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure artifact downloads are always written within a working directory.

Changes:
- Restrict all artifact downloads to a base directory under the server working directory (defaults to [.ado-mcp-artifacts](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html); configurable via [ADO_MCP_ARTIFACTS_DIR](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which must be a relative path within [process.cwd()](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
- Reject absolute [destinationPath](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values
- Reject [destinationPath](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) values that traverse outside the base directory (e.g. ../../etc)
- Reject [artifactName](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) containing path separators (/, \) or null bytes at the input boundary
- Sanitize artifact filenames via allowlist ([a-zA-Z0-9._-]) with length cap (128 chars)
- Validate the final resolved file path stays within the destination directory after [join()](vscode-file://vscode-app/c:/Users/ykholodkov/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 
- Prevent overwriting existing files using exclusive write flag (wx)

## **Associated Risks**
None

## ✅ **PR Checklist**

- [✅] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [✅] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [✅] Title of the pull request is clear and informative.
- [✅] 👌 Code hygiene
- [N/A] 🔭 Telemetry added, updated, or N/A
- [N/A] 📄 Documentation added, updated, or N/A
- [✅] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
- unit test
- manually test via promts
