### PR TITLE
fix: Update field and expand parameter on get_work_item

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -265,23 +265,36 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     {
       id: z.coerce.number().min(1).describe("The ID of the work item to retrieve."),
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      fields: z.array(z.string()).optional().describe("Optional list of fields to include in the response. If not provided, all fields will be returned."),
+      fields: z
+        .array(z.string())
+        .optional()
+        .describe("Optional list of fields to include in the response. If not provided, all fields will be returned. Cannot be used together with the expand parameter."),
       asOf: z.coerce.date().optional().describe("Optional date string to retrieve the work item as of a specific time. If not provided, the current state will be returned."),
       expand: z
         .enum(["all", "fields", "links", "none", "relations"])
-        .describe("Optional expand parameter to include additional details in the response.")
+        .describe("Optional expand parameter to include additional details in the response. Cannot be used together with the fields parameter.")
         .optional()
-        .describe("Expand options include 'all', 'fields', 'links', 'none', and 'relations'. Relations can be used to get child workitems. Defaults to 'none'."),
+        .describe(
+          "Expand options include 'All', 'Fields', 'Links', 'None', and 'Relations'. Relations can be used to get child workitems. Defaults to 'None'. Cannot be used together with the fields parameter."
+        ),
     },
     async ({ id, project, fields, asOf, expand }) => {
       try {
         const connection = await connectionProvider();
 
         let resolvedProject = project;
+
         if (!resolvedProject) {
           const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the work item from.");
+
           if ("response" in result) return result.response;
           resolvedProject = result.resolved;
+        }
+
+        // The Azure DevOps API does not support using expand and fields together.
+        // When both are provided, prefer fields as it is the more specific selection.
+        if (fields && fields.length > 0 && expand != null) {
+          expand = "none";
         }
 
         const workItemApi = await connection.getWorkItemTrackingApi();

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -688,6 +688,82 @@ describe("configureWorkItemTools", () => {
 
       expect(result.content[0].text).toBe(JSON.stringify([_mockWorkItem], null, 2));
     });
+
+    it("should call getWorkItem with fields and no expand when fields are provided but expand is empty", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
+
+      if (!call) throw new Error("wit_get_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
+
+      const params = {
+        id: 12,
+        fields: ["System.Title", "System.State"],
+        asOf: undefined,
+        expand: undefined,
+        project: "Contoso",
+      };
+
+      const result = await handler(params);
+
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(params.id, params.fields, params.asOf, undefined, params.project);
+
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
+
+    it("should call getWorkItem with expand and no fields when expand is provided but fields are empty", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
+
+      if (!call) throw new Error("wit_get_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
+
+      const params = {
+        id: 12,
+        fields: undefined,
+        asOf: undefined,
+        expand: "relations",
+        project: "Contoso",
+      };
+
+      const result = await handler(params);
+
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(params.id, params.fields, params.asOf, "relations", params.project);
+
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
+
+    it("should override expand to 'none' when both fields and expand are provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item");
+
+      if (!call) throw new Error("wit_get_work_item tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
+
+      const params = {
+        id: 12,
+        fields: ["System.Title", "System.State"],
+        asOf: undefined,
+        expand: "relations",
+        project: "Contoso",
+      };
+
+      const result = await handler(params);
+
+      // expand should be overridden to "none" because fields takes precedence
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(params.id, params.fields, params.asOf, "none", params.project);
+
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
   });
 
   describe("list_work_item_comments tool", () => {


### PR DESCRIPTION
This pull request improves the handling of the `fields` and `expand` parameters in the Azure DevOps work item retrieval tool, ensuring they are not used together and clarifying their precedence. It also adds comprehensive tests to verify the new logic.

## GitHub issue number
N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual testing and updated automated tests
