### PR TITLE
Document isError behavior for 404 in tool descriptions

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -962,7 +962,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.get_branch_by_name,
-    "Get a branch by its name.",
+    "Get a branch by its name. Returns isError: true if the branch is not found.",
     {
       repositoryId: z.string().describe("The ID or name of the repository where the branch is located. When using a repository name instead of a GUID, the project parameter must also be provided."),
       branchName: z.string().describe("The name of the branch to retrieve, e.g., 'main' or 'feature-branch'."),
@@ -1976,7 +1976,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.list_directory,
-    "List files and folders in a directory within a repository. Useful for exploring the structure of a codebase or finding related files.",
+    "List files and folders in a directory within a repository. Useful for exploring the structure of a codebase or finding related files. Returns isError: true if the path is not found.",
     {
       repositoryId: z.string().describe("The ID or name of the repository."),
       path: z.string().optional().default("/").describe("The directory path to list (e.g., '/src' or '/src/components'). Defaults to repository root."),
@@ -2062,7 +2062,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
   server.tool(
     REPO_TOOLS.get_file_content,
     "Get the content of a file from a Git repository at a specific version (branch, tag, or commit SHA). " +
-      "Useful for reading source files from PR branches, specific commits, or tags without having them checked out locally.",
+      "Useful for reading source files from PR branches, specific commits, or tags without having them checked out locally. " +
+      "Returns isError: true if the file is not found.",
     {
       repositoryId: z.string().describe("The ID (GUID) or name of the repository."),
       path: z.string().describe("The full path to the file in the repository, e.g., '/src/main.ts' or 'src/main.ts'."),

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -122,7 +122,7 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     WIKI_TOOLS.get_wiki_page,
-    "Retrieve wiki page metadata by path. This tool does not return page content.",
+    "Retrieve wiki page metadata by path. This tool does not return page content. Returns isError: true if the page is not found.",
     {
       wikiIdentifier: z.string().describe("The unique identifier of the wiki."),
       project: z.string().describe("The project name or ID where the wiki is located."),
@@ -184,7 +184,7 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     WIKI_TOOLS.get_wiki_page_content,
-    "Retrieve wiki page content. Provide either a 'url' parameter OR the combination of 'wikiIdentifier' and 'project' parameters.",
+    "Retrieve wiki page content. Provide either a 'url' parameter OR the combination of 'wikiIdentifier' and 'project' parameters. " + "Returns isError: true if the wiki page is not found.",
     {
       url: z
         .string()


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with GitHub Copilot assistance.

Fixes #1190

## Summary

Several tool descriptions don't document their not-found behavior (`isError: true`), making it harder for LLM agents to anticipate and handle missing resources gracefully.

This PR adds `Returns isError: true if the [resource] is not found.` to the descriptions of five tools:

| Tool | Added text |
|------|-----------|
| `repo_get_branch_by_name` | Returns isError: true if the branch is not found. |
| `repo_list_directory` | Returns isError: true if the path is not found. |
| `repo_get_file_content` | Returns isError: true if the file is not found. |
| `wiki_get_page` | Returns isError: true if the page is not found. |
| `wiki_get_page_content` | Returns isError: true if the wiki page is not found. |

The sixth tool mentioned in #1190 (`repo_list_branches_by_repo`) is addressed separately in PR #1204.

## Associated Risks

None — description-only changes, no logic affected.

## PR Checklist

- [x] Description text changes only
- [x] All 924 existing tests pass
- [x] No conflicts with other open PRs (#1203, #1204, #1205)

## How did you test it

Ran the full test suite (`npx jest`) — 924 tests pass with no changes needed.
