### PR TITLE
Clarify branch list tool descriptions to indicate string return

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -860,7 +860,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.list_branches_by_repo,
-    "Retrieve a list of branches for a given repository.",
+    "Retrieve a list of branch names for a given repository. Returns an array of branch name strings, not full branch objects. Use repo_get_branch_by_name to get full details for a specific branch.",
     {
       repositoryId: z
         .string()
@@ -893,7 +893,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.list_my_branches_by_repo,
-    "Retrieve a list of my branches for a given repository Id.",
+    "Retrieve a list of my branch names for a given repository Id. Returns an array of branch name strings, not full branch objects. Use repo_get_branch_by_name to get full details for a specific branch.",
     {
       repositoryId: z
         .string()


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1189

Agents seeing "Retrieve a list of branches" reasonably expect objects with metadata (commit SHA, ahead/behind counts, etc.) and attempt to access properties that don't exist. For example in Copilot CLI actual session, before this change:

```
The branch listing returned string names rather than objects with
metadata &#8212; there's no commit SHA, ahead/behind count, or other
properties available from this tool.
```

Clarify the descriptions of `repo_list_branches_by_repo` and `repo_list_my_branches_by_repo` to indicate they return branch name strings, not full branch objects, and point to `repo_get_branch_by_name` for full details.

This PR updates the descriptions to say "branch name strings, not full branch objects" and directs agents to 
`repo_get_branch_by_name` when they need full branch details.

## GitHub issue number

#1189

## **Associated Risks**

Description-only change. No behavioral change.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/repositories.test.ts --runInBand`
- `npm run validate-tools`
