### PR TITLE
fix: check for unsafe path components when accessing filesystem

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { StageUpdateType } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
 import { ConfigurationType, RepositoryType } from "azure-devops-node-api/interfaces/PipelinesInterfaces.js";
 import { mkdirSync, createWriteStream } from "fs";
-import { join, resolve } from "path";
+import { join, posix, resolve, win32 } from "path";
 
 const PIPELINE_TOOLS = {
   pipelines_get_builds: "pipelines_get_builds",
@@ -540,6 +540,16 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       destinationPath: z.string().optional().describe("The local path to download the artifact to. If not provided, returns binary content as base64."),
     },
     async ({ project, buildId, artifactName, destinationPath }) => {
+      const isAbsolutePath = (value: string) => posix.isAbsolute(value) || win32.isAbsolute(value);
+
+      if (artifactName.includes("..")) {
+        throw new Error("Invalid artifactName: path traversal is not allowed.");
+      }
+
+      if (destinationPath && (destinationPath.includes("..") || isAbsolutePath(destinationPath))) {
+        throw new Error("Invalid destinationPath: absolute paths and paths traversals are not allowed.");
+      }
+
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
       const artifact = await buildApi.getArtifact(project, buildId, artifactName);

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1056,14 +1056,14 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:\\temp\\artifacts",
+        destinationPath: "temp\\artifacts",
       };
 
       const result = await handler(params);
 
       expect(mockGetArtifact).toHaveBeenCalledWith("test-project", 12345, "drop");
       expect(mockGetArtifactContentZip).toHaveBeenCalledWith("test-project", 12345, "drop");
-      expect(mkdirSync).toHaveBeenCalledWith(resolve("D:\\temp\\artifacts"), { recursive: true });
+      expect(mkdirSync).toHaveBeenCalledWith(resolve("temp\\artifacts"), { recursive: true });
       expect(createWriteStream).toHaveBeenCalledWith(expect.stringContaining("drop.zip"));
       expect(result.content[0].text).toContain("Artifact drop downloaded");
     });
@@ -1084,7 +1084,7 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:\\temp\\artifacts",
+        destinationPath: "temp\\artifacts",
       };
 
       const result = await handler(params);
@@ -1110,10 +1110,78 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:\\temp\\artifacts",
+        destinationPath: "temp\\artifacts",
       };
 
       await expect(handler(params)).rejects.toThrow("Network error");
+    });
+
+    it("should reject destinationPath with a Windows absolute path", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "C:\\temp\\artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and paths traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject destinationPath with a Unix absolute path", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "/tmp/artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and paths traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject destinationPath with path traversal segments", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "drop",
+        destinationPath: "..\\..\\temp\\artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and paths traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject artifactName with path traversal segments", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
+      if (!call) throw new Error("pipelines_download_artifact tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "test-project",
+        buildId: 12345,
+        artifactName: "..\\..\\drop",
+        destinationPath: "temp\\artifacts",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid artifactName: path traversal is not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
     });
 
     it("should return artifact as base64 binary when destinationPath is not provided", async () => {


### PR DESCRIPTION
Ensuring downloaded pipeline artifact can only be saved on the disk in current folder or its subfolders.

## GitHub issue number
N/A

## **Associated Risks**

_Replace_ by possible risks this pull request can bring you might have thought of

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

_Replace_ with use cases tested and models used
