### PR TITLE
fix(testplan): remove quotes around Outcome enum values in OData filter

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -429,7 +429,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         const testResultsApi = await connection.getTestResultsApi();
 
         // Build filter expression for outcomes if specified
-        const outcomeFilter = outcomes?.map((o) => `Outcome eq '${o}'`).join(" or ");
+        const outcomeFilter = outcomes?.map((o) => `Outcome eq ${o}`).join(" or ");
 
         // Fetch test result details for the build in a single API call
         // This is more efficient than getTestRuns + getTestResults per run,


### PR DESCRIPTION
## Summary
- Remove single quotes around Outcome enum values in OData filter for testplan_show_test_results_from_build_id

## Why
Issue #1129: The current filter `Outcome eq '${o}'` uses quotes around enum values, but Azure DevOps OData API rejects quoted enum types. Removing quotes `Outcome eq ${o}` fixes the query.

## Validation
- [x] Code review confirmed fix correctness
- [x] Branch pushed to fork