### PR TITLE
Add file saving for attachments and enhance markdown handling

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -2,96 +2,96 @@
 
 ## Overview
 
-| Functional Area   | Tool                                                                                                      | Description                                              |
-| ----------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Advanced Security | [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)                                                   | Retrieve Advanced Security alerts for a repository       |
-| Advanced Security | [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details)                                     | Get detailed information about a specific security alert |
-| Core              | [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)                                                 | List all projects in the organization                    |
-| Core              | [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams)                                       | List teams within a project                              |
-| Core              | [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)                                           | Retrieve identity IDs by search filter                   |
-| Pipelines         | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                                   | Create a new pipeline with YAML configuration            |
-| Pipelines         | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                             | Retrieve a list of builds with optional filters          |
-| Pipelines         | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                                 | Get the status of a specific build                       |
-| Pipelines         | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                       | Retrieve complete logs for a build                       |
-| Pipelines         | [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                           | Get a specific build log by log ID                       |
-| Pipelines         | [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                               | Get changes (commits) associated with a build            |
-| Pipelines         | [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                       | List build/pipeline definitions in a project             |
-| Pipelines         | [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions)     | Get revision history of a build definition               |
-| Pipelines         | [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                         | Start a new pipeline run with optional parameters        |
-| Pipelines         | [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                                   | Get details of a specific pipeline run                   |
-| Pipelines         | [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                               | List recent runs for a pipeline                          |
-| Pipelines         | [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                             | Update a build stage (cancel, retry, or run)             |
-| Repositories      | [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                 | List all repositories in a project                       |
-| Repositories      | [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                               | Get repository details by name or ID                     |
-| Repositories      | [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                 | List all branches in a repository                        |
-| Repositories      | [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                           | List branches created by current user                    |
-| Repositories      | [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                       | Get details of a specific branch                         |
-| Repositories      | [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                 | Create a new branch from a source branch                 |
-| Repositories      | [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                               | Search for commits with comprehensive filters            |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project) | List pull requests with optional filters                 |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                 | Find pull requests containing specific commits           |
-| Repositories      | [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                               | Get details of a specific pull request                   |
-| Repositories      | [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                           | Get file changes (diff) for a pull request               |
-| Repositories      | [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                     | Create a new pull request                                |
-| Repositories      | [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                     | Update pull request properties and settings              |
-| Repositories      | [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                 | Add or remove reviewers from a pull request              |
-| Repositories      | [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                         | Cast a vote on a pull request                            |
-| Repositories      | [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                         | List comment threads on a pull request                   |
-| Repositories      | [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)         | List comments in a specific thread                       |
-| Repositories      | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request            |
-| Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread           |
-| Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                          |
-| Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                    |
-| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version                   |
-| Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                      |
-| Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                            |
-| Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                    |
-| Test Plans        | [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                     | List test plans in a project                             |
-| Test Plans        | [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                                   | Create a new test plan                                   |
-| Test Plans        | [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                                   | List test suites in a test plan                          |
-| Test Plans        | [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                                 | Create a test suite within a test plan                   |
-| Test Plans        | [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                     | Add test cases to a test suite                           |
-| Test Plans        | [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                     | List test cases in a test suite                          |
-| Test Plans        | [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                                   | Create a new test case work item                         |
-| Test Plans        | [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                       | Update steps of an existing test case                    |
-| Test Plans        | [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id)     | Get test results for a specific build                    |
-| Wiki              | [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                                                       | List wikis in organization or project                    |
-| Wiki              | [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                                                           | Get details of a specific wiki                           |
-| Wiki              | [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                                                       | List pages in a wiki                                     |
-| Wiki              | [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                                                           | Get wiki page metadata (without content)                 |
-| Wiki              | [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)                                           | Retrieve wiki page content                               |
-| Wiki              | [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page)                                 | Create or update a wiki page                             |
-| Work Items        | [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                                   | Get a work item by ID                                    |
-| Work Items        | [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)                       | Retrieve multiple work items by IDs                      |
-| Work Items        | [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                                             | Create a new work item                                   |
-| Work Items        | [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                                             | Update fields of a work item                             |
-| Work Items        | [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)                               | Update multiple work items in batch                      |
-| Work Items        | [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                                     | Create child work items under a parent                   |
-| Work Items        | [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                                               | Link work items together                                 |
-| Work Items        | [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                                             | Remove links from a work item                            |
-| Work Items        | [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                                           | Link artifacts (commits, builds, PRs) to work items      |
-| Work Items        | [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request)                 | Link a work item to a pull request                       |
-| Work Items        | [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)                               | List comments on a work item                             |
-| Work Items        | [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                                   | Add a comment to a work item                             |
-| Work Items        | [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)                             | Update an existing comment on a work item                |
-| Work Items        | [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)                             | Get revision history of a work item                      |
-| Work Items        | [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                                         | Get details of a work item type                          |
-| Work Items        | [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                                   | List work items relevant to current user                 |
-| Work Items        | [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)                     | Get work items in a specific iteration                   |
-| Work Items        | [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                                   | List backlogs for a team                                 |
-| Work Items        | [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)                               | Get work items in a backlog                              |
-| Work Items        | [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                                           | Get a work item query by ID or path                      |
-| Work Items        | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                               | Execute a query and get results                          |
-| Work Items        | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                   | Execute a WIQL query and return matching work items      |
-| Work Items        | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                             | Download a work item attachment as base64                |
-| Work              | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                             | List all iterations in a project                         |
-| Work              | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                         | Create new iterations in a project                       |
-| Work              | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                   | List iterations assigned to a team                       |
-| Work              | [mcp_ado_work_assign_iterations](#mcp_ado_work_assign_iterations)                                         | Assign iterations to a team                              |
-| Work              | [mcp_ado_work_get_iteration_capacities](#mcp_ado_work_get_iteration_capacities)                           | Get capacity for all teams in an iteration               |
-| Work              | [mcp_ado_work_get_team_capacity](#mcp_ado_work_get_team_capacity)                                         | Get capacity for a specific team in iteration            |
-| Work              | [mcp_ado_work_update_team_capacity](#mcp_ado_work_update_team_capacity)                                   | Update team member capacity for iteration                |
-| Work              | [mcp_ado_work_get_team_settings](#mcp_ado_work_get_team_settings)                                         | Get team settings including default iteration and area   |
+| Functional Area   | Tool                                                                                                      | Description                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Advanced Security | [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)                                                   | Retrieve Advanced Security alerts for a repository                |
+| Advanced Security | [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details)                                     | Get detailed information about a specific security alert          |
+| Core              | [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)                                                 | List all projects in the organization                             |
+| Core              | [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams)                                       | List teams within a project                                       |
+| Core              | [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)                                           | Retrieve identity IDs by search filter                            |
+| Pipelines         | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                                   | Create a new pipeline with YAML configuration                     |
+| Pipelines         | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                             | Retrieve a list of builds with optional filters                   |
+| Pipelines         | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                                 | Get the status of a specific build                                |
+| Pipelines         | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                       | Retrieve complete logs for a build                                |
+| Pipelines         | [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                           | Get a specific build log by log ID                                |
+| Pipelines         | [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                               | Get changes (commits) associated with a build                     |
+| Pipelines         | [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                       | List build/pipeline definitions in a project                      |
+| Pipelines         | [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions)     | Get revision history of a build definition                        |
+| Pipelines         | [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                         | Start a new pipeline run with optional parameters                 |
+| Pipelines         | [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                                   | Get details of a specific pipeline run                            |
+| Pipelines         | [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                               | List recent runs for a pipeline                                   |
+| Pipelines         | [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                             | Update a build stage (cancel, retry, or run)                      |
+| Repositories      | [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                 | List all repositories in a project                                |
+| Repositories      | [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                               | Get repository details by name or ID                              |
+| Repositories      | [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                 | List all branches in a repository                                 |
+| Repositories      | [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                           | List branches created by current user                             |
+| Repositories      | [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                       | Get details of a specific branch                                  |
+| Repositories      | [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                 | Create a new branch from a source branch                          |
+| Repositories      | [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                               | Search for commits with comprehensive filters                     |
+| Repositories      | [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project) | List pull requests with optional filters                          |
+| Repositories      | [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                 | Find pull requests containing specific commits                    |
+| Repositories      | [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                               | Get details of a specific pull request                            |
+| Repositories      | [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                           | Get file changes (diff) for a pull request                        |
+| Repositories      | [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                     | Create a new pull request                                         |
+| Repositories      | [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                     | Update pull request properties and settings                       |
+| Repositories      | [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                 | Add or remove reviewers from a pull request                       |
+| Repositories      | [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                         | Cast a vote on a pull request                                     |
+| Repositories      | [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                         | List comment threads on a pull request                            |
+| Repositories      | [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)         | List comments in a specific thread                                |
+| Repositories      | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request                     |
+| Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread                    |
+| Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                                   |
+| Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                             |
+| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version                            |
+| Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                               |
+| Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                                     |
+| Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                             |
+| Test Plans        | [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                     | List test plans in a project                                      |
+| Test Plans        | [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                                   | Create a new test plan                                            |
+| Test Plans        | [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                                   | List test suites in a test plan                                   |
+| Test Plans        | [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                                 | Create a test suite within a test plan                            |
+| Test Plans        | [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                     | Add test cases to a test suite                                    |
+| Test Plans        | [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                     | List test cases in a test suite                                   |
+| Test Plans        | [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                                   | Create a new test case work item                                  |
+| Test Plans        | [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                       | Update steps of an existing test case                             |
+| Test Plans        | [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id)     | Get test results for a specific build                             |
+| Wiki              | [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                                                       | List wikis in organization or project                             |
+| Wiki              | [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                                                           | Get details of a specific wiki                                    |
+| Wiki              | [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                                                       | List pages in a wiki                                              |
+| Wiki              | [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                                                           | Get wiki page metadata (without content)                          |
+| Wiki              | [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)                                           | Retrieve wiki page content                                        |
+| Wiki              | [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page)                                 | Create or update a wiki page                                      |
+| Work Items        | [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                                   | Get a work item by ID                                             |
+| Work Items        | [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)                       | Retrieve multiple work items by IDs                               |
+| Work Items        | [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                                             | Create a new work item                                            |
+| Work Items        | [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                                             | Update fields of a work item                                      |
+| Work Items        | [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)                               | Update multiple work items in batch                               |
+| Work Items        | [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                                     | Create child work items under a parent                            |
+| Work Items        | [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                                               | Link work items together                                          |
+| Work Items        | [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                                             | Remove links from a work item                                     |
+| Work Items        | [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                                           | Link artifacts (commits, builds, PRs) to work items               |
+| Work Items        | [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request)                 | Link a work item to a pull request                                |
+| Work Items        | [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)                               | List comments on a work item                                      |
+| Work Items        | [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                                   | Add a comment to a work item                                      |
+| Work Items        | [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)                             | Update an existing comment on a work item                         |
+| Work Items        | [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)                             | Get revision history of a work item                               |
+| Work Items        | [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                                         | Get details of a work item type                                   |
+| Work Items        | [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                                   | List work items relevant to current user                          |
+| Work Items        | [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)                     | Get work items in a specific iteration                            |
+| Work Items        | [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                                   | List backlogs for a team                                          |
+| Work Items        | [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)                               | Get work items in a backlog                                       |
+| Work Items        | [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                                           | Get a work item query by ID or path                               |
+| Work Items        | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                               | Execute a query and get results                                   |
+| Work Items        | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                   | Execute a WIQL query and return matching work items               |
+| Work Items        | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                             | Download a work item attachment; save locally or return as base64 |
+| Work              | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                             | List all iterations in a project                                  |
+| Work              | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                         | Create new iterations in a project                                |
+| Work              | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                   | List iterations assigned to a team                                |
+| Work              | [mcp_ado_work_assign_iterations](#mcp_ado_work_assign_iterations)                                         | Assign iterations to a team                                       |
+| Work              | [mcp_ado_work_get_iteration_capacities](#mcp_ado_work_get_iteration_capacities)                           | Get capacity for all teams in an iteration                        |
+| Work              | [mcp_ado_work_get_team_capacity](#mcp_ado_work_get_team_capacity)                                         | Get capacity for a specific team in iteration                     |
+| Work              | [mcp_ado_work_update_team_capacity](#mcp_ado_work_update_team_capacity)                                   | Update team member capacity for iteration                         |
+| Work              | [mcp_ado_work_get_team_settings](#mcp_ado_work_get_team_settings)                                         | Get team settings including default iteration and area            |
 
 ## Advanced Security
 
@@ -688,10 +688,10 @@ Execute a WIQL (Work Item Query Language) query and return the matching work ite
 
 ### mcp_ado_wit_get_work_item_attachment
 
-Download a work item attachment by its ID and return the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) attached to work items such as bugs.
+Download a work item attachment by its ID. If `savePath` is provided, saves the file to that local directory and returns the file path. Otherwise returns the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs.
 
-- **Required**: `project`, `attachmentId`
-- **Optional**: `fileName`
+- **Required**: `attachmentId`
+- **Optional**: `project`, `fileName`, `savePath`
 
 ## Work
 

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -1481,24 +1481,24 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item_attachment,
-    "Download a work item attachment by its ID. By default returns the content as a base64-encoded resource. If saveToPath is provided, saves the file locally to that directory and returns the file path instead. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
+    "Download a work item attachment by its ID. By default returns the content as a base64-encoded resource. If savePath is provided, saves the file locally to that directory and returns the file path instead. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
     {
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       attachmentId: z.string().describe("The GUID of the attachment. Found in the attachment URL: https://dev.azure.com/{org}/{project}/_apis/wit/attachments/{attachmentId}"),
       fileName: z.string().optional().describe("The file name of the attachment, e.g. 'screenshot.png'. Used to determine the MIME type or the saved file's name."),
-      saveToPath: z
+      savePath: z
         .string()
         .optional()
         .describe(
           "Optional local directory path where the file should be saved. Must be a relative path (e.g. 'temp' or 'downloads/attachments'); absolute paths and path traversals are not allowed. If provided, saves the attachment to this directory and returns the file path. If omitted, returns the content as a base64-encoded resource."
         ),
     },
-    async ({ project, attachmentId, fileName, saveToPath }) => {
+    async ({ project, attachmentId, fileName, savePath }) => {
       const isAbsolutePath = (value: string) => path.posix.isAbsolute(value) || path.win32.isAbsolute(value);
       const hasDriveLetter = (value: string) => /^[a-zA-Z]:/.test(value);
 
-      if (saveToPath !== undefined && (saveToPath.includes("..") || isAbsolutePath(saveToPath) || hasDriveLetter(saveToPath))) {
-        throw new Error("Invalid saveToPath: only relative paths are allowed (e.g. 'temp' or 'downloads/attachments'). Absolute paths and path traversals are not permitted.");
+      if (savePath !== undefined && (savePath.includes("..") || isAbsolutePath(savePath) || hasDriveLetter(savePath))) {
+        throw new Error("Invalid savePath: absolute paths and path traversals are not allowed.");
       }
 
       if (fileName !== undefined && fileName.includes("..")) {
@@ -1527,9 +1527,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         const buffer = Buffer.concat(chunks);
 
-        if (saveToPath) {
+        if (savePath) {
           const resolvedFileName = fileName ?? attachmentId;
-          const localFilePath = path.join(saveToPath, resolvedFileName);
+          const localFilePath = path.join(savePath, resolvedFileName);
 
           if (fs.existsSync(localFilePath)) {
             throw new Error(`File already exists: ${localFilePath}`);

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -1481,19 +1481,30 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item_attachment,
-    "Download a work item attachment by its ID. By default returns the content as a base64-encoded resource. If savePath is provided, saves the file locally to that directory and returns the file path instead. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
+    "Download a work item attachment by its ID. By default returns the content as a base64-encoded resource. If saveToPath is provided, saves the file locally to that directory and returns the file path instead. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
     {
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       attachmentId: z.string().describe("The GUID of the attachment. Found in the attachment URL: https://dev.azure.com/{org}/{project}/_apis/wit/attachments/{attachmentId}"),
       fileName: z.string().optional().describe("The file name of the attachment, e.g. 'screenshot.png'. Used to determine the MIME type or the saved file's name."),
-      savePath: z
+      saveToPath: z
         .string()
         .optional()
         .describe(
-          "Optional local directory path where the file should be saved. If provided, saves the attachment to this directory and returns the file path. If omitted, returns the content as a base64-encoded resource."
+          "Optional local directory path where the file should be saved. Must be a relative path (e.g. 'temp' or 'downloads/attachments'); absolute paths and path traversals are not allowed. If provided, saves the attachment to this directory and returns the file path. If omitted, returns the content as a base64-encoded resource."
         ),
     },
-    async ({ project, attachmentId, fileName, savePath }) => {
+    async ({ project, attachmentId, fileName, saveToPath }) => {
+      const isAbsolutePath = (value: string) => path.posix.isAbsolute(value) || path.win32.isAbsolute(value);
+      const hasDriveLetter = (value: string) => /^[a-zA-Z]:/.test(value);
+
+      if (saveToPath !== undefined && (saveToPath.includes("..") || isAbsolutePath(saveToPath) || hasDriveLetter(saveToPath))) {
+        throw new Error("Invalid saveToPath: only relative paths are allowed (e.g. 'temp' or 'downloads/attachments'). Absolute paths and path traversals are not permitted.");
+      }
+
+      if (fileName !== undefined && fileName.includes("..")) {
+        throw new Error("Invalid fileName: path traversal is not allowed.");
+      }
+
       try {
         const connection = await connectionProvider();
 
@@ -1516,9 +1527,13 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         const buffer = Buffer.concat(chunks);
 
-        if (savePath) {
+        if (saveToPath) {
           const resolvedFileName = fileName ?? attachmentId;
-          const localFilePath = path.join(savePath, resolvedFileName);
+          const localFilePath = path.join(saveToPath, resolvedFileName);
+
+          if (fs.existsSync(localFilePath)) {
+            throw new Error(`File already exists: ${localFilePath}`);
+          }
 
           fs.writeFileSync(localFilePath, buffer);
 

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as fs from "fs";
+import * as path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { WorkItemExpand, WorkItemRelation } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
@@ -500,8 +502,9 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         if (revisions && Array.isArray(revisions)) {
           revisions.forEach((revision) => {
             if (revision.fields) {
-              Object.keys(revision.fields).forEach((fieldName) => {
-                const fieldValue = revision.fields ? revision.fields[fieldName] : undefined;
+              const fields = revision.fields;
+              Object.keys(fields).forEach((fieldName) => {
+                const fieldValue = fields[fieldName];
                 // Check if this is an identity object by looking for common identity properties
                 if (
                   fieldValue &&
@@ -1478,13 +1481,19 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     WORKITEM_TOOLS.get_work_item_attachment,
-    "Download a work item attachment by its ID and return the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
+    "Download a work item attachment by its ID. By default returns the content as a base64-encoded resource. If savePath is provided, saves the file locally to that directory and returns the file path instead. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs. If a project is not specified, you will be prompted to select one.",
     {
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       attachmentId: z.string().describe("The GUID of the attachment. Found in the attachment URL: https://dev.azure.com/{org}/{project}/_apis/wit/attachments/{attachmentId}"),
-      fileName: z.string().optional().describe("The file name of the attachment, e.g. 'screenshot.png'. Used to determine the MIME type for the returned resource."),
+      fileName: z.string().optional().describe("The file name of the attachment, e.g. 'screenshot.png'. Used to determine the MIME type or the saved file's name."),
+      savePath: z
+        .string()
+        .optional()
+        .describe(
+          "Optional local directory path where the file should be saved. If provided, saves the attachment to this directory and returns the file path. If omitted, returns the content as a base64-encoded resource."
+        ),
     },
-    async ({ project, attachmentId, fileName }) => {
+    async ({ project, attachmentId, fileName, savePath }) => {
       try {
         const connection = await connectionProvider();
 
@@ -1506,9 +1515,27 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         });
 
         const buffer = Buffer.concat(chunks);
-        const base64Data = buffer.toString("base64");
+
+        if (savePath) {
+          const resolvedFileName = fileName ?? attachmentId;
+          const localFilePath = path.join(savePath, resolvedFileName);
+
+          fs.writeFileSync(localFilePath, buffer);
+
+          return {
+            content: [{ type: "text", text: `Attachment saved to: ${localFilePath}` }],
+          };
+        }
+
         const mimeType = getMimeType(fileName);
 
+        if (mimeType.startsWith("text/")) {
+          return {
+            content: [{ type: "text", text: buffer.toString("utf-8") }],
+          };
+        }
+
+        const base64Data = buffer.toString("base64");
         return {
           content: [
             {
@@ -1544,6 +1571,15 @@ function getMimeType(fileName: string | undefined): string {
     webp: "image/webp",
     pdf: "application/pdf",
     txt: "text/plain",
+    md: "text/markdown",
+    markdown: "text/markdown",
+    csv: "text/csv",
+    html: "text/html",
+    htm: "text/html",
+    xml: "text/xml",
+    json: "application/json",
+    yaml: "text/yaml",
+    yml: "text/yaml",
     zip: "application/zip",
   };
   return (ext && mimeTypes[ext]) ?? "application/octet-stream";

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -6,7 +6,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { configureWorkItemTools } from "../../../src/tools/work-items";
 import { WebApi } from "azure-devops-node-api";
 import { Readable } from "stream";
+import * as fs from "fs";
+import * as path from "path";
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
+
+jest.mock("fs");
 import {
   _mockBacklogs,
   _mockQuery,
@@ -3887,6 +3891,103 @@ describe("configureWorkItemTools", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe("Error retrieving work item attachment: Not found");
+    });
+
+    it("should save file to disk and return path text when savePath is provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const fakeData = Buffer.from("fake-png-bytes");
+      mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
+      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "/tmp/attachments",
+      };
+
+      const result = await handler(params);
+
+      const expectedPath = path.join("/tmp/attachments", "screenshot.png");
+      expect(writeFileSyncMock).toHaveBeenCalledWith(expectedPath, fakeData);
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toBe(`Attachment saved to: ${expectedPath}`);
+
+      writeFileSyncMock.mockRestore();
+    });
+
+    it("should use attachmentId as filename when savePath is provided but fileName is omitted", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const fakeData = Buffer.from("binary-data");
+      mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
+      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+
+      const attachmentId = "12341234-1234-1234-1234-123412341234";
+      const params = {
+        project: "TestProject",
+        attachmentId,
+        savePath: "/tmp/attachments",
+      };
+
+      const result = await handler(params);
+
+      const expectedPath = path.join("/tmp/attachments", attachmentId);
+      expect(writeFileSyncMock).toHaveBeenCalledWith(expectedPath, fakeData);
+      expect(result.content[0].text).toBe(`Attachment saved to: ${expectedPath}`);
+
+      writeFileSyncMock.mockRestore();
+    });
+
+    it("should return text content for markdown files when savePath is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const markdownContent = "# Hello\n\nThis is a markdown file.";
+      const fakeData = Buffer.from(markdownContent, "utf-8");
+      mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
+
+      const result = await handler({
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "notes.md",
+      });
+
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toBe(markdownContent);
+    });
+
+    it("should return text content for plain text files when savePath is not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const textContent = "Hello, world!";
+      const fakeData = Buffer.from(textContent, "utf-8");
+      mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
+
+      const result = await handler({
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "readme.txt",
+      });
+
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toBe(textContent);
     });
   });
 

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3908,12 +3908,12 @@ describe("configureWorkItemTools", () => {
         project: "TestProject",
         attachmentId: "12341234-1234-1234-1234-123412341234",
         fileName: "screenshot.png",
-        savePath: "/tmp/attachments",
+        savePath: "downloads/attachments",
       };
 
       const result = await handler(params);
 
-      const expectedPath = path.join("/tmp/attachments", "screenshot.png");
+      const expectedPath = path.join("downloads/attachments", "screenshot.png");
       expect(writeFileSyncMock).toHaveBeenCalledWith(expectedPath, fakeData);
       expect(result.content[0].type).toBe("text");
       expect(result.content[0].text).toBe(`Attachment saved to: ${expectedPath}`);
@@ -3936,16 +3936,43 @@ describe("configureWorkItemTools", () => {
       const params = {
         project: "TestProject",
         attachmentId,
-        savePath: "/tmp/attachments",
+        savePath: "downloads/attachments",
       };
 
       const result = await handler(params);
 
-      const expectedPath = path.join("/tmp/attachments", attachmentId);
+      const expectedPath = path.join("downloads/attachments", attachmentId);
       expect(writeFileSyncMock).toHaveBeenCalledWith(expectedPath, fakeData);
       expect(result.content[0].text).toBe(`Attachment saved to: ${expectedPath}`);
 
       writeFileSyncMock.mockRestore();
+    });
+
+    it("should throw an error if the file already exists at the savePath", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const fakeData = Buffer.from("fake-png-bytes");
+      mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
+      jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "downloads/attachments",
+      };
+
+      const expectedPath = path.join("downloads/attachments", "screenshot.png");
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(`Error retrieving work item attachment: File already exists: ${expectedPath}`);
+
+      jest.restoreAllMocks();
     });
 
     it("should return text content for markdown files when savePath is not provided", async () => {
@@ -3988,6 +4015,96 @@ describe("configureWorkItemTools", () => {
 
       expect(result.content[0].type).toBe("text");
       expect(result.content[0].text).toBe(textContent);
+    });
+
+    it("should reject savePath with a Unix absolute path", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "/tmp/attachments",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid savePath: absolute paths and path traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject savePath with a Windows absolute path", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "C:\\temp\\attachments",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid savePath: absolute paths and path traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject savePath with path traversal segments", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "../../etc",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid savePath: absolute paths and path traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject savePath with a Windows drive-relative path", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "screenshot.png",
+        savePath: "D:attachments",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid savePath: absolute paths and path traversals are not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("should reject fileName with path traversal segments", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_get_work_item_attachment");
+      if (!call) throw new Error("wit_get_work_item_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const params = {
+        project: "TestProject",
+        attachmentId: "12341234-1234-1234-1234-123412341234",
+        fileName: "../../etc/passwd",
+        savePath: "downloads",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Invalid fileName: path traversal is not allowed.");
+      expect(connectionProvider).not.toHaveBeenCalled();
     });
   });
 

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3902,7 +3902,7 @@ describe("configureWorkItemTools", () => {
 
       const fakeData = Buffer.from("fake-png-bytes");
       mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
-      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
 
       const params = {
         project: "TestProject",
@@ -3930,7 +3930,7 @@ describe("configureWorkItemTools", () => {
 
       const fakeData = Buffer.from("binary-data");
       mockWorkItemTrackingApi.getAttachmentContent.mockResolvedValue(makeReadableStream(fakeData));
-      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+      const writeFileSyncMock = jest.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
 
       const attachmentId = "12341234-1234-1234-1234-123412341234";
       const params = {


### PR DESCRIPTION
This pull request enhances the functionality and documentation of the `mcp_ado_wit_get_work_item_attachment` tool, allowing users to either download attachments as base64-encoded strings or save them directly to disk. It also improves MIME type detection for attachments and adds comprehensive tests for the new behaviors.

## GitHub issue number
#1148

## **Associated Risks**

None. Fall back to old way if needed.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual testing and updated auto tests
