### PR TITLE
fix: normalize literal \n sequences across all multi-line text tools

### DIFF
--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { apiVersion, getEnumKeys, safeEnumConvert } from "../utils.js";
+import { apiVersion, getEnumKeys, normalizeNewlines, safeEnumConvert } from "../utils.js";
 import { WebApi } from "azure-devops-node-api";
 import { BuildQueryOrder, DefinitionQueryOrder } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
 import { z } from "zod";
@@ -457,7 +457,7 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
         stagesToSkip: stagesToSkip,
         templateParameters: templateParameters,
         variables: variables,
-        yamlOverride: yamlOverride,
+        yamlOverride: yamlOverride ? normalizeNewlines(yamlOverride) : yamlOverride,
       };
 
       const pipelineRun = await pipelinesApi.runPipeline(runRequest, project, pipelineId, pipelineVersion);

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -27,7 +27,7 @@ import { z } from "zod";
 import { getCurrentUserDetails, getUserIdFromEmail } from "./auth.js";
 import { GitRepository } from "azure-devops-node-api/interfaces/TfvcInterfaces.js";
 import { WebApiTagDefinition } from "azure-devops-node-api/interfaces/CoreInterfaces.js";
-import { extractAdoStreamError, getEnumKeys, streamToString } from "../utils.js";
+import { extractAdoStreamError, getEnumKeys, normalizeNewlines, streamToString } from "../utils.js";
 
 const REPO_TOOLS = {
   list_repos_by_project: "repo_list_repos_by_project",
@@ -202,7 +202,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const labelDefinitions: WebApiTagDefinition[] | undefined = labels ? labels.map((label) => ({ name: label })) : undefined;
 
         // Normalize literal \n sequences that AI agents may produce via JSON-RPC serialization
-        const normalizedDescription = description?.replace(/\\n/g, "\n");
+        const normalizedDescription = description ? normalizeNewlines(description) : description;
 
         let pullRequest = await gitApi.createPullRequest(
           {
@@ -412,7 +412,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         if (title !== undefined) updateRequest.title = title;
         if (description !== undefined) {
           // Normalize literal \n sequences that AI agents may produce via JSON-RPC serialization
-          updateRequest.description = description.replace(/\\n/g, "\n");
+          updateRequest.description = normalizeNewlines(description);
         }
         if (isDraft !== undefined) updateRequest.isDraft = isDraft;
         if (targetRefName !== undefined) updateRequest.targetRefName = targetRefName;
@@ -1487,7 +1487,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
-        const comment = await gitApi.createComment({ content }, repositoryId, pullRequestId, threadId, project);
+        const comment = await gitApi.createComment({ content: normalizeNewlines(content) }, repositoryId, pullRequestId, threadId, project);
 
         // Check if the comment was successfully created
         if (!comment) {
@@ -1649,7 +1649,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         }
 
         const thread = await gitApi.createThread(
-          { comments: [{ content: content }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
+          { comments: [{ content: normalizeNewlines(content) }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
           repositoryId,
           pullRequestId,
           project

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -172,7 +172,13 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       sourceRefName: z.string().describe("The source branch name for the pull request, e.g., 'refs/heads/feature-branch'."),
       targetRefName: z.string().describe("The target branch name for the pull request, e.g., 'refs/heads/main'."),
       title: z.string().describe("The title of the pull request."),
-      description: z.string().max(4000).optional().describe("The description of the pull request. Must not be longer than 4000 characters. Optional."),
+      description: z
+        .string()
+        .max(4000)
+        .optional()
+        .describe(
+          "The description of the pull request. Must not be longer than 4000 characters. Supports markdown formatting. Use actual newline characters (not literal backslash-n sequences) for line breaks. Optional."
+        ),
       isDraft: z.boolean().optional().default(false).describe("Indicates whether the pull request is a draft. Defaults to false."),
       project: z.string().optional().describe("Project ID or project name. Required when repositoryId is a repository name instead of a GUID."),
       workItems: z.string().optional().describe("Work item IDs to associate with the pull request, space-separated."),
@@ -195,12 +201,15 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
         const labelDefinitions: WebApiTagDefinition[] | undefined = labels ? labels.map((label) => ({ name: label })) : undefined;
 
+        // Normalize literal \n sequences that AI agents may produce via JSON-RPC serialization
+        const normalizedDescription = description?.replace(/\\n/g, "\n");
+
         let pullRequest = await gitApi.createPullRequest(
           {
             sourceRefName,
             targetRefName,
             title,
-            description,
+            description: normalizedDescription,
             isDraft,
             workItemRefs: workItemRefs,
             forkSource,
@@ -357,7 +366,13 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       pullRequestId: z.coerce.number().min(1).describe("The ID of the pull request to update."),
       project: z.string().optional().describe("Project ID or project name. Required when repositoryId is a repository name instead of a GUID."),
       title: z.string().optional().describe("The new title for the pull request."),
-      description: z.string().max(4000).optional().describe("The new description for the pull request. Must not be longer than 4000 characters."),
+      description: z
+        .string()
+        .max(4000)
+        .optional()
+        .describe(
+          "The new description for the pull request. Must not be longer than 4000 characters. Supports markdown formatting. Use actual newline characters (not literal backslash-n sequences) for line breaks."
+        ),
       isDraft: z.boolean().optional().describe("Whether the pull request should be a draft."),
       targetRefName: z.string().optional().describe("The new target branch name (e.g., 'refs/heads/main')."),
       status: z.enum(["Active", "Abandoned"]).optional().describe("The new status of the pull request. Can be 'Active' or 'Abandoned'."),
@@ -395,7 +410,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const updateRequest: Record<string, unknown> = {};
 
         if (title !== undefined) updateRequest.title = title;
-        if (description !== undefined) updateRequest.description = description;
+        if (description !== undefined) {
+          // Normalize literal \n sequences that AI agents may produce via JSON-RPC serialization
+          updateRequest.description = description.replace(/\\n/g, "\n");
+        }
         if (isDraft !== undefined) updateRequest.isDraft = isDraft;
         if (targetRefName !== undefined) updateRequest.targetRefName = targetRefName;
         if (status !== undefined) {

--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -5,7 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { z } from "zod";
 import { WikiPagesBatchRequest } from "azure-devops-node-api/interfaces/WikiInterfaces.js";
-import { apiVersion, extractAdoStreamError } from "../utils.js";
+import { apiVersion, extractAdoStreamError, normalizeNewlines } from "../utils.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 
 const WIKI_TOOLS = {
@@ -304,6 +304,9 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
         const connection = await connectionProvider();
         const accessToken = await tokenProvider();
 
+        // Normalize literal \n sequences that AI agents may produce
+        const normalizedContent = normalizeNewlines(content);
+
         // Normalize the path
         const normalizedPath = path.startsWith("/") ? path : `/${path}`;
         const encodedPath = encodeURIComponent(normalizedPath);
@@ -322,7 +325,7 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
               "Content-Type": "application/json",
               "User-Agent": userAgentProvider(),
             },
-            body: JSON.stringify({ content: content }),
+            body: JSON.stringify({ content: normalizedContent }),
           });
 
           if (createResponse.ok) {
@@ -374,7 +377,7 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
                 "User-Agent": userAgentProvider(),
                 "If-Match": currentEtag,
               },
-              body: JSON.stringify({ content: content }),
+              body: JSON.stringify({ content: normalizedContent }),
             });
 
             if (updateResponse.ok) {

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -8,7 +8,7 @@ import { WebApi } from "azure-devops-node-api";
 import { WorkItemExpand, WorkItemRelation } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { z } from "zod";
-import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, safeEnumConvert, encodeFormattedValue } from "../utils.js";
+import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, normalizeNewlines, safeEnumConvert, encodeFormattedValue } from "../utils.js";
 import { elicitProject, elicitTeam } from "../shared/elicitations.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 
@@ -375,7 +375,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         const accessToken = await tokenProvider();
 
         const body = {
-          text: comment,
+          text: normalizeNewlines(comment),
         };
 
         const formatParameter = (format ?? "Markdown") === "Markdown" ? 0 : 1;
@@ -434,7 +434,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
-        const body: Record<string, string> = { text };
+        const body: Record<string, string> = { text: normalizeNewlines(text) };
         const formatParameter = (format ?? "Markdown") === "Markdown" ? 0 : 1;
 
         const response = await fetch(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,21 @@ export function safeEnumConvert<T extends Record<string, string | number>>(enumO
 }
 
 /**
+ * Normalizes literal backslash-n sequences (`\n`) into real newline characters.
+ *
+ * AI agents communicating over JSON-RPC often produce the two-character sequence
+ * `\n` (backslash + n) instead of an actual newline (U+000A) in multi-line text
+ * fields.  This helper normalizes those sequences so that descriptions, comments,
+ * and wiki content render correctly in Azure DevOps.
+ *
+ * @param text The input text that may contain literal `\n` sequences
+ * @returns The text with literal `\n` replaced by real newlines
+ */
+export function normalizeNewlines(text: string): string {
+  return text.replace(/\\n/g, "\n");
+}
+
+/**
  * Encodes `>` and `<` for Markdown formatted fields.
  *
  * @param value The text value to encode
@@ -69,7 +84,7 @@ export function safeEnumConvert<T extends Record<string, string | number>>(enumO
  */
 export function encodeFormattedValue(value: string, format?: "Markdown" | "Html"): string {
   if (!value || format !== "Markdown") return value;
-  const result = value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const result = normalizeNewlines(value).replace(/</g, "&lt;").replace(/>/g, "&gt;");
   return result;
 }
 

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -961,6 +961,45 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(expectedTrimmedPR, null, 2));
     });
 
+    it("should normalize literal backslash-n sequences in description", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
+      if (!call) throw new Error("repo_create_pull_request tool not registered");
+      const [, , , handler] = call;
+
+      const mockCreatedPR = {
+        pullRequestId: 789,
+        codeReviewId: 789,
+        repository: { name: "test-repo" },
+        status: 1,
+        createdBy: { displayName: "Test User", uniqueName: "testuser@example.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "Test PR",
+        isDraft: false,
+        sourceRefName: "refs/heads/feature",
+        targetRefName: "refs/heads/main",
+      };
+      mockGitApi.createPullRequest.mockResolvedValue(mockCreatedPR);
+
+      await handler({
+        repositoryId: "repo123",
+        sourceRefName: "refs/heads/feature",
+        targetRefName: "refs/heads/main",
+        title: "Test PR",
+        description: "Line 1\\nLine 2\\nLine 3",
+        project: "test-project",
+      });
+
+      expect(mockGitApi.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "Line 1\nLine 2\nLine 3",
+        }),
+        "repo123",
+        "test-project"
+      );
+    });
+
     it("should create pull request with all optional fields including labels", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AlertType, AlertValidityStatus, Confidence, Severity, State } from "azure-devops-node-api/interfaces/AlertInterfaces";
-import { createEnumMapping, encodeFormattedValue, extractAdoStreamError, getEnumKeys, mapStringArrayToEnum, mapStringToEnum, safeEnumConvert } from "../../src/utils";
+import { createEnumMapping, encodeFormattedValue, extractAdoStreamError, getEnumKeys, mapStringArrayToEnum, mapStringToEnum, normalizeNewlines, safeEnumConvert } from "../../src/utils";
 
 describe("utils", () => {
   describe("createEnumMapping", () => {
@@ -521,5 +521,33 @@ describe("encodeFormattedValue", () => {
       expect(once).toBe("Already &lt;tag&gt; plus &lt;new&gt; and $cash");
       expect(twice).toBe(once);
     });
+  });
+
+  it("normalizes literal backslash-n sequences in Markdown format", () => {
+    const input = "Line 1\\nLine 2\\nLine 3";
+    const result = encodeFormattedValue(input, "Markdown");
+    expect(result).toBe("Line 1\nLine 2\nLine 3");
+  });
+});
+
+describe("normalizeNewlines", () => {
+  it("replaces literal backslash-n with real newlines", () => {
+    expect(normalizeNewlines("Line 1\\nLine 2")).toBe("Line 1\nLine 2");
+  });
+
+  it("handles multiple occurrences", () => {
+    expect(normalizeNewlines("a\\nb\\nc")).toBe("a\nb\nc");
+  });
+
+  it("does not affect real newlines", () => {
+    expect(normalizeNewlines("a\nb")).toBe("a\nb");
+  });
+
+  it("returns unchanged text when no literal backslash-n present", () => {
+    expect(normalizeNewlines("no newlines here")).toBe("no newlines here");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeNewlines("")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1219

AI agents (Copilot, Claude, etc.) communicating over JSON-RPC often send literal two-character `\n` sequences instead of real newline characters in multi-line text fields. This causes descriptions, comments, and wiki content to render with visible `\n` instead of line breaks.

## Changes

### Shared utility (`src/utils.ts`)
- Added `normalizeNewlines(text)`  replaces literal `\n` with real newlines
- Integrated into `encodeFormattedValue()` so all Markdown work item fields are automatically normalized

### Tools updated

| Tool | File | Field |
|------|------|-------|
| Create PR | `repositories.ts` | `description` |
| Update PR | `repositories.ts` | `description` |
| Reply to comment | `repositories.ts` | `content` |
| Create thread | `repositories.ts` | `content` |
| Add work item comment | `work-items.ts` | `comment` |
| Update work item comment | `work-items.ts` | `text` |
| Create/update work item fields | `work-items.ts` | via `encodeFormattedValue()` |
| Create/update wiki page | `wiki.ts` | `content` |
| Run pipeline (YAML override) | `pipelines.ts` | `yamlOverride` |

### Tests (`test/src/utils.test.ts`)
- 6 new tests for `normalizeNewlines()` and its integration with `encodeFormattedValue()`
- All 950 existing tests pass