### PR TITLE
feat: support project and team env vars for MCP defaults, fix #1195

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ We recommend that you always enable `core` tools so that you can fetch project l
 
 > By default all domains are loaded
 
+> New: You can now configure default Azure DevOps project and team values from `.vscode/mcp.json` using `DEFAULT_PROJECT` and `DEFAULT_TEAM`, so tools can skip selection prompts.
+
+### Example `.vscode/mcp.json`
+
+```json
+{
+  "servers": {
+    "ado": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@azure-devops/mcp", "myorg", "--authentication", "azcli"],
+      "env": {
+        "DEFAULT_PROJECT": "MyProject",
+        "DEFAULT_TEAM": "MyTeam"
+      }
+    }
+  }
+}
+```
+
 ## 📝 Troubleshooting
 
 See the [Troubleshooting guide](./docs/TROUBLESHOOTING.md) for help with common issues and logging.

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ We recommend that you always enable `core` tools so that you can fetch project l
       "command": "npx",
       "args": ["-y", "@azure-devops/mcp", "myorg", "--authentication", "azcli"],
       "env": {
-        "project": "Contoso",
-        "team": "Fabrikam Team"
+        "ado_mcp_project": "Contoso",
+        "ado_mcp_team": "Fabrikam Team"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ We recommend that you always enable `core` tools so that you can fetch project l
 
 > By default all domains are loaded
 
-> New: You can now configure default Azure DevOps project and team values from `.vscode/mcp.json` using `DEFAULT_PROJECT` and `DEFAULT_TEAM`, so tools can skip selection prompts.
+> New: You can now configure default Azure DevOps project and team values from `.vscode/mcp.json` using `project` and `team`, so tools can skip selection prompts.
 
 ### Example `.vscode/mcp.json`
 
@@ -182,8 +182,8 @@ We recommend that you always enable `core` tools so that you can fetch project l
       "command": "npx",
       "args": ["-y", "@azure-devops/mcp", "myorg", "--authentication", "azcli"],
       "env": {
-        "DEFAULT_PROJECT": "MyProject",
-        "DEFAULT_TEAM": "MyTeam"
+        "project": "Contoso",
+        "team": "fabrikam team"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ We recommend that you always enable `core` tools so that you can fetch project l
       "args": ["-y", "@azure-devops/mcp", "myorg", "--authentication", "azcli"],
       "env": {
         "project": "Contoso",
-        "team": "fabrikam team"
+        "team": "Fabrikam Team"
       }
     }
   }

