### PR TITLE
Fix test result outcome filtering

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -428,6 +428,10 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         const connection = await connectionProvider();
         const testResultsApi = await connection.getTestResultsApi();
 
+        // Build filter expression for outcomes if specified.
+        // The API accepts: Outcome eq Failed,Passed (unquoted, comma-separated)
+        const outcomeFilter = outcomes?.length ? `Outcome eq ${outcomes.join(",")}` : undefined;
+
         // Fetch test result details for the build in a single API call
         // This is more efficient than getTestRuns + getTestResults per run,
         // especially for builds with many test runs (e.g., cloud testing with one run per test case)
@@ -436,7 +440,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
           buildid,
           undefined, // publishContext
           undefined, // groupBy
-          undefined, // filter
+          outcomeFilter, // filter by outcome
           undefined, // orderby
           true // shouldIncludeResults - get individual test results, not just aggregates
         );
@@ -452,20 +456,17 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         }
 
         // Format results to extract useful fields
-        const outcomeFilter = outcomes?.length ? new Set(outcomes.map((outcome) => outcome.toLowerCase())) : undefined;
-        const formattedResults = allResults
-          .filter((r) => !outcomeFilter || (typeof r.outcome === "string" && outcomeFilter.has(r.outcome.toLowerCase())))
-          .map((r) => ({
-            id: r.id,
-            testCaseTitle: r.testCaseTitle,
-            outcome: r.outcome,
-            errorMessage: r.errorMessage,
-            stackTrace: r.stackTrace,
-            automatedTestName: r.automatedTestName,
-            automatedTestStorage: r.automatedTestStorage,
-            durationInMs: r.durationInMs,
-            runId: r.testRun?.id,
-          }));
+        const formattedResults = allResults.map((r) => ({
+          id: r.id,
+          testCaseTitle: r.testCaseTitle,
+          outcome: r.outcome,
+          errorMessage: r.errorMessage,
+          stackTrace: r.stackTrace,
+          automatedTestName: r.automatedTestName,
+          automatedTestStorage: r.automatedTestStorage,
+          durationInMs: r.durationInMs,
+          runId: r.testRun?.id,
+        }));
 
         return {
           content: [{ type: "text", text: JSON.stringify(formattedResults, null, 2) }],

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -428,9 +428,6 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         const connection = await connectionProvider();
         const testResultsApi = await connection.getTestResultsApi();
 
-        // Build filter expression for outcomes if specified
-        const outcomeFilter = outcomes?.map((o) => `Outcome eq '${o}'`).join(" or ");
-
         // Fetch test result details for the build in a single API call
         // This is more efficient than getTestRuns + getTestResults per run,
         // especially for builds with many test runs (e.g., cloud testing with one run per test case)
@@ -439,7 +436,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
           buildid,
           undefined, // publishContext
           undefined, // groupBy
-          outcomeFilter, // filter by outcome
+          undefined, // filter
           undefined, // orderby
           true // shouldIncludeResults - get individual test results, not just aggregates
         );
@@ -455,17 +452,20 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         }
 
         // Format results to extract useful fields
