### PR TITLE
Update runId field to be optional in pipeline configuration

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -387,7 +387,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     pipelines: z.record(
       z.string().describe("Name of the pipeline resource."),
       z.object({
-        runId: z.coerce.number().min(1).describe("Id of the source pipeline run that triggered or is referenced by this pipeline run."),
+        runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run that triggered or is referenced by this pipeline run."),
         version: z.string().optional().describe("Version of the source pipeline run."),
       })
     ),
@@ -439,6 +439,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       const pipelineRun = await pipelinesApi.runPipeline(runRequest, project, pipelineId, pipelineVersion);
       const queuedBuild = { id: pipelineRun.id };
       const buildId = queuedBuild.id;
+
       if (buildId === undefined) {
         throw new Error("Failed to get build ID from pipeline run");
       }


### PR DESCRIPTION
This pull request makes a small change to the pipeline tools to improve flexibility and robustness. The main change is making the `runId` property optional in the pipeline resource schema, which allows for pipeline runs that may not have a referenced source run.

## GitHub issue number
#1101 

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Ran automated tests. Manual check
