### PR TITLE
Auto-resolve repository name to GUID in get_build_definitions

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -35,7 +35,12 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     "Retrieves a list of build definitions for a given project.",
     {
       project: z.string().describe("Project ID or name to get build definitions for"),
-      repositoryId: z.string().optional().describe("Repository ID to filter build definitions"),
+      repositoryId: z
+        .string()
+        .optional()
+        .describe(
+          "Repository ID to filter build definitions. Can be a GUID or a repository name; when a name is provided, it is auto-resolved to the repository GUID using the project parameter (Azure Repos / TfsGit only)."
+        ),
       repositoryType: z.enum(["TfsGit", "GitHub", "BitbucketCloud"]).optional().describe("Type of repository to filter build definitions"),
       name: z.string().optional().describe("Name of the build definition to filter"),
       path: z.string().optional().describe("Path of the build definition to filter"),
@@ -76,10 +81,29 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     }) => {
       const connection = await connectionProvider();
       const buildApi = await connection.getBuildApi();
+
+      // Auto-resolve repositoryId from name to GUID for Azure Repos
+      let resolvedRepositoryId = repositoryId;
+      if (repositoryId) {
+        const isGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(repositoryId);
+        if (!isGuid && (!repositoryType || repositoryType === "TfsGit")) {
+          const gitApi = await connection.getGitApi();
+          const repositories = await gitApi.getRepositories(project);
+          const repo = repositories?.find((r) => r.name === repositoryId);
+          if (!repo?.id) {
+            return {
+              content: [{ type: "text", text: `Error: Repository '${repositoryId}' not found in project '${project}'.` }],
+              isError: true,
+            };
+          }
+          resolvedRepositoryId = repo.id;
+        }
+      }
+
       const buildDefinitions = await buildApi.getDefinitions(
         project,
         name,
-        repositoryId,
+        resolvedRepositoryId,
         repositoryType,
         safeEnumConvert(DefinitionQueryOrder, queryOrder),
         top,

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -25,7 +25,7 @@ describe("configurePipelineTools", () => {
   let tokenProvider: TokenProviderMock;
   let connectionProvider: ConnectionProviderMock;
   let userAgentProvider: () => string;
-  let mockConnection: { getBuildApi: jest.Mock; getPipelinesApi: jest.Mock; serverUrl: string };
+  let mockConnection: { getBuildApi: jest.Mock; getPipelinesApi: jest.Mock; getGitApi: jest.Mock; serverUrl: string };
 
   beforeEach(() => {
     server = { tool: jest.fn() } as unknown as McpServer;
@@ -34,6 +34,7 @@ describe("configurePipelineTools", () => {
     mockConnection = {
       getBuildApi: jest.fn(),
       getPipelinesApi: jest.fn(),
+      getGitApi: jest.fn(),
       serverUrl: "https://dev.azure.com/test-org",
     };
     connectionProvider = jest.fn().mockResolvedValue(mockConnection);
@@ -380,7 +381,7 @@ describe("configurePipelineTools", () => {
 
       const params = {
         project: "test-project",
-        repositoryId: "repo-123",
+        repositoryId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         repositoryType: "TfsGit" as const,
         name: "test-build",
         top: 10,
@@ -391,7 +392,7 @@ describe("configurePipelineTools", () => {
       expect(mockBuildApi.getDefinitions).toHaveBeenCalledWith(
         "test-project",
         "test-build",
-        "repo-123",
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         "TfsGit",
         undefined, // queryOrder
         10, // top
@@ -434,6 +435,183 @@ describe("configurePipelineTools", () => {
       const params = { project: "test-project" };
 
       await expect(handler(params)).rejects.toThrow("API Error");
+    });
+
+    it("should auto-resolve repository name to GUID for TfsGit", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
+      if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockGitApi = {
+        getRepositories: jest.fn().mockResolvedValue([
+          { id: "resolved-guid-1234", name: "my-repo" },
+          { id: "other-guid-5678", name: "other-repo" },
+        ]),
+      };
+      const mockBuildApi = {
+        getDefinitions: jest.fn().mockResolvedValue([{ id: 1, name: "Build" }]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getGitApi = jest.fn().mockResolvedValue(mockGitApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "my-repo",
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.getRepositories).toHaveBeenCalledWith("test-project");
+      expect(mockBuildApi.getDefinitions).toHaveBeenCalledWith(
+        "test-project",
+        undefined, // name
+        "resolved-guid-1234", // resolved repositoryId
+        undefined, // repositoryType
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("should return error when repository name is not found", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
+      if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockGitApi = {
+        getRepositories: jest.fn().mockResolvedValue([{ id: "some-guid", name: "other-repo" }]),
+      };
+      const mockBuildApi = {
+        getDefinitions: jest.fn(),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+      mockConnection.getGitApi = jest.fn().mockResolvedValue(mockGitApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "nonexistent-repo",
+      };
+
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("nonexistent-repo");
+      expect(result.content[0].text).toContain("not found");
+      expect(mockBuildApi.getDefinitions).not.toHaveBeenCalled();
+    });
+
+    it("should pass GUID repositoryId through without resolution", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
+      if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitions: jest.fn().mockResolvedValue([]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getDefinitions).toHaveBeenCalledWith(
+        "test-project",
+        undefined,
+        "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("should not resolve repository name for GitHub repositoryType", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
+      if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinitions: jest.fn().mockResolvedValue([]),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "owner/repo",
+        repositoryType: "GitHub" as const,
+      };
+
+      const result = await handler(params);
+
+      // Should pass through without attempting resolution
+      expect(mockBuildApi.getDefinitions).toHaveBeenCalledWith(
+        "test-project",
+        undefined,
+        "owner/repo",
+        "GitHub",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("should propagate error when getRepositories fails during name resolution", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_get_build_definitions");
+      if (!call) throw new Error("pipelines_get_build_definitions tool not registered");
+      const [, , , handler] = call;
+
+      const mockGitApi = {
+        getRepositories: jest.fn().mockRejectedValue(new Error("Project access denied")),
+      };
+      mockConnection.getGitApi = jest.fn().mockResolvedValue(mockGitApi);
+
+      const params = {
+        project: "test-project",
+        repositoryId: "my-repo",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Project access denied");
     });
   });
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1194

Auto-resolve repository names to GUIDs in `pipelines_get_build_definitions` for Azure Repos (TfsGit).

The Azure DevOps `getDefinitions()` API requires a GUID for `repositoryId` when `repositoryType` is TfsGit. Agents naturally pass repository names (which they get from other tools), causing a cryptic failure:

```
Tool: ado-dnceng-public-pipelines_get_build_definitions
Args: { "project": "public", "repositoryId": "aspnet-AspLabs", "repositoryType": "TfsGit" }
Result: Repository ID for a tfsgit repository should be a GUID.
IsError: true
```

This PR detects when `repositoryId` is not a GUID (and the repository type is TfsGit or unspecified), resolves it via `getRepositories(project)`, and passes the GUID to the API. If the name isn't found, it returns a clear error.

Confirmed with live ADO API against `aspnet-AspLabs` in dnceng — name fails, resolved GUID succeeds.

## GitHub issue number

#1194

## **Associated Risks**

Adds an extra API call (`getRepositories`) only when `repositoryId` is not a GUID and the repository type is TfsGit or unspecified. GUID values and non-TfsGit types are passed through unchanged.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `npm test -- --runTestsByPath test/src/tools/pipelines.test.ts --runInBand`
- Confirmed with live ADO API: `getDefinitions(project, "aspnet-AspLabs", "TfsGit")` returns "Repository ID should be a GUID"; after resolving to GUID `4b7f10b6-89f4-46cf-8858-4c21032ec66a` returns 1 definition
