### PR TITLE
Handle missing pull request thread arrays

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -762,17 +762,17 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
 
-        const threads = await gitApi.getThreads(repositoryId, pullRequestId, project, iteration, baseIteration);
+        const threads = (await gitApi.getThreads(repositoryId, pullRequestId, project, iteration, baseIteration)) ?? [];
 
         let filteredThreads = threads;
 
         if (status !== undefined) {
           const statusValue = CommentThreadStatus[status as keyof typeof CommentThreadStatus];
-          filteredThreads = filteredThreads?.filter((thread) => thread.status === statusValue);
+          filteredThreads = filteredThreads.filter((thread) => thread.status === statusValue);
         }
 
         if (authorEmail !== undefined) {
-          filteredThreads = filteredThreads?.filter((thread) => {
+          filteredThreads = filteredThreads.filter((thread) => {
             const firstComment = thread.comments?.[0];
             return firstComment?.author?.uniqueName?.toLowerCase() === authorEmail.toLowerCase();
           });
@@ -780,13 +780,13 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
         if (authorDisplayName !== undefined) {
           const lowerAuthorName = authorDisplayName.toLowerCase();
-          filteredThreads = filteredThreads?.filter((thread) => {
+          filteredThreads = filteredThreads.filter((thread) => {
             const firstComment = thread.comments?.[0];
             return firstComment?.author?.displayName?.toLowerCase().includes(lowerAuthorName);
           });
         }
 
-        const paginatedThreads = filteredThreads?.sort((a, b) => (a.id ?? 0) - (b.id ?? 0)).slice(skip, skip + top);
+        const paginatedThreads = filteredThreads.sort((a, b) => (a.id ?? 0) - (b.id ?? 0)).slice(skip, skip + top);
 
         if (fullResponse) {
           return {
@@ -795,7 +795,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         }
 
         // Return trimmed thread data focusing on essential information
-        const trimmedThreads = paginatedThreads?.map((thread) => trimPullRequestThread(thread));
+        const trimmedThreads = paginatedThreads.map((thread) => trimPullRequestThread(thread));
 
         return {
           content: [{ type: "text", text: JSON.stringify(trimmedThreads, null, 2) }],

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -2612,6 +2612,49 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(mockThreads, null, 2));
     });
 
+    it("should return an empty array when no pull request threads are returned", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      mockGitApi.getThreads.mockResolvedValue(undefined);
+
+      const result = await handler({
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        top: 100,
+        skip: 0,
+      });
+
+      expect(mockGitApi.getThreads).toHaveBeenCalledWith("repo123", 456, undefined, undefined, undefined);
+      expect(result).not.toHaveProperty("isError");
+      expect(result.content[0].text).toBe(JSON.stringify([], null, 2));
+    });
+
+    it("should return an empty full response when no pull request threads are returned", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_request_threads);
+      if (!call) throw new Error("repo_list_pull_request_threads tool not registered");
+      const [, , , handler] = call;
+
+      mockGitApi.getThreads.mockResolvedValue(undefined);
+
+      const result = await handler({
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        fullResponse: true,
+        top: 100,
+        skip: 0,
+      });
+
+      expect(mockGitApi.getThreads).toHaveBeenCalledWith("repo123", 456, undefined, undefined, undefined);
+      expect(result).not.toHaveProperty("isError");
+      expect(result.content[0].text).toBe(JSON.stringify([], null, 2));
+    });
+
     it("should filter threads by status (Active)", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1180

Normalize missing pull request thread responses in `repo_list_pull_request_threads`.

If `gitApi.getThreads(...)` returns `undefined`, `JSON.stringify(undefined)` also returns `undefined`, which can produce an invalid MCP tool result because `content[0].text` must be a string, from Copilot here:

```text
Tool: ado-dnceng-repo_list_pull_request_threads
Args: { "repositoryId": "copilot-agent-runtime", "project": "copilot-agent-runtime", "pullRequestId": 6536, "status": "Active" }
Result: Invalid tools/call result ... content[0].text expected string, received undefined
```
 This PR normalizes missing thread responses to `[]` and keeps the rest of the filtering/paging/mapping logic array-based.

## GitHub issue number

#1180

## **Associated Risks**

Low. The intended behavior for a missing thread array is to return an empty JSON array rather than an invalid MCP result shape.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/repositories.test.ts --runInBand`
- `npm run validate-tools`

