### PR TITLE
Add elicitation decline and accept paths for work item tools

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -7,7 +7,7 @@ import { WorkItemExpand, WorkItemRelation } from "azure-devops-node-api/interfac
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { z } from "zod";
 import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, safeEnumConvert, encodeFormattedValue } from "../utils.js";
-import { elicitProject } from "../shared/elicitations.js";
+import { elicitProject, elicitTeam } from "../shared/elicitations.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 
 const WORKITEM_TOOLS = {
@@ -70,16 +70,31 @@ function getLinkTypeFromName(name: string) {
 function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     WORKITEM_TOOLS.list_backlogs,
-    "Receive a list of backlogs for a given project and team.",
+    "Receive a list of backlogs for a given project and team. If a project or team is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
-      team: z.string().describe("The name or ID of the Azure DevOps team."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
+      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Reuse from prior context if already known. If not provided, a team selection prompt will be shown."),
     },
     async ({ project, team }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list backlogs for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
+        let resolvedTeam = team;
+        if (!resolvedTeam) {
+          const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to list backlogs for.");
+          if ("response" in result) return result.response;
+          resolvedTeam = result.resolved;
+        }
+
         const workApi = await connection.getWorkApi();
-        const teamContext = { project, team };
+        const teamContext = { project: resolvedProject, team: resolvedTeam };
         const backlogs = await workApi.getBacklogs(teamContext);
 
         return {
@@ -97,17 +112,32 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.list_backlog_work_items,
-    "Retrieve a list of backlogs of for a given project, team, and backlog category",
+    "Retrieve a list of backlogs of for a given project, team, and backlog category. If a project or team is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
-      team: z.string().describe("The name or ID of the Azure DevOps team."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
+      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Reuse from prior context if already known. If not provided, a team selection prompt will be shown."),
       backlogId: z.string().describe("The ID of the backlog category to retrieve work items from."),
     },
     async ({ project, team, backlogId }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list backlog work items for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
+        let resolvedTeam = team;
+        if (!resolvedTeam) {
+          const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to list backlog work items for.");
+          if ("response" in result) return result.response;
+          resolvedTeam = result.resolved;
+        }
+
         const workApi = await connection.getWorkApi();
-        const teamContext = { project, team };
+        const teamContext = { project: resolvedProject, team: resolvedTeam };
 
         const workItems = await workApi.getBacklogLevelWorkItems(teamContext, backlogId);
 
@@ -126,9 +156,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.my_work_items,
-    "Retrieve a list of work items relevent to the authenticated user.",
+    "Retrieve a list of work items relevent to the authenticated user. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       type: z.enum(["assignedtome", "myactivity"]).default("assignedtome").describe("The type of work items to retrieve. Defaults to 'assignedtome'."),
       top: z.coerce.number().default(50).describe("The maximum number of work items to return. Defaults to 50."),
       includeCompleted: z.boolean().default(false).describe("Whether to include completed work items. Defaults to false."),
@@ -136,9 +166,17 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, type, top, includeCompleted }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve work items for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workApi = await connection.getWorkApi();
 
-        const workItems = await workApi.getPredefinedQueryResults(project, type, top, includeCompleted);
+        const workItems = await workApi.getPredefinedQueryResults(resolvedProject, type, top, includeCompleted);
 
         return {
           content: [{ type: "text", text: JSON.stringify(workItems, null, 2) }],
@@ -155,22 +193,30 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_items_batch_by_ids,
-    "Retrieve list of work items by IDs in batch.",
+    "Retrieve list of work items by IDs in batch. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       ids: z.array(z.coerce.number().min(1)).describe("The IDs of the work items to retrieve."),
       fields: z.array(z.string()).optional().describe("Optional list of fields to include in the response. If not provided, a hardcoded default set of fields will be used."),
     },
     async ({ project, ids, fields }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve work items for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
         const defaultFields = ["System.Id", "System.WorkItemType", "System.Title", "System.State", "System.Parent", "System.Tags", "Microsoft.VSTS.Common.StackRank", "System.AssignedTo"];
 
         // If no fields are provided, use the default set of fields
         const fieldsToUse = !fields || fields.length === 0 ? defaultFields : fields;
 
-        const workitems = await workItemApi.getWorkItemsBatch({ ids, fields: fieldsToUse }, project);
+        const workitems = await workItemApi.getWorkItemsBatch({ ids, fields: fieldsToUse }, resolvedProject);
 
         // List of identity fields that need to be transformed from objects to formatted strings
         const identityFields = [
@@ -215,10 +261,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item,
-    "Get a single work item by ID.",
+    "Get a single work item by ID. If a project is not specified, you will be prompted to select one.",
     {
       id: z.coerce.number().min(1).describe("The ID of the work item to retrieve."),
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       fields: z.array(z.string()).optional().describe("Optional list of fields to include in the response. If not provided, all fields will be returned."),
       asOf: z.coerce.date().optional().describe("Optional date string to retrieve the work item as of a specific time. If not provided, the current state will be returned."),
       expand: z
@@ -230,8 +276,16 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ id, project, fields, asOf, expand }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the work item from.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const workItem = await workItemApi.getWorkItem(id, fields, asOf, expand as unknown as WorkItemExpand, project);
+        const workItem = await workItemApi.getWorkItem(id, fields, asOf, expand as unknown as WorkItemExpand, resolvedProject);
 
         return {
           content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
@@ -249,17 +303,25 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.list_work_item_comments,
-    "Retrieve list of comments for a work item by ID.",
+    "Retrieve list of comments for a work item by ID. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemId: z.coerce.number().min(1).describe("The ID of the work item to retrieve comments for."),
       top: z.coerce.number().default(50).describe("Optional number of comments to retrieve. Defaults to all comments."),
     },
     async ({ project, workItemId, top }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list work item comments for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const comments = await workItemApi.getComments(project, workItemId, top);
+        const comments = await workItemApi.getComments(resolvedProject, workItemId, top);
 
         return {
           content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
@@ -276,9 +338,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.add_work_item_comment,
-    "Add comment to a work item by ID.",
+    "Add comment to a work item by ID. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemId: z.coerce.number().min(1).describe("The ID of the work item to add a comment to."),
       comment: z.string().describe("The text of the comment to add to the work item."),
       format: z.enum(["markdown", "html"]).optional().default("html"),
@@ -286,6 +348,14 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, workItemId, comment, format }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to add a work item comment in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
 
@@ -294,15 +364,18 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         };
 
         const formatParameter = format === "markdown" ? 0 : 1;
-        const response = await fetch(`${orgUrl}/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments?format=${formatParameter}&api-version=${markdownCommentsApiVersion}`, {
-          method: "POST",
-          headers: {
-            "Authorization": `Bearer ${accessToken}`,
-            "Content-Type": "application/json",
-            "User-Agent": userAgentProvider(),
-          },
-          body: JSON.stringify(body),
-        });
+        const response = await fetch(
+          `${orgUrl}/${encodeURIComponent(resolvedProject)}/_apis/wit/workItems/${workItemId}/comments?format=${formatParameter}&api-version=${markdownCommentsApiVersion}`,
+          {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${accessToken}`,
+              "Content-Type": "application/json",
+              "User-Agent": userAgentProvider(),
+            },
+            body: JSON.stringify(body),
+          }
+        );
 
         if (!response.ok) {
           throw new Error(`Failed to add a work item comment: ${response.statusText}}`);
@@ -325,9 +398,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.update_work_item_comment,
-    "Update an existing comment on a work item by ID.",
+    "Update an existing comment on a work item by ID. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemId: z.coerce.number().min(1).describe("The ID of the work item."),
       commentId: z.coerce.number().min(1).describe("The ID of the comment to update."),
       text: z.string().describe("The updated comment text."),
@@ -336,13 +409,21 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, workItemId, commentId, text, format }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to update the work item comment in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
         const body: Record<string, string> = { text };
 
         const formatParameter = format === "markdown" ? 0 : 1;
         const response = await fetch(
-          `${orgUrl}/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments/${commentId}?format=${formatParameter}&api-version=${markdownCommentsApiVersion}`,
+          `${orgUrl}/${encodeURIComponent(resolvedProject)}/_apis/wit/workItems/${workItemId}/comments/${commentId}?format=${formatParameter}&api-version=${markdownCommentsApiVersion}`,
           {
             method: "PATCH",
             headers: {
@@ -375,9 +456,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.list_work_item_revisions,
-    "Retrieve list of revisions for a work item by ID.",
+    "Retrieve list of revisions for a work item by ID. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemId: z.coerce.number().min(1).describe("The ID of the work item to retrieve revisions for."),
       top: z.coerce.number().default(50).describe("Optional number of revisions to retrieve. If not provided, all revisions will be returned."),
       skip: z.coerce.number().optional().describe("Optional number of revisions to skip for pagination. Defaults to 0."),
@@ -390,8 +471,16 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, workItemId, top, skip, expand }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list work item revisions for.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const revisions = await workItemApi.getRevisions(workItemId, top, skip, safeEnumConvert(WorkItemExpand, expand), project);
+        const revisions = await workItemApi.getRevisions(workItemId, top, skip, safeEnumConvert(WorkItemExpand, expand), resolvedProject);
 
         // Dynamically clean up identity objects in revision fields
         // Identity objects typically have properties like displayName, url, _links, id, uniqueName, imageUrl, descriptor
@@ -436,10 +525,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.add_child_work_items,
-    "Create one or many child work items from a parent by work item type and parent id.",
+    "Create one or many child work items from a parent by work item type and parent id. If a project is not specified, you will be prompted to select one.",
     {
       parentId: z.coerce.number().min(1).describe("The ID of the parent work item to create a child work item under."),
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemType: z.string().describe("The type of the child work item to create."),
       items: z.array(
         z.object({
@@ -454,6 +543,14 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ parentId, project, workItemType, items }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to create child work items in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
 
@@ -493,7 +590,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               path: "/relations/-",
               value: {
                 rel: "System.LinkTypes.Hierarchy-Reverse",
-                url: `${connection.serverUrl}/${project}/_apis/wit/workItems/${parentId}`,
+                url: `${connection.serverUrl}/${resolvedProject}/_apis/wit/workItems/${parentId}`,
               },
             },
           ];
@@ -530,7 +627,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
           return {
             method: "PATCH",
-            uri: `/${encodeURIComponent(project)}/_apis/wit/workitems/$${encodeURIComponent(workItemType)}?api-version=${batchApiVersion}`,
+            uri: `/${encodeURIComponent(resolvedProject)}/_apis/wit/workitems/$${encodeURIComponent(workItemType)}?api-version=${batchApiVersion}`,
             headers: {
               "Content-Type": "application/json-patch+json",
             },
@@ -640,19 +737,27 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_items_for_iteration,
-    "Retrieve a list of work items for a specified iteration.",
+    "Retrieve a list of work items for a specified iteration. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       team: z.string().optional().describe("The name or ID of the Azure DevOps team. If not provided, the default team will be used."),
       iterationId: z.string().describe("The ID of the iteration to retrieve work items for."),
     },
     async ({ project, team, iterationId }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve work items for iteration.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workApi = await connection.getWorkApi();
 
         //get the work items for the current iteration
-        const workItems = await workApi.getIterationWorkItems({ project, team }, iterationId);
+        const workItems = await workApi.getIterationWorkItems({ project: resolvedProject, team }, iterationId);
 
         return {
           content: [{ type: "text", text: JSON.stringify(workItems, null, 2) }],
@@ -715,17 +820,25 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item_type,
-    "Get a specific work item type.",
+    "Get a specific work item type. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemType: z.string().describe("The name of the work item type to retrieve."),
     },
     async ({ project, workItemType }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the work item type from.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
 
-        const workItemTypeInfo = await workItemApi.getWorkItemType(project, workItemType);
+        const workItemTypeInfo = await workItemApi.getWorkItemType(resolvedProject, workItemType);
 
         return {
           content: [{ type: "text", text: JSON.stringify(workItemTypeInfo, null, 2) }],
@@ -742,9 +855,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.create_work_item,
-    "Create a new work item in a specified project and work item type.",
+    "Create a new work item in a specified project and work item type. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       workItemType: z.string().describe("The type of work item to create, e.g., 'Task', 'Bug', etc."),
       fields: z
         .array(
@@ -759,6 +872,14 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, workItemType, fields }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to create the work item in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
 
         const document = fields.map(({ name, value, format }) => ({
@@ -780,7 +901,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           }
         });
 
-        const newWorkItem = await workItemApi.createWorkItem(null, document, project, workItemType);
+        const newWorkItem = await workItemApi.createWorkItem(null, document, resolvedProject, workItemType);
 
         if (!newWorkItem) {
           return { content: [{ type: "text", text: "Work item was not created" }], isError: true };
@@ -802,9 +923,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_query,
-    "Get a query by its ID or path.",
+    "Get a query by its ID or path. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       query: z.string().describe("The ID or path of the query to retrieve."),
       expand: z
         .enum(getEnumKeys(QueryExpand) as [string, ...string[]])
@@ -817,9 +938,17 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, query, expand, depth, includeDeleted, useIsoDateFormat }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the query from.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
 
-        const queryDetails = await workItemApi.getQuery(project, query, safeEnumConvert(QueryExpand, expand), depth, includeDeleted, useIsoDateFormat);
+        const queryDetails = await workItemApi.getQuery(resolvedProject, query, safeEnumConvert(QueryExpand, expand), depth, includeDeleted, useIsoDateFormat);
 
         return {
           content: [{ type: "text", text: JSON.stringify(queryDetails, null, 2) }],
@@ -959,9 +1088,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.work_items_link,
-    "Link work items together in batch.",
+    "Link work items together in batch. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       updates: z
         .array(
           z.object({
@@ -981,6 +1110,14 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, updates }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to link work items in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
 
@@ -1000,7 +1137,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               path: "/relations/-",
               value: {
                 rel: `${getLinkTypeFromName(type)}`,
-                url: `${orgUrl}/${project}/_apis/wit/workItems/${linkToId}`,
+                url: `${orgUrl}/${resolvedProject}/_apis/wit/workItems/${linkToId}`,
                 attributes: {
                   comment: comment || "",
                 },
@@ -1039,9 +1176,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.work_item_unlink,
-    "Remove one or many links from a single work item",
+    "Remove one or many links from a single work item. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       id: z.coerce.number().min(1).describe("The ID of the work item to remove the links from."),
       type: z
         .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by", "artifact"])
@@ -1054,8 +1191,16 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ project, id, type, url }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to unlink work items in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const workItem = await workItemApi.getWorkItem(id, undefined, undefined, WorkItemExpand.Relations, project);
+        const workItem = await workItemApi.getWorkItem(id, undefined, undefined, WorkItemExpand.Relations, resolvedProject);
         const relations: WorkItemRelation[] = workItem.relations ?? [];
         const linkType = getLinkTypeFromName(type);
 
@@ -1087,7 +1232,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           path: `/relations/${idx}`,
         }));
 
-        const updatedWorkItem = await workItemApi.updateWorkItem(null, apiUpdates, id, project);
+        const updatedWorkItem = await workItemApi.updateWorkItem(null, apiUpdates, id, resolvedProject);
 
         return {
           content: [
@@ -1118,10 +1263,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.add_artifact_link,
-    "Add artifact links (repository, branch, commit, builds) to work items. You can either provide the full vstfs URI or the individual components to build it automatically.",
+    "Add artifact links (repository, branch, commit, builds) to work items. You can either provide the full vstfs URI or the individual components to build it automatically. If a project is not specified, you will be prompted to select one.",
     {
       workItemId: z.coerce.number().min(1).describe("The ID of the work item to add the artifact link to."),
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
 
       // Option 1: Provide full URI directly
       artifactUri: z.string().optional().describe("The complete VSTFS URI of the artifact to link. If provided, individual component parameters are ignored."),
@@ -1158,6 +1303,14 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     async ({ workItemId, project, artifactUri, projectId, repositoryId, branchName, commitId, pullRequestId, buildId, linkType, comment }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to add the artifact link in.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemTrackingApi = await connection.getWorkItemTrackingApi();
 
         let finalArtifactUri: string;
@@ -1235,7 +1388,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         ];
 
         // Use the WorkItem API to update the work item with the new relation
-        const workItem = await workItemTrackingApi.updateWorkItem({}, patchDocument, workItemId, project);
+        const workItem = await workItemTrackingApi.updateWorkItem({}, patchDocument, workItemId, resolvedProject);
 
         if (!workItem) {
           return { content: [{ type: "text", text: "Work item update failed" }], isError: true };
@@ -1309,17 +1462,25 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item_attachment,
-    "Download a work item attachment by its ID and return the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) attached to work items such as bugs.",
+    "Download a work item attachment by its ID and return the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
     {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       attachmentId: z.string().describe("The GUID of the attachment. Found in the attachment URL: https://dev.azure.com/{org}/{project}/_apis/wit/attachments/{attachmentId}"),
       fileName: z.string().optional().describe("The file name of the attachment, e.g. 'screenshot.png'. Used to determine the MIME type for the returned resource."),
     },
     async ({ project, attachmentId, fileName }) => {
       try {
         const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the work item attachment from.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
         const workItemApi = await connection.getWorkItemTrackingApi();
-        const stream = await workItemApi.getAttachmentContent(attachmentId, fileName, project);
+        const stream = await workItemApi.getAttachmentContent(attachmentId, fileName, resolvedProject);
 
         const chunks: Buffer[] = [];
         await new Promise<void>((resolve, reject) => {

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -4396,7 +4396,7 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1, relations: [] });
       (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
 
-      const result = await handler({ id: 1, type: "related" });
+      await handler({ id: 1, type: "related" });
       expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, undefined, undefined, 1, "Contoso");
     });
 
@@ -4446,7 +4446,7 @@ describe("configureWorkItemTools", () => {
       });
 
       // After the transform, "Replace" should become "replace"
-      expect((parsed as { updates: Array<{ op: string }> }).updates[0].op).toBe("replace");
+      expect((parsed as { updates: { op: string }[] }).updates[0].op).toBe("replace");
     });
   });
 
@@ -4456,7 +4456,7 @@ describe("configureWorkItemTools", () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([name]) => name === toolName);
       if (!call) throw new Error(`${toolName} not registered`);
-      return call[3] as (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+      return call[3] as (params: Record<string, unknown>) => Promise<{ content: { text: string }[]; isError?: boolean }>;
     }
 
     it("list_backlogs: should return unknown error message for non-Error throws", async () => {

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3888,4 +3888,757 @@ describe("configureWorkItemTools", () => {
       expect(result.content[0].text).toBe("Error executing WIQL query: WIQL syntax error");
     });
   });
+
+  describe("elicitation decline paths", () => {
+    // Helper to set up getCoreApi mock for elicitation
+    function setupElicitMocks(elicitAction: "accept" | "decline", selectedProject = "Contoso", selectedTeam = "Fabrikam") {
+      (mockConnection.getCoreApi as jest.Mock).mockResolvedValue({
+        getProjects: jest.fn().mockResolvedValue([{ id: "proj-1", name: selectedProject }]),
+        getTeams: jest.fn().mockResolvedValue([{ id: "team-1", name: selectedTeam }]),
+      });
+      ((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock).mockResolvedValue(
+        elicitAction === "accept" ? { action: "accept", content: { project: selectedProject, team: selectedTeam } } : { action: "decline" }
+      );
+    }
+
+    it("list_backlogs: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
+      if (!call) throw new Error("wit_list_backlogs not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ team: "Fabrikam" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("list_backlogs: should use elicited project and return elicitation response when team selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
+      if (!call) throw new Error("wit_list_backlogs not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ project: "Contoso" });
+      expect(result.content[0].text).toBe("Team selection cancelled.");
+    });
+
+    it("list_backlog_work_items: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
+      if (!call) throw new Error("wit_list_backlog_work_items not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ team: "Fabrikam", backlogId: "Microsoft.FeatureCategory" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("list_backlog_work_items: should return elicitation response when team selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
+      if (!call) throw new Error("wit_list_backlog_work_items not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ project: "Contoso", backlogId: "Microsoft.FeatureCategory" });
+      expect(result.content[0].text).toBe("Team selection cancelled.");
+    });
+
+    it("my_work_items: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_my_work_items");
+      if (!call) throw new Error("wit_my_work_items not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ type: "assignedtome", top: 50, includeCompleted: false });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_work_items_batch_by_ids: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
+      if (!call) throw new Error("wit_get_work_items_batch_by_ids not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ ids: [1, 2] });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_work_item: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
+      if (!call) throw new Error("wit_get_work_item not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ id: 1 });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("list_work_item_comments: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_comments");
+      if (!call) throw new Error("wit_list_work_item_comments not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemId: 1, top: 10 });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("add_work_item_comment: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_work_item_comment");
+      if (!call) throw new Error("wit_add_work_item_comment not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemId: 1, comment: "test comment" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("update_work_item_comment: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item_comment");
+      if (!call) throw new Error("wit_update_work_item_comment not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemId: 1, commentId: 1, text: "updated text" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("list_work_item_revisions: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
+      if (!call) throw new Error("wit_list_work_item_revisions not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemId: 1, top: 10 });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("add_child_work_items: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
+      if (!call) throw new Error("wit_add_child_work_items not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ parentId: 1, workItemType: "Task", items: [{ title: "Child", description: "Desc" }] });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_work_items_for_iteration: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_for_iteration");
+      if (!call) throw new Error("wit_get_work_items_for_iteration not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ iterationId: "iter-1" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_work_item_type: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_type");
+      if (!call) throw new Error("wit_get_work_item_type not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemType: "Bug" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("create_work_item: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+      if (!call) throw new Error("wit_create_work_item not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemType: "Task", fields: [{ name: "System.Title", value: "Test" }] });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_query: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query");
+      if (!call) throw new Error("wit_get_query not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ query: "some-query-id", depth: 0, includeDeleted: false, useIsoDateFormat: false });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("work_items_link: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
+      if (!call) throw new Error("wit_work_items_link not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ updates: [{ id: 1, linkToId: 2, type: "related" }] });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("work_item_unlink: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
+      if (!call) throw new Error("wit_work_item_unlink not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ id: 1, type: "related" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("add_artifact_link: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+      if (!call) throw new Error("wit_add_artifact_link not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ workItemId: 1, artifactUri: "vstfs:///Git/Ref/test", linkType: "Branch" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+
+    it("get_work_item_attachment: should return elicitation response when project selection is declined", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment not registered");
+      const [, , , handler] = call;
+
+      setupElicitMocks("decline");
+
+      const result = await handler({ attachmentId: "12341234-1234-1234-1234-123412341234", fileName: "screenshot.png" });
+      expect(result.content[0].text).toBe("Project selection cancelled.");
+    });
+  });
+
+  describe("elicitation accept paths", () => {
+    function setupAcceptMocks(selectedProject = "Contoso", selectedTeam = "Fabrikam") {
+      (mockConnection.getCoreApi as jest.Mock).mockResolvedValue({
+        getProjects: jest.fn().mockResolvedValue([{ id: "proj-1", name: selectedProject }]),
+        getTeams: jest.fn().mockResolvedValue([{ id: "team-1", name: selectedTeam }]),
+      });
+      ((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock).mockResolvedValue({
+        action: "accept",
+        content: { project: selectedProject, team: selectedTeam },
+      });
+    }
+
+    it("list_backlogs: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
+      if (!call) throw new Error("wit_list_backlogs not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getBacklogs as jest.Mock).mockResolvedValue([]);
+
+      await handler({ team: "Fabrikam" });
+      expect(mockWorkApi.getBacklogs).toHaveBeenCalledWith({ project: "Contoso", team: "Fabrikam" });
+    });
+
+    it("list_backlogs: should use elicited team when team is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlogs");
+      if (!call) throw new Error("wit_list_backlogs not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getBacklogs as jest.Mock).mockResolvedValue([]);
+
+      await handler({ project: "Contoso" });
+      expect(mockWorkApi.getBacklogs).toHaveBeenCalledWith({ project: "Contoso", team: "Fabrikam" });
+    });
+
+    it("list_backlog_work_items: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
+      if (!call) throw new Error("wit_list_backlog_work_items not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getBacklogLevelWorkItems as jest.Mock).mockResolvedValue([]);
+
+      await handler({ team: "Fabrikam", backlogId: "Microsoft.FeatureCategory" });
+      expect(mockWorkApi.getBacklogLevelWorkItems).toHaveBeenCalledWith({ project: "Contoso", team: "Fabrikam" }, "Microsoft.FeatureCategory");
+    });
+
+    it("list_backlog_work_items: should use elicited team when team is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_backlog_work_items");
+      if (!call) throw new Error("wit_list_backlog_work_items not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getBacklogLevelWorkItems as jest.Mock).mockResolvedValue([]);
+
+      await handler({ project: "Contoso", backlogId: "Microsoft.FeatureCategory" });
+      expect(mockWorkApi.getBacklogLevelWorkItems).toHaveBeenCalledWith({ project: "Contoso", team: "Fabrikam" }, "Microsoft.FeatureCategory");
+    });
+
+    it("my_work_items: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_my_work_items");
+      if (!call) throw new Error("wit_my_work_items not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getPredefinedQueryResults as jest.Mock).mockResolvedValue([]);
+
+      await handler({ type: "assignedtome", top: 10, includeCompleted: false });
+      expect(mockWorkApi.getPredefinedQueryResults).toHaveBeenCalledWith("Contoso", "assignedtome", 10, false);
+    });
+
+    it("get_work_items_batch_by_ids: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_batch_by_ids");
+      if (!call) throw new Error("wit_get_work_items_batch_by_ids not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getWorkItemsBatch as jest.Mock).mockResolvedValue([]);
+
+      await handler({ ids: [1, 2] });
+      expect(mockWorkItemTrackingApi.getWorkItemsBatch).toHaveBeenCalledWith({ ids: [1, 2], fields: expect.any(Array) }, "Contoso");
+    });
+
+    it("get_work_item: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
+      if (!call) throw new Error("wit_get_work_item not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
+
+      await handler({ id: 1 });
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, undefined, undefined, undefined, "Contoso");
+    });
+
+    it("list_work_item_comments: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_comments");
+      if (!call) throw new Error("wit_list_work_item_comments not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getComments as jest.Mock).mockResolvedValue([]);
+
+      await handler({ workItemId: 1, top: 10 });
+      expect(mockWorkItemTrackingApi.getComments).toHaveBeenCalledWith("Contoso", 1, 10);
+    });
+
+    it("add_work_item_comment: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_work_item_comment");
+      if (!call) throw new Error("wit_add_work_item_comment not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("{}") });
+
+      await handler({ workItemId: 1, comment: "test comment" });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("Contoso");
+    });
+
+    it("update_work_item_comment: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item_comment");
+      if (!call) throw new Error("wit_update_work_item_comment not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("{}") });
+
+      await handler({ workItemId: 1, commentId: 1, text: "updated" });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("Contoso");
+    });
+
+    it("list_work_item_revisions: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_list_work_item_revisions");
+      if (!call) throw new Error("wit_list_work_item_revisions not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue([]);
+
+      await handler({ workItemId: 1, top: 10 });
+      expect(mockWorkItemTrackingApi.getRevisions).toHaveBeenCalledWith(1, 10, undefined, undefined, "Contoso");
+    });
+
+    it("add_child_work_items: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_child_work_items");
+      if (!call) throw new Error("wit_add_child_work_items not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ responses: [] }) });
+
+      await handler({ parentId: 1, workItemType: "Task", items: [{ title: "Child", description: "Desc" }] });
+      const calledBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(calledBody[0].uri).toContain("Contoso");
+    });
+
+    it("get_work_items_for_iteration: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_items_for_iteration");
+      if (!call) throw new Error("wit_get_work_items_for_iteration not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkApi.getIterationWorkItems as jest.Mock).mockResolvedValue([]);
+
+      await handler({ iterationId: "iter-1" });
+      expect(mockWorkApi.getIterationWorkItems).toHaveBeenCalledWith({ project: "Contoso", team: undefined }, "iter-1");
+    });
+
+    it("get_work_item_type: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_type");
+      if (!call) throw new Error("wit_get_work_item_type not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getWorkItemType as jest.Mock).mockResolvedValue({});
+
+      await handler({ workItemType: "Bug" });
+      expect(mockWorkItemTrackingApi.getWorkItemType).toHaveBeenCalledWith("Contoso", "Bug");
+    });
+
+    it("create_work_item: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_create_work_item");
+      if (!call) throw new Error("wit_create_work_item not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
+
+      await handler({ workItemType: "Task", fields: [{ name: "System.Title", value: "Test" }] });
+      expect(mockWorkItemTrackingApi.createWorkItem).toHaveBeenCalledWith(null, expect.any(Array), "Contoso", "Task");
+    });
+
+    it("get_query: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_query");
+      if (!call) throw new Error("wit_get_query not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getQuery as jest.Mock).mockResolvedValue({});
+
+      await handler({ query: "some-query-id", depth: 0, includeDeleted: false, useIsoDateFormat: false });
+      expect(mockWorkItemTrackingApi.getQuery).toHaveBeenCalledWith("Contoso", "some-query-id", undefined, 0, false, false);
+    });
+
+    it("work_items_link: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_items_link");
+      if (!call) throw new Error("wit_work_items_link not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
+
+      await handler({ updates: [{ id: 1, linkToId: 2, type: "related" }] });
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("work_item_unlink: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
+      if (!call) throw new Error("wit_work_item_unlink not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1, relations: [] });
+      (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
+
+      const result = await handler({ id: 1, type: "related" });
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, undefined, undefined, 1, "Contoso");
+    });
+
+    it("add_artifact_link: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+      if (!call) throw new Error("wit_add_artifact_link not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
+
+      await handler({ workItemId: 1, artifactUri: "vstfs:///Git/Ref/test", linkType: "Branch" });
+      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith({}, expect.any(Array), 1, "Contoso");
+    });
+
+    it("get_work_item_attachment: should use elicited project when project is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment not registered");
+      const [, , , handler] = call;
+
+      setupAcceptMocks();
+      const fakeStream = new Readable();
+      fakeStream.push(Buffer.from("data"));
+      fakeStream.push(null);
+      (mockWorkItemTrackingApi.getAttachmentContent as jest.Mock).mockResolvedValue(fakeStream);
+
+      await handler({ attachmentId: "12341234-1234-1234-1234-123412341234", fileName: "screenshot.png" });
+      expect(mockWorkItemTrackingApi.getAttachmentContent).toHaveBeenCalledWith("12341234-1234-1234-1234-123412341234", "screenshot.png", "Contoso");
+    });
+  });
+
+  describe("update_work_item schema transform coverage", () => {
+    it("should apply lowercase transform to the op field via Zod schema", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_update_work_item");
+      if (!call) throw new Error("wit_update_work_item not registered");
+      const [, , schemaShape] = call;
+
+      // Parse through the Zod schema to trigger the transform callback
+      const { z } = await import("zod");
+      const fullSchema = z.object(schemaShape as Parameters<typeof z.object>[0]);
+      const parsed = fullSchema.parse({
+        id: 1,
+        updates: [{ op: "Replace", path: "/fields/System.Title", value: "test" }],
+      });
+
+      // After the transform, "Replace" should become "replace"
+      expect((parsed as { updates: Array<{ op: string }> }).updates[0].op).toBe("replace");
+    });
+  });
+
+  describe("unknown error type branch coverage", () => {
+    // Helper to get handler for a tool
+    function getHandler(toolName: string) {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([name]) => name === toolName);
+      if (!call) throw new Error(`${toolName} not registered`);
+      return call[3] as (params: Record<string, unknown>) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
+    }
+
+    it("list_backlogs: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_list_backlogs");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", team: "T" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error listing backlogs: Unknown error occurred");
+    });
+
+    it("list_backlog_work_items: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_list_backlog_work_items");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", team: "T", backlogId: "B" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error listing backlog work items: Unknown error occurred");
+    });
+
+    it("my_work_items: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_my_work_items");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", type: "assignedtome", top: 10, includeCompleted: false });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work items: Unknown error occurred");
+    });
+
+    it("get_work_items_batch_by_ids: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_work_items_batch_by_ids");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", ids: [1] });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work items batch: Unknown error occurred");
+    });
+
+    it("get_work_item: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_work_item");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ id: 1, project: "P" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work item: Unknown error occurred");
+    });
+
+    it("list_work_item_comments: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_list_work_item_comments");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", workItemId: 1, top: 10 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error listing work item comments: Unknown error occurred");
+    });
+
+    it("add_work_item_comment: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_add_work_item_comment");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", workItemId: 1, comment: "test" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error adding work item comment: Unknown error occurred");
+    });
+
+    it("update_work_item_comment: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_update_work_item_comment");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", workItemId: 1, commentId: 1, text: "updated" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error updating work item comment: Unknown error occurred");
+    });
+
+    it("update_work_item_comment: should use format=0 when format is markdown", async () => {
+      const handler = getHandler("wit_update_work_item_comment");
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve("{}") });
+
+      await handler({ project: "P", workItemId: 1, commentId: 1, text: "updated", format: "markdown" });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("format=0");
+    });
+
+    it("list_work_item_revisions: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_list_work_item_revisions");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", workItemId: 1, top: 10 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error listing work item revisions: Unknown error occurred");
+    });
+
+    it("list_work_item_revisions: should handle null revisions without errors", async () => {
+      const handler = getHandler("wit_list_work_item_revisions");
+      (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(null);
+      const result = await handler({ project: "P", workItemId: 1, top: 10 });
+      expect(result.content[0].text).toBe(JSON.stringify(null, null, 2));
+    });
+
+    it("get_work_items_for_iteration: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_work_items_for_iteration");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", iterationId: "iter-1" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work items for iteration: Unknown error occurred");
+    });
+
+    it("update_work_item: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_update_work_item");
+      (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ id: 1, updates: [{ op: "add", path: "/fields/System.Title", value: "T" }] });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error updating work item: Unknown error occurred");
+    });
+
+    it("get_work_item_type: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_work_item_type");
+      (mockWorkItemTrackingApi.getWorkItemType as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", workItemType: "Bug" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work item type: Unknown error occurred");
+    });
+
+    it("get_query: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_query");
+      (mockWorkItemTrackingApi.getQuery as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", query: "q", depth: 0, includeDeleted: false, useIsoDateFormat: false });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving query: Unknown error occurred");
+    });
+
+    it("get_query_results_by_id: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_query_results_by_id");
+      (mockWorkItemTrackingApi.queryById as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ id: "q-id", project: "P", top: 10 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving query results: Unknown error occurred");
+    });
+
+    it("get_query_results_by_id: should handle null workItems in ids mode", async () => {
+      const handler = getHandler("wit_get_query_results_by_id");
+      (mockWorkItemTrackingApi.queryById as jest.Mock).mockResolvedValue({ workItems: null });
+      const result = await handler({ id: "q-id", project: "P", responseType: "ids", top: 50 });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.ids).toEqual([]);
+      expect(parsed.count).toBe(0);
+    });
+
+    it("update_work_items_batch: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_update_work_items_batch");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ updates: [{ op: "replace", id: 1, path: "/fields/System.Title", value: "T" }] });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error updating work items in batch: Unknown error occurred");
+    });
+
+    it("work_items_link: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_work_items_link");
+      (connectionProvider as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", updates: [{ id: 1, linkToId: 2, type: "related" }] });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error linking work items: Unknown error occurred");
+    });
+
+    it("get_work_item_attachment: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_get_work_item_attachment");
+      (mockWorkItemTrackingApi.getAttachmentContent as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ project: "P", attachmentId: "att-id" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error retrieving work item attachment: Unknown error occurred");
+    });
+
+    it("query_by_wiql: should return unknown error message for non-Error throws", async () => {
+      const handler = getHandler("wit_query_by_wiql");
+      (mockWorkItemTrackingApi.queryByWiql as jest.Mock).mockRejectedValue("string error");
+      const result = await handler({ wiql: "SELECT [System.Id] FROM WorkItems", project: "P", top: 50 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error executing WIQL query: Unknown error occurred");
+    });
+
+    it("list_work_item_revisions: should handle revision without fields property", async () => {
+      const handler = getHandler("wit_list_work_item_revisions");
+      const revisionsWithNoFields = [
+        { id: 1, rev: 1 }, // no fields property
+        { id: 2, rev: 2, fields: { "System.Title": "Test" } },
+      ];
+      (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(revisionsWithNoFields);
+      const result = await handler({ project: "P", workItemId: 1, top: 10 });
+      expect(result.content[0].text).toBe(JSON.stringify(revisionsWithNoFields, null, 2));
+    });
+  });
 });


### PR DESCRIPTION
- Implemented tests for handling project and team selection declines in various work item tools.
- Added mocks for elicitation responses to simulate user acceptance and decline scenarios.
- Ensured that appropriate messages are returned when project or team selections are canceled.
- Verified that elicited project and team are used when not provided in requests.
- Enhanced error handling for unknown error types across multiple work item operations.


## GitHub issue number
N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual tests and updated and ran automated tests
