### PR TITLE
Harden artifact download path validation

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -229,7 +229,7 @@ Lists artifacts for a given build.
 Downloads a pipeline artifact.
 
 - **Required**: `project`, `buildId`, `artifactName`
-- **Optional**: `destinationPath`
+- **Optional**: `destinationPath` (relative local path; absolute paths and path traversal are not allowed)
 
 ## Repositories
 

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -537,18 +537,20 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       project: z.string().describe("The name or ID of the project."),
       buildId: z.coerce.number().min(1).describe("The ID of the build."),
       artifactName: z.string().describe("The name of the artifact to download."),
-      destinationPath: z.string().optional().describe("The local path to download the artifact to. If not provided, returns binary content as base64."),
+      destinationPath: z.string().optional().describe("The relative local path to download the artifact to. If not provided, returns binary content as base64."),
     },
     async ({ project, buildId, artifactName, destinationPath }) => {
-      const isAbsolutePath = (value: string) => posix.isAbsolute(value) || win32.isAbsolute(value);
+      const hasUnsafePathSegment = (value: string) => value.split(/[\\/]+/).some((segment) => segment === "." || segment === "..");
+      const hasPathSeparators = (value: string) => /[\\/]/.test(value);
       const hasDriveLetter = (value: string) => /^[a-zA-Z]:/.test(value);
+      const isAbsolutePath = (value: string) => posix.isAbsolute(value) || win32.isAbsolute(value);
 
-      if (artifactName.includes("..")) {
-        throw new Error("Invalid artifactName: path traversal is not allowed.");
+      if (hasUnsafePathSegment(artifactName) || hasPathSeparators(artifactName) || hasDriveLetter(artifactName) || isAbsolutePath(artifactName)) {
+        throw new Error("Invalid artifactName: artifactName must be a file name, not a path.");
       }
 
-      if (destinationPath && (destinationPath.includes("..") || isAbsolutePath(destinationPath) || hasDriveLetter(destinationPath))) {
-        throw new Error("Invalid destinationPath: absolute paths and path traversals are not allowed.");
+      if (destinationPath && (hasUnsafePathSegment(destinationPath) || isAbsolutePath(destinationPath) || hasDriveLetter(destinationPath))) {
+        throw new Error("Invalid destinationPath: use a relative path without path traversal.");
       }
 
       const connection = await connectionProvider();

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -532,7 +532,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
 
   server.tool(
     PIPELINE_TOOLS.pipelines_download_artifact,
-    "Downloads a pipeline artifact.",
+    "Downloads a pipeline artifact. When destinationPath is provided, it must be a relative local path; absolute paths and path traversal are not allowed.",
     {
       project: z.string().describe("The name or ID of the project."),
       buildId: z.coerce.number().min(1).describe("The ID of the build."),

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1507,7 +1507,7 @@ describe("configurePipelineTools", () => {
         destinationPath: "C:\\temp\\artifacts",
       };
 
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: use a relative path without path traversal.");
       expect(connectionProvider).not.toHaveBeenCalled();
     });
 
@@ -1524,7 +1524,7 @@ describe("configurePipelineTools", () => {
         destinationPath: "/tmp/artifacts",
       };
 
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: use a relative path without path traversal.");
       expect(connectionProvider).not.toHaveBeenCalled();
     });
 
@@ -1541,11 +1541,18 @@ describe("configurePipelineTools", () => {
         destinationPath: "..\\..\\temp\\artifacts",
       };
 
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: use a relative path without path traversal.");
       expect(connectionProvider).not.toHaveBeenCalled();
     });
 
-    it("should reject artifactName with path traversal segments", async () => {
+    it.each([
+      ["path traversal segments", "..\\..\\drop"],
+      ["Windows path separators", "folder\\drop"],
+      ["Unix path separators", "folder/drop"],
+      ["Windows absolute path", "C:\\temp\\drop"],
+      ["Unix absolute path", "/tmp/drop"],
+      ["current directory segment", "."],
+    ])("should reject artifactName with %s", async (_description, artifactName) => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
       if (!call) throw new Error("pipelines_download_artifact tool not registered");
@@ -1554,15 +1561,25 @@ describe("configurePipelineTools", () => {
       const params = {
         project: "test-project",
         buildId: 12345,
-        artifactName: "..\\..\\drop",
+        artifactName,
         destinationPath: "temp\\artifacts",
       };
 
-      await expect(handler(params)).rejects.toThrow("Invalid artifactName: path traversal is not allowed.");
+      await expect(handler(params)).rejects.toThrow("Invalid artifactName: artifactName must be a file name, not a path.");
       expect(connectionProvider).not.toHaveBeenCalled();
     });
 
-    it("should reject destinationPath with a Windows drive-relative path", async () => {
+    it.each([
+      ["Windows drive-relative path", "D:artifacts"],
+      ["Windows drive-relative path with subdirectory", "E:sub\\deep"],
+      ["only a drive letter and colon", "D:"],
+      ["Windows root-relative path", "\\temp\\artifacts"],
+      ["Windows UNC path", "\\\\server\\share\\artifacts"],
+      ["Windows extended-length path", "\\\\?\\C:\\temp\\artifacts"],
+      ["segment-level traversal", "temp\\..\\artifacts"],
+      ["current directory segment", "."],
+      ["segment-level current directory", "temp\\.\\artifacts"],
+    ])("should reject destinationPath with %s", async (_description, destinationPath) => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
       if (!call) throw new Error("pipelines_download_artifact tool not registered");
@@ -1572,44 +1589,10 @@ describe("configurePipelineTools", () => {
         project: "test-project",
         buildId: 12345,
         artifactName: "drop",
-        destinationPath: "D:artifacts",
+        destinationPath,
       };
 
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
-      expect(connectionProvider).not.toHaveBeenCalled();
-    });
-
-    it("should reject destinationPath with a drive-relative path with subdirectory", async () => {
-      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
-      if (!call) throw new Error("pipelines_download_artifact tool not registered");
-      const [, , , handler] = call;
-
-      const params = {
-        project: "test-project",
-        buildId: 12345,
-        artifactName: "drop",
-        destinationPath: "E:sub\\deep",
-      };
-
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
-      expect(connectionProvider).not.toHaveBeenCalled();
-    });
-
-    it("should reject destinationPath with only a drive letter and colon", async () => {
-      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_download_artifact");
-      if (!call) throw new Error("pipelines_download_artifact tool not registered");
-      const [, , , handler] = call;
-
-      const params = {
-        project: "test-project",
-        buildId: 12345,
-        artifactName: "drop",
-        destinationPath: "D:",
-      };
-
-      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: absolute paths and path traversals are not allowed.");
+      await expect(handler(params)).rejects.toThrow("Invalid destinationPath: use a relative path without path traversal.");
       expect(connectionProvider).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1181

Clarify and harden path validation for `pipelines_download_artifact`.

The tool rejects absolute `destinationPath` values, but agents primarily see runtime MCP tool descriptions rather than repository docs. In Copilot CLI I got
```text
Tool: ado-dnceng-public-pipelines_download_artifact
Args: { "project": "public", "buildId": 1395596, "artifactName": "Windows_NT_Libraries Test Run release coreclr windows x86 Release_Attempt1", "destinationPath": "C:\\temp\\runtime-127406-testresults" }
Result: Invalid destinationPath: absolute paths and path traversals are not allowed.
```

This PR makes the relative-only requirement visible in both the top-level tool description and the `destinationPath` parameter description.

It also strengthens validation by treating `artifactName` as a name rather than a path and rejecting path separators, absolute paths, drive-letter syntax, and `.`/`..` path segments.

## GitHub issue number

#1181

## **Associated Risks**

This intentionally keeps absolute `destinationPath` values rejected to avoid arbitrary local write locations. Agents that currently pass absolute paths will receive a clearer pre-call schema description and a clearer validation error.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/pipelines.test.ts --runInBand`
- `npm run validate-tools`

