### PR TITLE
chore: work-items.ts to increase char check for markdown format

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -903,9 +903,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         // Check if any field has format === "Markdown" and add the multilineFieldsFormat operation
         // this should only happen for large text fields, but since we dont't know by field name, lets assume if the users
-        // passes a value longer than 50 characters, then we can set the format to Markdown
+        // passes a value longer than 100 characters, then we can set the format to Markdown
         fields.forEach(({ name, value, format }) => {
-          if (value.length > 50 && format === "Markdown") {
+          if (value.length > 100 && format === "Markdown") {
             document.push({
               op: "add",
               path: `/multilineFieldsFormat/${name}`,
@@ -1055,7 +1055,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
           // Add format operations for Markdown fields
           workItemUpdates.forEach(({ path, value, format }) => {
-            if (format === "Markdown" && value && value.length > 50) {
+            if (format === "Markdown" && value && value.length > 100) {
               operations.push({
                 op: "Add",
                 path: `/multilineFieldsFormat${path.replace("/fields", "")}`,


### PR DESCRIPTION
This pull request makes a minor adjustment to the logic for handling Markdown-formatted fields in work item updates. The threshold for considering a field as Markdown based on its value length has been increased from 50 to 100 characters, making the detection less aggressive. 

## GitHub issue number
N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual tests. re-ran auto tests
