### PR TITLE
Avoid stack overflow flattening test results

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -449,7 +449,9 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
         if (testResultDetails.resultsForGroup) {
           for (const group of testResultDetails.resultsForGroup) {
             if (group.results) {
-              allResults.push(...group.results);
+              for (const result of group.results) {
+                allResults.push(result);
+              }
             }
           }
         }

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -848,6 +848,30 @@ describe("configureTestPlanTools", () => {
       });
     });
 
+    it("should handle large result groups without spreading them onto the stack", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      const largeResults = Array.from({ length: 150_000 }, (_, id) => ({
+        id,
+        testCaseTitle: `Test ${id}`,
+        outcome: "Passed",
+      }));
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [{ results: largeResults }],
+      });
+
+      const result = await handler({ project: "proj1", buildid: 456 });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(largeResults.length);
+      expect(parsed[0].testCaseTitle).toBe("Test 0");
+      expect(parsed[largeResults.length - 1].testCaseTitle).toBe("Test 149999");
+    });
+
     it("should handle empty results groups without errors", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1179

Avoid stack overflow when flattening large result groups in `testplan_show_test_results_from_build_id`.

The previous implementation used:

```ts
allResults.push(...group.results)
```

For very large result groups, that spreads every result as a function argument and can exceed JavaScript engine argument limits, throwing `Maximum call stack size exceeded`:
```
Tool: ado-dnceng-public-testplan_show_test_results_from_build_id
Args: { "project": "public", "buildid": 1395596 }
Result: MCP server 'ado-dnceng-public': Error fetching test results: Maximum call stack size exceeded
```

This PR changes the flattening to iterate results and push one item at a time. The structure of the JSON is not changed -- it's the same structure the code would produce if it didn't stack overflow the engine by using spread.

## GitHub issue number

#1179

## **Associated Risks**

This is intended to be behavior-preserving except for avoiding the spread/argument-limit failure. It does not otherwise change result fetching or output shape.
Returning very large output successfully may now expose a limitation elsewhere.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/test-plan.test.ts --runInBand`
- `npm run validate-tools`

