### PR TITLE
docs: Add missing mcp_ado_repo_get_file_content tool to TOOLSET.md

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -42,6 +42,7 @@
 | Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread           |
 | Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                          |
 | Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                    |
+| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version                   |
 | Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                      |
 | Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                            |
 | Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                    |
@@ -388,6 +389,13 @@ List files and folders in a directory within a repository.
 
 - **Required**: `repositoryId`
 - **Optional**: `path`, `project`, `version`, `versionType`, `recursive`, `recursionDepth`
+
+### mcp_ado_repo_get_file_content
+
+Get the content of a file from a Git repository at a specific version (branch, tag, or commit SHA).
+
+- **Required**: `repositoryId`, `path`
+- **Optional**: `project`, `version`, `versionType`
 
 ## Search
 


### PR DESCRIPTION
Added the missing mcp_ado_repo_get_file_content tool to TOOLSET.md. 

The tool was already implemented in repositories.ts but was not documented.

## GitHub issue number

988

## **Associated Risks**

None

## ✅ **PR Checklist**

- [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [X] Title of the pull request is clear and informative.
- [X] 👌 Code hygiene
- [N/A] 🔭 Telemetry added, updated, or N/A
- [X] 📄 Documentation added, updated, or N/A
- [N/A] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

No testing is needed since it is just a documentation update