### PR TITLE
fix: set isError:true when ADO API returns error stream for missing resources

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -27,7 +27,7 @@ import { z } from "zod";
 import { getCurrentUserDetails, getUserIdFromEmail } from "./auth.js";
 import { GitRepository } from "azure-devops-node-api/interfaces/TfvcInterfaces.js";
 import { WebApiTagDefinition } from "azure-devops-node-api/interfaces/CoreInterfaces.js";
-import { getEnumKeys, streamToString } from "../utils.js";
+import { extractAdoStreamError, getEnumKeys, streamToString } from "../utils.js";
 
 const REPO_TOOLS = {
   list_repos_by_project: "repo_list_repos_by_project",
@@ -2105,6 +2105,14 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         );
 
         const content = await streamToString(stream);
+
+        const streamError = extractAdoStreamError(content);
+        if (streamError) {
+          return {
+            content: [{ type: "text", text: `Error getting file content for '${path}': ${streamError}` }],
+            isError: true,
+          };
+        }
 
         return {
           content: [{ type: "text", text: content }],

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -5,7 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { z } from "zod";
 import { WikiPagesBatchRequest } from "azure-devops-node-api/interfaces/WikiInterfaces.js";
-import { apiVersion } from "../utils.js";
+import { apiVersion, extractAdoStreamError } from "../utils.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 
 const WIKI_TOOLS = {
@@ -266,6 +266,14 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
             return { content: [{ type: "text", text: "No wiki page content found" }], isError: true };
           }
           pageContent = await streamToString(stream);
+
+          const streamError = extractAdoStreamError(pageContent);
+          if (streamError) {
+            return {
+              content: [{ type: "text", text: `Error fetching wiki page content: ${streamError}` }],
+              isError: true,
+            };
+          }
         }
 
         return createExternalContentResponse(pageContent, "wiki page");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,29 @@ export function encodeFormattedValue(value: string, format?: "Markdown" | "Html"
 }
 
 /**
+ * Detects whether a string returned from an ADO API stream is actually an error
+ * response serialized as JSON (e.g. a 404 GitItemNotFoundException or
+ * WikiPageNotFoundException) rather than real content.
+ *
+ * The ADO Node API client swallows non-2xx HTTP responses and delivers the
+ * error body as a stream, so callers must check explicitly after reading.
+ *
+ * @returns The human-readable error message extracted from the JSON, or null if
+ *          the content is not an ADO error response.
+ */
+export function extractAdoStreamError(content: string): string | null {
+  try {
+    const json = JSON.parse(content.trim());
+    if (json && typeof json.typeName === "string" && typeof json.message === "string") {
+      return json.message;
+    }
+  } catch {
+    // Not JSON — not an ADO error response.
+  }
+  return null;
+}
+
+/**
  * Convert a Node.js ReadableStream to a string.
  * Shared utility for consistent stream handling across tools.
  */

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -7892,7 +7892,51 @@ describe("repos tools", () => {
       });
     });
 
-    describe("repo_get_file_content isError on ADO error stream", () => {
+    describe("repo_get_file_content", () => {
+      it("returns file content on success", async () => {
+        configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_file_content);
+        if (!call) throw new Error("repo_get_file_content tool not registered");
+        const [, , , handler] = call;
+
+        const fileContent = "# Hello World\nThis is a test file.";
+        const { Readable } = await import("stream");
+        const contentStream = new Readable();
+        contentStream.push(fileContent);
+        contentStream.push(null);
+
+        mockGitApi.getItemText.mockResolvedValue(contentStream);
+
+        const result = await handler({
+          repositoryId: "test-repo",
+          path: "README.md",
+          project: "test-project",
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(result.content[0].text).toBe(fileContent);
+      });
+
+      it("returns isError: true when getItemText throws", async () => {
+        configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_file_content);
+        if (!call) throw new Error("repo_get_file_content tool not registered");
+        const [, , , handler] = call;
+
+        mockGitApi.getItemText.mockRejectedValue(new Error("Network error"));
+
+        const result = await handler({
+          repositoryId: "test-repo",
+          path: "README.md",
+          project: "test-project",
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Network error");
+      });
+
       it("returns isError: true when getItemText stream contains ADO error JSON (e.g. file not found)", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -7891,5 +7891,43 @@ describe("repos tools", () => {
         });
       });
     });
+
+    describe("repo_get_file_content isError on ADO error stream", () => {
+      it("returns isError: true when getItemText stream contains ADO error JSON (e.g. file not found)", async () => {
+        configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.get_file_content);
+        if (!call) throw new Error("repo_get_file_content tool not registered");
+        const [, , , handler] = call;
+
+        const adoErrorBody = JSON.stringify({
+          $id: "1",
+          innerException: null,
+          message: "The file 'nonexistent.md' does not exist in the repository.",
+          typeName: "Microsoft.TeamFoundation.Git.Server.GitItemNotFoundException",
+          typeKey: "GitItemNotFoundException",
+          errorCode: 0,
+          eventId: 3000,
+        });
+
+        const { Readable } = await import("stream");
+        const errorStream = new Readable();
+        errorStream.push(adoErrorBody);
+        errorStream.push(null);
+
+        mockGitApi.getItemText.mockResolvedValue(errorStream);
+
+        const params = {
+          repositoryId: "test-repo",
+          path: "nonexistent.md",
+          project: "test-project",
+        };
+
+        const result = await handler(params);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("The file 'nonexistent.md' does not exist in the repository.");
+      });
+    });
   });
 });

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -924,6 +924,37 @@ describe("configureWikiTools", () => {
         expect(calledUrl).toContain(encodeURIComponent("../../_apis/connectionData"));
       }
     });