-        const formattedResults = allResults.map((r) => ({
-          id: r.id,
-          testCaseTitle: r.testCaseTitle,
-          outcome: r.outcome,
-          errorMessage: r.errorMessage,
-          stackTrace: r.stackTrace,
-          automatedTestName: r.automatedTestName,
-          automatedTestStorage: r.automatedTestStorage,
-          durationInMs: r.durationInMs,
-          runId: r.testRun?.id,
-        }));
+        const outcomeFilter = outcomes?.length ? new Set(outcomes.map((outcome) => outcome.toLowerCase())) : undefined;
+        const formattedResults = allResults
+          .filter((r) => !outcomeFilter || (typeof r.outcome === "string" && outcomeFilter.has(r.outcome.toLowerCase())))
+          .map((r) => ({
+            id: r.id,
+            testCaseTitle: r.testCaseTitle,
+            outcome: r.outcome,
+            errorMessage: r.errorMessage,
+            stackTrace: r.stackTrace,
+            automatedTestName: r.automatedTestName,
+            automatedTestStorage: r.automatedTestStorage,
+            durationInMs: r.durationInMs,
+            runId: r.testRun?.id,
+          }));
 
         return {
           content: [{ type: "text", text: JSON.stringify(formattedResults, null, 2) }],

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -745,7 +745,7 @@ describe("configureTestPlanTools", () => {
       expect(parsed[1].outcome).toBe("Passed");
     });
 
-    it("should pass outcome filter expression for server-side filtering", async () => {
+    it("should filter outcomes after fetching test results", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
@@ -754,22 +754,29 @@ describe("configureTestPlanTools", () => {
       (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
         resultsForGroup: [
           {
-            results: [{ id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" }],
+            results: [
+              { id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" },
+              { id: 2, testCaseTitle: "PassingTest", outcome: "Passed" },
+              { id: 3, testCaseTitle: "AbortedTest", outcome: "Aborted" },
+            ],
           },
         ],
       });
 
-      await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
+      const result = await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
 
       expect(mockTestResultsApi.getTestResultDetailsForBuild).toHaveBeenCalledWith(
         "proj1",
         123,
         undefined, // publishContext
         undefined, // groupBy
-        "Outcome eq 'Failed' or Outcome eq 'Aborted'", // filter expression
+        undefined, // filter
         undefined, // orderby
         true // shouldIncludeResults
       );
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed.map((r: { outcome: string }) => r.outcome)).toEqual(["Failed", "Aborted"]);
     });
 
     it("should handle API errors when fetching test results", async () => {

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -745,38 +745,27 @@ describe("configureTestPlanTools", () => {
       expect(parsed[1].outcome).toBe("Passed");
     });
 
-    it("should filter outcomes after fetching test results", async () => {
+    it("should pass outcome filter expression for server-side filtering", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
       if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
       const [, , , handler] = call;
 
       (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
-        resultsForGroup: [
-          {
-            results: [
-              { id: 1, testCaseTitle: "FailingTest", outcome: "Failed", errorMessage: "error" },
-              { id: 2, testCaseTitle: "PassingTest", outcome: "Passed" },
-              { id: 3, testCaseTitle: "AbortedTest", outcome: "Aborted" },
-            ],
-          },
-        ],
+        resultsForGroup: [],
       });
 
-      const result = await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
+      await handler({ project: "proj1", buildid: 123, outcomes: ["Failed", "Aborted"] });
 
       expect(mockTestResultsApi.getTestResultDetailsForBuild).toHaveBeenCalledWith(
         "proj1",
         123,
         undefined, // publishContext
         undefined, // groupBy
-        undefined, // filter
+        "Outcome eq Failed,Aborted", // filter expression
         undefined, // orderby
         true // shouldIncludeResults
       );
-      const parsed = JSON.parse(result.content[0].text);
-      expect(parsed).toHaveLength(2);
-      expect(parsed.map((r: { outcome: string }) => r.outcome)).toEqual(["Failed", "Aborted"]);
     });
 
     it("should handle API errors when fetching test results", async () => {


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1129

Avoid sending the invalid Azure DevOps result-details `$filter` expression for `outcomes` in `testplan_show_test_results_from_build_id`.

The current implementation builds an expression like:

```text
Outcome eq 'Failed' or Outcome eq 'Aborted'
```

Azure DevOps rejects this for the result-details endpoint, this is what I got in Copilot:

```text
Tool: ado-dnceng-testplan_show_test_results_from_build_id
Args: { "project": "internal", "buildid": 2952924, "outcomes": ["Failed"] }
Result: Error fetching test results: Argument filter with value Outcome eq 'Failed' is not correct.
```

## Cause

This is because of a  bug in test-plans.ts, where it assumed values should be quoted and joined with "or" when what actually is expected by the API is unquoted and joined with comma:
https://github.com/microsoft/azure-devops-mcp/blob/main/src/tools/test-plans.ts#L431-L432

Proof -- this [example working URL](https://vstmr.dev.azure.com/dnceng-public/public/_apis/testresults/resultdetailsbybuild?buildId=1396794&publishContext=CI&groupBy=TestRun&%24filter=Outcome%20eq%20Failed%2CPassed&%24orderby=&shouldIncludeResults=true&queryRunSummaryForInProgress=false) filters for "failed or passed" and contains `Outcome%20eq%20Failed%2CPassed` ie unquoted comma separated.

## GitHub issue number

#1129

## **Associated Risks**

Relies on the filter syntax, which is not well (or at all?) documented, however the existing code already relies on this. Plus, this repo is owned by the Azure Devops team, who can presumably be confident of what is OK to rely on.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/test-plan.test.ts --runInBand`
- `npm run validate-tools`

