### PR TITLE
Add merge commit message option to repo_update_pull_request

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -366,6 +366,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .enum(getEnumKeys(GitPullRequestMergeStrategy) as [string, ...string[]])
         .optional()
         .describe("The merge strategy to use when the pull request autocompletes. Defaults to 'NoFastForward'."),
+      mergeCommitMessage: z.string().optional().describe("Commit message to use when the pull request is completed."),
       deleteSourceBranch: z.boolean().optional().default(false).describe("Whether to delete the source branch when the pull request autocompletes. Defaults to false."),
       transitionWorkItems: z.boolean().optional().default(true).describe("Whether to transition associated work items to the next state when the pull request autocompletes. Defaults to true."),
       bypassReason: z.string().optional().describe("Reason for bypassing branch policies. When provided, branch policies will be automatically bypassed during autocompletion."),
@@ -382,6 +383,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       status,
       autoComplete,
       mergeStrategy,
+      mergeCommitMessage,
       deleteSourceBranch,
       transitionWorkItems,
       bypassReason,
@@ -416,6 +418,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
             if (mergeStrategy) {
               completionOptions.mergeStrategy = GitPullRequestMergeStrategy[mergeStrategy as keyof typeof GitPullRequestMergeStrategy];
+            }
+
+            if (mergeCommitMessage) {
+              completionOptions.mergeCommitMessage = mergeCommitMessage;
             }
 
             if (bypassReason) {

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -492,6 +492,63 @@ describe("repos tools", () => {
       expect(parsedResult.pullRequestId).toBe(123);
     });
 
+    it("should set merge commit message when autocomplete is enabled", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+      if (!call) throw new Error("repo_update_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockUpdatedPR = {
+        pullRequestId: 123,
+        title: "Updated PR",
+        autoCompleteSetBy: { id: "user-id" },
+        completionOptions: {
+          mergeStrategy: 2, // Squash
+          deleteSourceBranch: true,
+          transitionWorkItems: false,
+          bypassPolicy: false,
+          mergeCommitMessage: "Merged PR 123: Update dependencies",
+        },
+      };
+
+      mockGitApi.updatePullRequest.mockResolvedValue(mockUpdatedPR);
+      mockGetCurrentUserDetails.mockResolvedValue({
+        authenticatedUser: { id: "current-user-id" },
+        authorizedUser: { id: "current-user-id" },
+      });
+
+      const params = {
+        repositoryId: "test-repo-id",
+        pullRequestId: 123,
+        project: "test-project",
+        autoComplete: true,
+        mergeStrategy: "Squash",
+        mergeCommitMessage: "Merged PR 123: Update dependencies",
+        deleteSourceBranch: true,
+        transitionWorkItems: false,
+      };
+
+      const result = await handler(params);
+
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          autoCompleteSetBy: { id: "current-user-id" },
+          completionOptions: expect.objectContaining({
+            mergeStrategy: 2, // GitPullRequestMergeStrategy.Squash
+            mergeCommitMessage: "Merged PR 123: Update dependencies",
+            deleteSourceBranch: true,
+            transitionWorkItems: false,
+            bypassPolicy: false,
+          }),
+        }),
+        "test-repo-id",
+        123,
+        "test-project"
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
     it("should disable autocomplete when autoComplete is false", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 


### PR DESCRIPTION
## Summary
- Add an optional `mergeCommitMessage` parameter to `repo_update_pull_request`.
- Pass the value through to `completionOptions.mergeCommitMessage` when autocomplete completion options are built.
- Add Jest coverage for the autocomplete path.

## Why
Azure DevOps supports customizing the final merge or squash commit message through pull request completion options, but the MCP tool did not expose that field.

Fixes #1209

## Validation
- `npm test -- --runTestsByPath test/src/tools/repositories.test.ts`
- `npm run validate-tools`