+
+    it("should return isError: true when getPageText stream contains an ADO error JSON (e.g. page not found)", async () => {
+      configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
+      if (!call) throw new Error("wiki_get_page_content tool not registered");
+      const [, , , handler] = call;
+
+      const adoErrorBody = JSON.stringify({
+        $id: "1",
+        innerException: null,
+        message: "Page '/nonexistent' does not exist in wiki 'my-wiki'",
+        typeName: "Microsoft.TeamFoundation.Wiki.Server.WikiPageNotFoundException",
+        typeKey: "WikiPageNotFoundException",
+        errorCode: 0,
+        eventId: 3000,
+      });
+      const mockStream = {
+        setEncoding: jest.fn(),
+        on: function (event: string, cb: (chunk?: unknown) => void) {
+          if (event === "data") setImmediate(() => cb(adoErrorBody));
+          if (event === "end") setImmediate(() => cb());
+          return this;
+        },
+      };
+      mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
+
+      const result = await handler({ wikiIdentifier: "my-wiki", project: "proj1", path: "/nonexistent" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Page '/nonexistent' does not exist in wiki 'my-wiki'");
+    });
   });
 
   describe("create_or_update_page tool", () => {

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AlertType, AlertValidityStatus, Confidence, Severity, State } from "azure-devops-node-api/interfaces/AlertInterfaces";
-import { createEnumMapping, encodeFormattedValue, getEnumKeys, mapStringArrayToEnum, mapStringToEnum, safeEnumConvert } from "../../src/utils";
+import { createEnumMapping, encodeFormattedValue, extractAdoStreamError, getEnumKeys, mapStringArrayToEnum, mapStringToEnum, safeEnumConvert } from "../../src/utils";
 
 describe("utils", () => {
   describe("createEnumMapping", () => {
@@ -429,6 +429,65 @@ describe("utils", () => {
       expect(safeEnumConvert(mockEnum, "B")).toBe(1);
       expect(safeEnumConvert(mockEnum, "0")).toBeUndefined(); // Numeric strings aren't valid keys
     });
+  });
+});
+
+describe("extractAdoStreamError", () => {
+  const ADO_ERROR_JSON = JSON.stringify({
+    $id: "1",
+    innerException: null,
+    message: "Page '/nonexistent' does not exist in wiki 'my-wiki'",
+    typeName: "Microsoft.TeamFoundation.Wiki.Server.WikiPageNotFoundException, Microsoft.TeamFoundation.Wiki.Server",
+    typeKey: "WikiPageNotFoundException",
+    errorCode: 0,
+    eventId: 3000,
+  });
+
+  it("returns the message from a valid ADO error JSON string", () => {
+    expect(extractAdoStreamError(ADO_ERROR_JSON)).toBe(
+      "Page '/nonexistent' does not exist in wiki 'my-wiki'"
+    );
+  });
+
+  it("returns null for normal (non-error) content", () => {
+    expect(extractAdoStreamError("# Hello World\nSome markdown content")).toBeNull();
+  });
+
+  it("returns null for a non-JSON string", () => {
+    expect(extractAdoStreamError("plain text content")).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractAdoStreamError("")).toBeNull();
+  });
+
+  it("returns null for JSON that lacks typeName", () => {
+    const json = JSON.stringify({ message: "Something went wrong" });
+    expect(extractAdoStreamError(json)).toBeNull();
+  });
+
+  it("returns null for JSON that lacks message", () => {
+    const json = JSON.stringify({
+      typeName: "Microsoft.SomeException",
+      errorCode: 0,
+    });
+    expect(extractAdoStreamError(json)).toBeNull();
+  });
+
+  it("returns null for JSON where typeName is not a string", () => {
+    const json = JSON.stringify({ typeName: 42, message: "oops" });
+    expect(extractAdoStreamError(json)).toBeNull();
+  });
+
+  it("returns null for JSON where message is not a string", () => {
+    const json = JSON.stringify({ typeName: "SomeException", message: { nested: true } });
+    expect(extractAdoStreamError(json)).toBeNull();
+  });
+
+  it("handles whitespace around the JSON string", () => {
+    expect(extractAdoStreamError(`  ${ADO_ERROR_JSON}  `)).toBe(
+      "Page '/nonexistent' does not exist in wiki 'my-wiki'"
+    );
   });
 });
 

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -444,9 +444,7 @@ describe("extractAdoStreamError", () => {
   });
 
   it("returns the message from a valid ADO error JSON string", () => {
-    expect(extractAdoStreamError(ADO_ERROR_JSON)).toBe(
-      "Page '/nonexistent' does not exist in wiki 'my-wiki'"
-    );
+    expect(extractAdoStreamError(ADO_ERROR_JSON)).toBe("Page '/nonexistent' does not exist in wiki 'my-wiki'");
   });
 
   it("returns null for normal (non-error) content", () => {
@@ -485,9 +483,7 @@ describe("extractAdoStreamError", () => {
   });
 
   it("handles whitespace around the JSON string", () => {
-    expect(extractAdoStreamError(`  ${ADO_ERROR_JSON}  `)).toBe(
-      "Page '/nonexistent' does not exist in wiki 'my-wiki'"
-    );
+    expect(extractAdoStreamError(`  ${ADO_ERROR_JSON}  `)).toBe("Page '/nonexistent' does not exist in wiki 'my-wiki'");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two tools that silently return ADO error JSON as successful content instead of propagating the error correctly.

> [!NOTE]
> This PR was authored with AI/Copilot assistance.

## Root cause

The ADO Node API client methods `getPageText` and `getItemText` do **not** throw on non-2xx HTTP responses. Instead they return a `ReadableStream` whose content is the error body — an ADO exception JSON object with fields like `typeName`, `typeKey`, and `message` (e.g. `WikiPageNotFoundException`, `GitItemNotFoundException`).

Previously, both tools piped this stream through `streamToString()` and returned the raw error JSON as if it were valid page/file content, with `isError: false`. An agent receiving this response has no way to know an error occurred.

## Fix

Add `extractAdoStreamError(content: string): string | null` to `src/utils.ts`. It attempts to JSON-parse the stream content and returns the human-readable `message` field if the result looks like an ADO error object (i.e. has `typeName` and `message`), otherwise returns `null`.

Both affected tools now call this helper immediately after `streamToString()` and return `isError: true` with the error message when an ADO error is detected.

## Affected tools

| Tool | Issue |
|------|-------|
| `wiki_get_page_content` | Returns `WikiPageNotFoundException` JSON as page content with `isError: false` |
| `repo_get_file_content` | Returns `GitItemNotFoundException` JSON as file content with `isError: false` |

## Repro steps

Both can be reproduced against the public `dnceng-public` org (`https://dev.azure.com/dnceng-public/`) — no credentials required.

**wiki_get_page_content** — request a page path that does not exist:
```json
{
  "wikiIdentifier": "dotnet-public-wiki",
  "project": "public",
  "path": "/nonexistent-page-that-does-not-exist"
}
```
- Before fix: returns exception JSON wrapped in content-safety markers, `isError: false`
- After fix: returns `isError: true` with message `"Wiki page '/nonexistent-page-that-does-not-exist' could not be found..."`

**repo_get_file_content** — request a file path that does not exist:
```json
{
  "repositoryId": "dotnet-public-wiki",
  "project": "public",
  "path": "nonexistent-file-that-does-not-exist.md"
}
```
- Before fix: returns `GitItemNotFoundException` JSON as file text, `isError: false`
- After fix: returns `isError: true` with message `"TF401174: The item 'nonexistent-file-that-does-not-exist.md' could not be found in the repository..."`

Closes #1186
Closes #1187
