### PR TITLE
Fix wit_work_item_unlink ignoring type when url is provided

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -1225,7 +1225,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         if (url && url.trim().length > 0) {
           // If url is provided, find relations matching both rel type and url
-          relationIndexes = relations.map((relation, idx) => (relation.url === url ? idx : -1)).filter((idx) => idx !== -1);
+          relationIndexes = relations.map((relation, idx) => (relation.rel === linkType && relation.url === url ? idx : -1)).filter((idx) => idx !== -1);
         } else {
           // If url is not provided, find all relations matching rel type
           relationIndexes = relations.map((relation, idx) => (relation.rel === linkType ? idx : -1)).filter((idx) => idx !== -1);

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -2406,6 +2406,48 @@ describe("configureWorkItemTools", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe("Error unlinking work item: Unknown error occurred");
     });
+
+    describe("type + url matching", () => {
+      const artifactUrl = "vstfs:///Git/Ref/project%2Frepo%2FGBmain";
+      const relatedUrl = "https://dev.azure.com/contoso/_apis/wit/workItems/2";
+      const relations = [
+        { rel: "ArtifactLink", url: artifactUrl, attributes: { name: "Branch" } },
+        { rel: "System.LinkTypes.Related", url: relatedUrl, attributes: { isLocked: false, name: "Related" } },
+      ];
+
+      const getUnlinkHandler = () => {
+        configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_unlink");
+        if (!call) throw new Error("wit_work_item_unlink tool not registered");
+        return call[3];
+      };
+
+      it.each([
+        { name: "type=related + ArtifactLink url (type bypass)", type: "related", url: artifactUrl },
+        { name: "type=child + ArtifactLink url (type bypass)", type: "child", url: artifactUrl },
+      ])("should NOT remove a relation when url matches but type does not ($name)", async ({ type, url }) => {
+        const handler = getUnlinkHandler();
+        (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1, relations });
+
+        const result = await handler({ project: "TestProject", id: 1, type, url });
+
+        expect(mockWorkItemTrackingApi.updateWorkItem).not.toHaveBeenCalled();
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("No matching relations found");
+      });
+
+      it("should remove a relation when both url and type match", async () => {
+        const handler = getUnlinkHandler();
+        (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1, relations });
+        (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 1, rev: 10 });
+
+        const result = await handler({ project: "TestProject", id: 1, type: "related", url: relatedUrl });
+
+        expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(null, [{ op: "remove", path: "/relations/1" }], 1, "TestProject");
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toContain("Removed 1 link(s) of type 'related':");
+      });
+    });
   });
 
   // Add error handling tests for existing tools


### PR DESCRIPTION
**Fix type parameter bypass in `wit_work_item_unlink` when URL is provided.**

The URL-match branch in the `work_item_unlink` tool only checked `relation.url` without verifying `relation.rel` matched the requested link type. This allowed deletion of relations whose actual type differed from the `type` parameter (e.g., removing an `ArtifactLink` when `type="related"` was specified). The code comment already stated "find relations matching both rel type and url" but the implementation only enforced the URL check.

Added `relation.rel === linkType` to the URL-match condition so both type and URL must match before a relation is removed.

## GitHub issue number

N/A

## **Associated Risks**

- Callers that previously relied on URL-only matching (ignoring type) will now get a "No matching relations found" error if the type doesn't match the relation at that URL. This is the correct behavior per the tool's documented contract.
- No breaking changes for callers that already pass consistent type + URL combinations.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A — N/A
- [x] 📄 Documentation added, updated, or N/A — N/A (no doc changes needed; tool schema/description unchanged)
- [x] 🛡️ Automated tests added, or N/A — Added

## 🧪 **How did you test it?**

Added 3 unit tests in work-items.test.ts under `work_item_unlink tool > type + url matching`:

| Test case | Scenario | Expected |
|---|---|---|
| `type=related` + ArtifactLink URL | URL matches but `rel` is `ArtifactLink`, not `System.LinkTypes.Related` | No deletion, returns "No matching relations found" |
| `type=child` + ArtifactLink URL | URL matches but `rel` is `ArtifactLink`, not `System.LinkTypes.Hierarchy-Forward` | No deletion, returns "No matching relations found" |
| `type=related` + matching Related URL | Both URL and `rel` match | Deletes the correct relation at index 1 |

All 3 tests pass after the fix. Before the fix, tests 1 and 2 correctly failed (confirming the bug).
