### PR TITLE
fix(work-items): use "Wiki Page" as attributes.name for Wiki artifact links

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -67,6 +67,29 @@ function getLinkTypeFromName(name: string) {
   }
 }
 
+/**
+ * Maps the user-facing `linkType` enum accepted by wit_add_artifact_link to
+ * the `attributes.name` value that Azure DevOps expects on the ArtifactLink
+ * relation.
+ *
+ * Most link types are 1:1 (e.g. "Branch" -> "Branch", "Pull Request" ->
+ * "Pull Request"). The exception is wiki pages: the MCP tool exposes them as
+ * `linkType: "Wiki"` for discoverability, but Azure DevOps' relation
+ * attribute name is `"Wiki Page"`. Using anything else produces a
+ * TF401028 "Unrecognized Resource link" rejection from the REST API.
+ *
+ * Keep this map narrow on purpose: only override when the ADO-required name
+ * differs from the enum value, so unexpected values pass through unchanged.
+ */
+function getArtifactLinkAttributeName(linkType: string): string {
+  switch (linkType) {
+    case "Wiki":
+      return "Wiki Page";
+    default:
+      return linkType;
+  }
+}
+
 function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     WORKITEM_TOOLS.list_backlogs,
@@ -1387,7 +1410,15 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           }
         }
 
-        // Create the patch document for adding an artifact link relation
+        // Create the patch document for adding an artifact link relation.
+        //
+        // The `attributes.name` field must match Azure DevOps' internal link
+        // category name, which is NOT always the same as the user-facing
+        // `linkType` enum value. For example, a wiki page link renders under
+        // the "Wiki Page" category on the work item, not "Wiki". Passing the
+        // enum value verbatim for mismatched types produces a
+        // TF401028 "Unrecognized Resource link" rejection from the REST API.
+        // See getArtifactLinkAttributeName for the full mapping.
         const patchDocument = [
           {
             op: "add",
@@ -1396,7 +1427,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               rel: "ArtifactLink",
               url: finalArtifactUri,
               attributes: {
-                name: linkType,
+                name: getArtifactLinkAttributeName(linkType),
                 ...(comment && { comment }),
               },
             },

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3795,6 +3795,56 @@ describe("configureWorkItemTools", () => {
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toBe("Work item update failed");
       });
+
+      it("should emit attributes.name = 'Wiki Page' for Wiki linkType", async () => {
+        // Regression test: Azure DevOps rejects the ArtifactLink relation with
+        // TF401028 "Unrecognized Resource link" unless the attribute name is
+        // the exact category name "Wiki Page" — not the enum value "Wiki".
+        configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+        if (!call) throw new Error("wit_add_artifact_link tool not registered");
+        const [, , , handler] = call;
+
+        const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
+        mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
+
+        const wikiUri = "vstfs:///Wiki/WikiPage/12341234-1234-1234-1234-123412341234%2F56785678-5678-5678-5678-567856785678%2FFeatures/MyFeature";
+
+        const params = {
+          workItemId: 1234,
+          project: "TestProject",
+          artifactUri: wikiUri,
+          linkType: "Wiki",
+          comment: "Feature spec",
+        };
+
+        const result = await handler(params);
+
+        expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
+          {},
+          [
+            {
+              op: "add",
+              path: "/relations/-",
+              value: {
+                rel: "ArtifactLink",
+                url: wikiUri,
+                attributes: {
+                  name: "Wiki Page",
+                  comment: "Feature spec",
+                },
+              },
+            },
+          ],
+          1234,
+          "TestProject"
+        );
+
+        const response = JSON.parse(result.content[0].text);
+        expect(response.success).toBe(true);
+        expect(response.linkType).toBe("Wiki");
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

`wit_add_artifact_link` currently fails for every call with `linkType: "Wiki"` because it writes `attributes.name: "Wiki"` on the ArtifactLink relation, but Azure DevOps expects the internal category name `"Wiki Page"`. The REST API rejects the PATCH with `TF401028 Unrecognized Resource link`, so wiki pages can never be linked to work items via this tool today.

This PR:

1. Adds a narrow `getArtifactLinkAttributeName()` helper that maps `"Wiki"` -> `"Wiki Page"` and lets every other enum value pass through unchanged.
2. Uses that helper when building the PATCH document, so the relation payload matches what ADO expects on the wire.
3. Adds a regression test for the Wiki case that asserts the exact shape of the ArtifactLink relation (`attributes.name: "Wiki Page"`).

Behaviour for every other supported `linkType` (`Branch`, `Pull Request`, `Fixed in Commit`, `Build`, `Found in build`, `Integrated in build`, etc.) is unchanged — the existing tests continue to assert `attributes.name: "<enum value>"` and all still pass.

## Reproducer (before the fix)

```ts
wit_add_artifact_link({
  workItemId: 1245913,
  project: "Payoneer",
  // valid vstfs URI for a wiki page
  artifactUri: "vstfs:///Wiki/WikiPage/<projectId>%2F<wikiId>%2F<pagePath>",
  linkType: "Wiki",
  comment: "Feature spec"
})
// -> TF401028 Unrecognized Resource link
```

With this patch applied the same call succeeds and the wiki page shows up under the **Development / Wiki Page** section of the work item, matching the behaviour the user sees when they add a wiki link through the Azure DevOps web UI.

## Why only `"Wiki"` is mapped

I deliberately kept the switch narrow. All other values in the `linkType` enum (`Branch`, `Build`, `Fixed in Commit`, `Fixed in Changeset`, `Found in build`, `Integrated in build`, `Model Link`, `Pull Request`, `Related Workitem`, `Result Attachment`, `Source Code File`, `Tag`, `Test Result`) are already exercised by existing tests that assert `attributes.name === "<enum value>"`, and the REST API accepts those names as-is. Forcing a full renaming table would be riskier than the bug it fixes. The `default` branch preserves today's behaviour for any value not explicitly remapped.

If future reports show the same category-name mismatch for another type (e.g. `Related Workitem`, which is arguably not even an artifact link), it can be added to the same switch in a follow-up.

## Test plan

- [x] `npx jest --testPathPatterns=work-items` — **188/188 passing**, including the new `should emit attributes.name = 'Wiki Page' for Wiki linkType` regression test.
- [x] `work-items.ts` coverage: 100% stmts / 100% funcs / 100% lines / 99.65% branches (unchanged).
- [x] `npx prettier --write` and `npx eslint` on both touched files — clean.
- [x] `tsc` via `npm run build` — clean.
- [x] Manual repro against a live Azure DevOps project: a Wiki ArtifactLink was successfully created and is visible on the work item's Development / Wiki Page section, matching the manual "Add link -> Wiki page" flow from the ADO web UI.

## Files changed

- `src/tools/work-items.ts` — new `getArtifactLinkAttributeName` helper; wired into the PATCH document construction.
- `test/src/tools/work-items.test.ts` — new regression test for Wiki linkType.

Made with [Cursor](https://cursor.com)