### PR TITLE
Pipelines URL Path Traversal Fix - Add parameters encoding to the pipelines tool

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -481,7 +481,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, buildId, stageName, status, forceRetryAllJobs }) => {
       const connection = await connectionProvider();
       const orgUrl = connection.serverUrl;
-      const endpoint = `${orgUrl}/${project}/_apis/build/builds/${buildId}/stages/${stageName}?api-version=${apiVersion}`;
+      const endpoint = `${orgUrl}/${encodeURIComponent(project)}/_apis/build/builds/${buildId}/stages/${encodeURIComponent(stageName)}?api-version=${apiVersion}`;
       const token = await tokenProvider();
 
       const body = {

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -226,6 +226,141 @@ describe("configurePipelineTools", () => {
         })
       );
     });
+
+    describe("URL path injection prevention", () => {
+      it("should encode project parameter to prevent path traversal in URL", async () => {
+        configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
+        if (!call) throw new Error("pipelines_update_build_stage tool not registered");
+        const [, , , handler] = call;
+
+        (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
+
+        const mockResponse = {
+          ok: true,
+          text: jest.fn().mockResolvedValue(JSON.stringify(mockUpdateBuildStageResponse)),
+        };
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+        const maliciousProject = "../../_apis/hooks/subscriptions";
+        const params = {
+          project: maliciousProject,
+          buildId: 1,
+          stageName: "Build",
+          status: "Retry",
+          forceRetryAllJobs: false,
+        };
+
+        await handler(params);
+
+        const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+        // The URL must NOT contain the raw unencoded traversal sequence
+        expect(calledUrl).not.toContain("../../_apis/hooks/subscriptions");
+        // The URL must contain the encoded project parameter
+        expect(calledUrl).toContain(encodeURIComponent(maliciousProject));
+      });
+
+      it("should encode stageName parameter to prevent path traversal in URL", async () => {
+        configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
+        if (!call) throw new Error("pipelines_update_build_stage tool not registered");
+        const [, , , handler] = call;
+
+        (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
+
+        const mockResponse = {
+          ok: true,
+          text: jest.fn().mockResolvedValue(JSON.stringify(mockUpdateBuildStageResponse)),
+        };
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+        const maliciousStageName = "../../../_apis/serviceendpoint/endpoints";
+        const params = {
+          project: "test-project",
+          buildId: 1,
+          stageName: maliciousStageName,
+          status: "Retry",
+          forceRetryAllJobs: false,
+        };
+
+        await handler(params);
+
+        const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+        // The URL must NOT contain the raw unencoded traversal sequence
+        expect(calledUrl).not.toContain("../../../_apis/serviceendpoint/endpoints");
+        // The URL must contain the encoded stageName parameter
+        expect(calledUrl).toContain(encodeURIComponent(maliciousStageName));
+      });
+
+      it("should encode both project and stageName when both contain malicious input", async () => {
+        configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
+        if (!call) throw new Error("pipelines_update_build_stage tool not registered");
+        const [, , , handler] = call;
+
+        (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
+
+        const mockResponse = {
+          ok: true,
+          text: jest.fn().mockResolvedValue(JSON.stringify(mockUpdateBuildStageResponse)),
+        };
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+        const maliciousProject = "../../_apis/hooks/subscriptions";
+        const maliciousStageName = "../../_apis/wit/workitems";
+        const params = {
+          project: maliciousProject,
+          buildId: 1,
+          stageName: maliciousStageName,
+          status: "Retry",
+          forceRetryAllJobs: false,
+        };
+
+        await handler(params);
+
+        const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+        // The URL must contain both encoded parameters
+        expect(calledUrl).toContain(encodeURIComponent(maliciousProject));
+        expect(calledUrl).toContain(encodeURIComponent(maliciousStageName));
+        // Verify the correct URL structure is maintained
+        expect(calledUrl).toMatch(
+          new RegExp(
+            `^https://dev\\.azure\\.com/test-org/${encodeURIComponent(maliciousProject).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/_apis/build/builds/1/stages/${encodeURIComponent(maliciousStageName).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\?api-version=`
+          )
+        );
+      });
+
+      it("should encode project parameter containing slash characters", async () => {
+        configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_update_build_stage");
+        if (!call) throw new Error("pipelines_update_build_stage tool not registered");
+        const [, , , handler] = call;
+
+        (tokenProvider as jest.Mock).mockResolvedValue("mock-token");
+
+        const mockResponse = {
+          ok: true,
+          text: jest.fn().mockResolvedValue(JSON.stringify(mockUpdateBuildStageResponse)),
+        };
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+        const projectWithSlashes = "my/project/name";
+        const params = {
+          project: projectWithSlashes,
+          buildId: 1,
+          stageName: "Build",
+          status: "Retry",
+          forceRetryAllJobs: false,
+        };
+
+        await handler(params);
+
+        const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+        // Slashes in project name must be encoded to prevent path manipulation
+        expect(calledUrl).toContain(encodeURIComponent(projectWithSlashes));
+        expect(calledUrl).not.toMatch(/test-org\/my\/project\/name\/_apis/);
+      });
+    });
   });
 
   describe("get_definitions tool", () => {


### PR DESCRIPTION
This change adds the parameter encoding for the pipelines tool. It protects against URL Path Traversal that was possible.

## GitHub issue number
NA

## **Associated Risks**

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

I have created automated test against the changes. Also, it was tested against live system.
