### PR TITLE
Return isError for missing paths in repo_list_directory

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -2004,7 +2004,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
         if (!items || items.length === 0) {
           return {
-            content: [{ type: "text", text: `No items found at path: ${path}` }],
+            content: [{ type: "text", text: `No items found at path: ${path}. The path may not exist in the repository.` }],
+            isError: true,
           };
         }
 

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -7879,7 +7879,7 @@ describe("repos tools", () => {
         );
       });
 
-      it("should return no items found message", async () => {
+      it("should return isError when no items found (empty array)", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_directory);
         const [, , , handler] = call;
@@ -7889,7 +7889,44 @@ describe("repos tools", () => {
         const result = await handler({ repositoryId: "repo123", path: "/missing" });
 
         expect(result).toEqual({
-          content: [{ type: "text", text: "No items found at path: /missing" }],
+          content: [{ type: "text", text: "No items found at path: /missing. The path may not exist in the repository." }],
+          isError: true,
+        });
+      });
+
+      it("should succeed for empty directory (folder entry only)", async () => {
+        configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_directory);
+        const [, , , handler] = call;
+
+        const items = [
+          {
+            path: "/empty-dir",
+            isFolder: true,
+            gitObjectType: 2,
+            commitId: "abc123",
+          },
+        ];
+        mockGitApi.getItems.mockResolvedValue(items);
+
+        const result = await handler({ repositoryId: "repo123", path: "/empty-dir" });
+
+        expect(result.isError).toBeFalsy();
+        expect(result.content[0].text).toContain('"count": 1');
+      });
+
+      it("should return isError when getItems returns null", async () => {
+        configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_directory);
+        const [, , , handler] = call;
+
+        mockGitApi.getItems.mockResolvedValue(null);
+
+        const result = await handler({ repositoryId: "repo123", path: "/nonexistent" });
+
+        expect(result).toEqual({
+          content: [{ type: "text", text: "No items found at path: /nonexistent. The path may not exist in the repository." }],
+          isError: true,
         });
       });
     });


### PR DESCRIPTION
Fixes #1188

Return `isError: true` when `repo_list_directory` finds no items at the requested path.

The Azure DevOps `getItems()` API returns `null` for nonexistent paths rather than throwing. The tool currently returns a success response with "No items found at path: ..." which the agent treats as a valid empty result. This makes it difficult for agents to detect a bad path and recover.

This PR adds `isError: true` to the response and appends "The path may not exist in the repository." to the message, consistent with the `isError` pattern already used elsewhere in this codebase (e.g., `core.ts` identities lookup, `work.ts` iterations, `repositories.ts` PR iterations).

Confirmed with live ADO API: `getItems("/nonexistent")` on a real repository returns `null`, not an exception.

Note -- the case where `[]` is returned is also treated as an error, consistent with other tools in this MCP, although in practice this hasn't been seen. An empty directory always returns at least itself in the results.

## Example
```
 Tool: ado-dnceng-public-repo_list_directory                                                          
   Args: { "project": "public", "repositoryId": "2459d599-fdb2-4d28-9810-daeec061cf90", "path":        
  "/nonexistent-path-xyz-12345" }
```
currently
```                                                         
  Result: No items found at path: /nonexistent-path-xyz-12345                                         
  IsError: false                                                                                       
```                                                                                                       
  then with this fix
```                                                                                                   
  Result: No items found at path: /nonexistent-path-xyz-12345. The path may not exist in the repository
  IsError: true     
```

## GitHub issue number

#1188

## **Associated Risks**

Agents that currently ignore the "No items found" message and treat it as success will now see `isError: true`. This is the intended behavior change.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/repositories.test.ts --runInBand`
- Confirmed with live ADO API that `getItems()` returns `null` for nonexistent paths