--- a/src/shared/elicitations.ts
+++ b/src/shared/elicitations.ts
@@ -15,6 +15,12 @@ interface ElicitResponse {
 export type ElicitResult = ElicitResolved | ElicitResponse;
 
 export async function elicitProject(server: McpServer, connection: WebApi, message?: string): Promise<ElicitResult> {
+  // Check for default project from environment variable
+  const defaultProject = process.env.DEFAULT_PROJECT;
+  if (defaultProject) {
+    return { resolved: defaultProject };
+  }
+
   const coreApi = await connection.getCoreApi();
   const projects = await coreApi.getProjects("wellFormed", 100, 0, undefined, false);
 
@@ -50,6 +56,12 @@ export async function elicitProject(server: McpServer, connection: WebApi, messa
 }
 
 export async function elicitTeam(server: McpServer, connection: WebApi, project: string, message?: string): Promise<ElicitResult> {
+  // Check for default team from environment variable
+  const defaultTeam = process.env.DEFAULT_TEAM;
+  if (defaultTeam) {
+    return { resolved: defaultTeam };
+  }
+
   const coreApi = await connection.getCoreApi();
   const teams = await coreApi.getTeams(project, undefined, undefined, undefined, false);
 

--- a/src/shared/elicitations.ts
+++ b/src/shared/elicitations.ts
@@ -16,7 +16,7 @@ export type ElicitResult = ElicitResolved | ElicitResponse;
 
 export async function elicitProject(server: McpServer, connection: WebApi, message?: string): Promise<ElicitResult> {
   // Check for default project from environment variable
-  const defaultProject = process.env.DEFAULT_PROJECT;
+  const defaultProject = process.env.project;
   if (defaultProject) {
     return { resolved: defaultProject };
   }
@@ -57,7 +57,7 @@ export async function elicitProject(server: McpServer, connection: WebApi, messa
 
 export async function elicitTeam(server: McpServer, connection: WebApi, project: string, message?: string): Promise<ElicitResult> {
   // Check for default team from environment variable
-  const defaultTeam = process.env.DEFAULT_TEAM;
+  const defaultTeam = process.env.team;
   if (defaultTeam) {
     return { resolved: defaultTeam };
   }

--- a/src/shared/elicitations.ts
+++ b/src/shared/elicitations.ts
@@ -15,8 +15,10 @@ interface ElicitResponse {
 export type ElicitResult = ElicitResolved | ElicitResponse;
 
 export async function elicitProject(server: McpServer, connection: WebApi, message?: string): Promise<ElicitResult> {
+  
   // Check for default project from environment variable
-  const defaultProject = process.env.project;
+  const defaultProject = process.env.ado_mcp_project;
+  
   if (defaultProject) {
     return { resolved: defaultProject };
   }
@@ -56,8 +58,10 @@ export async function elicitProject(server: McpServer, connection: WebApi, messa
 }
 
 export async function elicitTeam(server: McpServer, connection: WebApi, project: string, message?: string): Promise<ElicitResult> {
+  
   // Check for default team from environment variable
-  const defaultTeam = process.env.team;
+  const defaultTeam = process.env.ado_mcp_team;
+  
   if (defaultTeam) {
     return { resolved: defaultTeam };
   }

--- a/test/src/elicitations.test.ts
+++ b/test/src/elicitations.test.ts
@@ -45,8 +45,8 @@ describe("elicitations", () => {
       expect(result).toEqual({ resolved: "ProjectAlpha" });
     });
 
-    it("should return DEFAULT_PROJECT from environment variable without prompting", async () => {
-      process.env.DEFAULT_PROJECT = "DefaultProject";
+    it("should return project from environment variable without prompting", async () => {
+      process.env.project = "DefaultProject";
 
       const result = await elicitProject(server, mockConnection as unknown as WebApi);
 
@@ -59,8 +59,8 @@ describe("elicitations", () => {
       expect(result).toEqual({ resolved: "DefaultProject" });
     });
 
-    it("should ignore DEFAULT_PROJECT if empty string", async () => {
-      process.env.DEFAULT_PROJECT = "";
+    it("should ignore project if empty string", async () => {
+      process.env.project = "";
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
@@ -106,8 +106,8 @@ describe("elicitations", () => {
       expect(result).toEqual({ resolved: "team-1" });
     });
 
-    it("should return DEFAULT_TEAM from environment variable without prompting", async () => {
-      process.env.DEFAULT_TEAM = "DefaultTeam";
+    it("should return team from environment variable without prompting", async () => {
+      process.env.team = "DefaultTeam";
 
       const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
 
@@ -120,8 +120,8 @@ describe("elicitations", () => {
       expect(result).toEqual({ resolved: "DefaultTeam" });
     });
 
-    it("should ignore DEFAULT_TEAM if empty string", async () => {
-      process.env.DEFAULT_TEAM = "";
+    it("should ignore team if empty string", async () => {
+      process.env.team = "";
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;

--- a/test/src/elicitations.test.ts
+++ b/test/src/elicitations.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, expect, it, beforeEach } from "@jest/globals";
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { elicitProject, elicitTeam } from "../../src/shared/elicitations";
@@ -10,8 +10,11 @@ describe("elicitations", () => {
   let server: McpServer;
   let mockCoreApi: { getProjects: jest.Mock; getTeams: jest.Mock };
   let mockConnection: { getCoreApi: jest.Mock };
+  const originalEnv = process.env;
 
   beforeEach(() => {
+    process.env = { ...originalEnv };
+
     server = { tool: jest.fn(), server: { elicitInput: jest.fn() } } as unknown as McpServer;
 
     mockCoreApi = {
@@ -22,6 +25,10 @@ describe("elicitations", () => {
     mockConnection = {
       getCoreApi: jest.fn().mockResolvedValue(mockCoreApi),
     };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   describe("elicitProject", () => {
@@ -36,6 +43,33 @@ describe("elicitations", () => {
       const callArgs = elicitMock.mock.calls[0][0];
       expect(callArgs.message).toBe("Select the Azure DevOps project.");
       expect(result).toEqual({ resolved: "ProjectAlpha" });
+    });
+
+    it("should return DEFAULT_PROJECT from environment variable without prompting", async () => {
+      process.env.DEFAULT_PROJECT = "DefaultProject";
+
+      const result = await elicitProject(server, mockConnection as unknown as WebApi);
+
+      // Should not call getCoreApi or elicitInput
+      expect(mockCoreApi.getProjects).not.toHaveBeenCalled();
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      expect(elicitMock).not.toHaveBeenCalled();
+
+      // Should return the default value
+      expect(result).toEqual({ resolved: "DefaultProject" });
+    });
+
+    it("should ignore DEFAULT_PROJECT if empty string", async () => {
+      process.env.DEFAULT_PROJECT = "";
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      elicitMock.mockResolvedValue({ action: "accept", content: { project: "ProjectAlpha" } });
+
+      const result = await elicitProject(server, mockConnection as unknown as WebApi);
+
+      // Should call elicit since empty string is falsy
+      expect(elicitMock).toHaveBeenCalled();
     });
   });
 
@@ -70,6 +104,33 @@ describe("elicitations", () => {
       expect(oneOf[0]).toEqual({ const: "team-1", title: "team-1" });
       expect(oneOf[1]).toEqual({ const: "", title: "Unknown team" });
       expect(result).toEqual({ resolved: "team-1" });
+    });
+
+    it("should return DEFAULT_TEAM from environment variable without prompting", async () => {
+      process.env.DEFAULT_TEAM = "DefaultTeam";
+
+      const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
+
+      // Should not call getCoreApi or elicitInput
+      expect(mockCoreApi.getTeams).not.toHaveBeenCalled();
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      expect(elicitMock).not.toHaveBeenCalled();
+
+      // Should return the default value
+      expect(result).toEqual({ resolved: "DefaultTeam" });
+    });
+
+    it("should ignore DEFAULT_TEAM if empty string", async () => {
+      process.env.DEFAULT_TEAM = "";
+      (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      elicitMock.mockResolvedValue({ action: "accept", content: { team: "Team One" } });
+
+      const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
+
+      // Should call elicit since empty string is falsy
+      expect(elicitMock).toHaveBeenCalled();
     });
   });
 });

--- a/test/src/elicitations.test.ts
+++ b/test/src/elicitations.test.ts
@@ -46,7 +46,7 @@ describe("elicitations", () => {
     });
 
     it("should return project from environment variable without prompting", async () => {
-      process.env.project = "DefaultProject";
+      process.env.ado_mcp_project = "DefaultProject";
 
       const result = await elicitProject(server, mockConnection as unknown as WebApi);
 
@@ -60,7 +60,7 @@ describe("elicitations", () => {
     });
 
     it("should ignore project if empty string", async () => {
-      process.env.project = "";
+      process.env.ado_mcp_project = "";
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
@@ -107,7 +107,7 @@ describe("elicitations", () => {
     });
 
     it("should return team from environment variable without prompting", async () => {
-      process.env.team = "DefaultTeam";
+      process.env.ado_mcp_team = "DefaultTeam";
 
       const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
 
@@ -121,7 +121,7 @@ describe("elicitations", () => {
     });
 
     it("should ignore team if empty string", async () => {
-      process.env.team = "";
+      process.env.ado_mcp_team = "";
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;


### PR DESCRIPTION
lts, fix #1195 

before prompting to user program now checks for default team name & project name from environment

## #1195

## **Associated Risks**

- User can add non-existent project/team in env

## ✅ **PR Checklist**

- [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [X] Title of the pull request is clear and informative.
- [X] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [X] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

added my own team name and project name