### PR TITLE
feat: add optional AI attribution marker for PR comments and descriptions

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -54,6 +54,28 @@ const REPO_TOOLS = {
   get_file_content: "repo_get_file_content",
 };
 
+const DEFAULT_AI_ATTRIBUTION_MARKER = "\n\n---\n🤖 *This content was generated with AI assistance.*";
+
+const aiAttributionSchema = {
+  aiGenerated: z.boolean().optional().default(false).describe("When true, appends an AI attribution marker to the content indicating it was generated with AI assistance."),
+  aiAuthor: z.string().optional().describe("Optional author name to include in the AI attribution marker (e.g. '@username'). Only used when aiGenerated is true."),
+};
+
+/**
+ * Appends the AI attribution marker to content if aiGenerated is true.
+ * @param content The original content string
+ * @param aiGenerated Whether to append the AI attribution marker
+ * @param aiAuthor Optional author name to include in the attribution (e.g. "@username")
+ * @returns The content with the marker appended, or the original content
+ */
+function applyAiAttribution(content: string, aiGenerated?: boolean, aiAuthor?: string): string {
+  if (!aiGenerated) return content;
+  if (aiAuthor && aiAuthor.trim()) {
+    return content + `\n\n---\n🤖 *This content was generated with AI assistance on behalf of ${aiAuthor.trim()}.*`;
+  }
+  return content + DEFAULT_AI_ATTRIBUTION_MARKER;
+}
+
 function branchesFilterOutIrrelevantProperties(branches: GitRef[], top: number) {
   return branches
     ?.flatMap((branch) => (branch.name ? [branch.name] : []))
@@ -178,8 +200,9 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       workItems: z.string().optional().describe("Work item IDs to associate with the pull request, space-separated."),
       forkSourceRepositoryId: z.string().optional().describe("The ID of the fork repository that the pull request originates from. Optional, used when creating a pull request from a fork."),
       labels: z.array(z.string()).optional().describe("Array of label names to add to the pull request after creation."),
+      ...aiAttributionSchema,
     },
-    async ({ repositoryId, sourceRefName, targetRefName, title, description, isDraft, project, workItems, forkSourceRepositoryId, labels }) => {
+    async ({ repositoryId, sourceRefName, targetRefName, title, description, isDraft, project, workItems, forkSourceRepositoryId, labels, aiGenerated, aiAuthor }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
@@ -200,7 +223,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
             sourceRefName,
             targetRefName,
             title,
-            description,
+            description: description ? applyAiAttribution(description, aiGenerated, aiAuthor) : description,
             isDraft,
             workItemRefs: workItemRefs,
             forkSource,
@@ -370,6 +393,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       transitionWorkItems: z.boolean().optional().default(true).describe("Whether to transition associated work items to the next state when the pull request autocompletes. Defaults to true."),
       bypassReason: z.string().optional().describe("Reason for bypassing branch policies. When provided, branch policies will be automatically bypassed during autocompletion."),
       labels: z.array(z.string()).optional().describe("Array of label names to replace existing labels on the pull request. This will remove all current labels and add the specified ones."),
+      ...aiAttributionSchema,
     },
     async ({
       repositoryId,
@@ -386,6 +410,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       transitionWorkItems,
       bypassReason,
       labels,
+      aiGenerated,
+      aiAuthor,
     }) => {
       try {
         const connection = await connectionProvider();
@@ -395,7 +421,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const updateRequest: Record<string, unknown> = {};
 
         if (title !== undefined) updateRequest.title = title;
-        if (description !== undefined) updateRequest.description = description;
+        if (description !== undefined) updateRequest.description = description ? applyAiAttribution(description, aiGenerated, aiAuthor) : description;
         if (isDraft !== undefined) updateRequest.isDraft = isDraft;
         if (targetRefName !== undefined) updateRequest.targetRefName = targetRefName;
         if (status !== undefined) {
@@ -1464,12 +1490,13 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       content: z.string().describe("The content of the comment to be added."),
       project: z.string().optional().describe("Project ID or project name. Required when repositoryId is a repository name instead of a GUID."),
       fullResponse: z.boolean().optional().default(false).describe("Return full comment JSON response instead of a simple confirmation message."),
+      ...aiAttributionSchema,
     },
-    async ({ repositoryId, pullRequestId, threadId, content, project, fullResponse }) => {
+    async ({ repositoryId, pullRequestId, threadId, content, project, fullResponse, aiGenerated, aiAuthor }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
-        const comment = await gitApi.createComment({ content }, repositoryId, pullRequestId, threadId, project);
+        const comment = await gitApi.createComment({ content: applyAiAttribution(content, aiGenerated, aiAuthor) }, repositoryId, pullRequestId, threadId, project);
 
         // Check if the comment was successfully created
         if (!comment) {
@@ -1538,8 +1565,9 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .describe(
           "Position of last character of the thread's span in right file. The character offset of a thread's position inside of a line. Must be set if rightFileEndLine is also specified. (optional)"
         ),
+      ...aiAttributionSchema,
     },
-    async ({ repositoryId, pullRequestId, content, project, filePath, status, rightFileStartLine, rightFileStartOffset, rightFileEndLine, rightFileEndOffset }) => {
+    async ({ repositoryId, pullRequestId, content, project, filePath, status, rightFileStartLine, rightFileStartOffset, rightFileEndLine, rightFileEndOffset, aiGenerated, aiAuthor }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
@@ -1631,7 +1659,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         }
 
         const thread = await gitApi.createThread(
-          { comments: [{ content: content }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
+          { comments: [{ content: applyAiAttribution(content, aiGenerated, aiAuthor) }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
           repositoryId,
           pullRequestId,
           project

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -165,11 +165,60 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(expectedTrimmedPR, null, 2));
     });
 
+    it("should append AI attribution marker to description when aiGenerated is true", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+      const [, , , handler] = call!;
+      mockGitApi.updatePullRequest.mockResolvedValue({
+        pullRequestId: 123,
+        repository: { name: "r" },
+        status: 1,
+        createdBy: { displayName: "U", uniqueName: "u@e.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "T",
+        isDraft: false,
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+      });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 123, project: "p", description: "My description", aiGenerated: true });
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "My description\n\n---\n🤖 *This content was generated with AI assistance.*" }),
+        "repo123",
+        123,
+        "p"
+      );
+    });
+
+    it("should include aiAuthor in AI attribution marker when provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
+      const [, , , handler] = call!;
+      mockGitApi.updatePullRequest.mockResolvedValue({
+        pullRequestId: 123,
+        repository: { name: "r" },
+        status: 1,
+        createdBy: { displayName: "U", uniqueName: "u@e.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "T",
+        isDraft: false,
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+      });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 123, project: "p", description: "My description", aiGenerated: true, aiAuthor: "@test-user" });
+      expect(mockGitApi.updatePullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "My description\n\n---\n🤖 *This content was generated with AI assistance on behalf of @test-user.*" }),
+        "repo123",
+        123,
+        "p"
+      );
+    });
+
     it("should update pull request with only title", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.update_pull_request);
-
       if (!call) throw new Error("repo_update_pull_request tool not registered");
       const [, , , handler] = call;
 
@@ -959,6 +1008,79 @@ describe("repos tools", () => {
         targetRefName: "refs/heads/main",
       };
       expect(result.content[0].text).toBe(JSON.stringify(expectedTrimmedPR, null, 2));
+    });
+
+    it("should append AI attribution marker to description when aiGenerated is true", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
+      const [, , , handler] = call!;
+      mockGitApi.createPullRequest.mockResolvedValue({
+        pullRequestId: 789,
+        repository: { name: "r" },
+        status: 1,
+        createdBy: { displayName: "U", uniqueName: "u@e.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "T",
+        isDraft: false,
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+      });
+
+      await handler({ repositoryId: "repo123", sourceRefName: "refs/heads/f", targetRefName: "refs/heads/main", title: "T", description: "Generated", project: "p", aiGenerated: true });
+      expect(mockGitApi.createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ description: "Generated\n\n---\n🤖 *This content was generated with AI assistance.*" }), "repo123", "p");
+    });
+
+    it("should not append AI attribution marker when aiGenerated is omitted", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
+      const [, , , handler] = call!;
+      mockGitApi.createPullRequest.mockResolvedValue({
+        pullRequestId: 789,
+        repository: { name: "r" },
+        status: 1,
+        createdBy: { displayName: "U", uniqueName: "u@e.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "T",
+        isDraft: false,
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+      });
+
+      await handler({ repositoryId: "repo123", sourceRefName: "refs/heads/f", targetRefName: "refs/heads/main", title: "T", description: "Plain", project: "p" });
+      expect(mockGitApi.createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ description: "Plain" }), "repo123", "p");
+    });
+
+    it("should include aiAuthor in AI attribution marker when provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
+      const [, , , handler] = call!;
+      mockGitApi.createPullRequest.mockResolvedValue({
+        pullRequestId: 789,
+        repository: { name: "r" },
+        status: 1,
+        createdBy: { displayName: "U", uniqueName: "u@e.com" },
+        creationDate: "2023-01-01T00:00:00Z",
+        title: "T",
+        isDraft: false,
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+      });
+
+      await handler({
+        repositoryId: "repo123",
+        sourceRefName: "refs/heads/f",
+        targetRefName: "refs/heads/main",
+        title: "T",
+        description: "Generated",
+        project: "p",
+        aiGenerated: true,
+        aiAuthor: "@copilot-user",
+      });
+      expect(mockGitApi.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "Generated\n\n---\n🤖 *This content was generated with AI assistance on behalf of @copilot-user.*" }),
+        "repo123",
+        "p"
+      );
     });
 
     it("should create pull request with all optional fields including labels", async () => {
@@ -4872,6 +4994,26 @@ describe("repos tools", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error: Failed to add comment to thread 789");
     });
+
+    it("should append AI attribution marker to reply when aiGenerated is true", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
+      const [, , , handler] = call!;
+      mockGitApi.createComment.mockResolvedValue({ id: 789, content: "Reply" });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 456, threadId: 789, content: "Reply", aiGenerated: true });
+      expect(mockGitApi.createComment).toHaveBeenCalledWith({ content: "Reply\n\n---\n🤖 *This content was generated with AI assistance.*" }, "repo123", 456, 789, undefined);
+    });
+
+    it("should include aiAuthor in AI attribution marker for reply when provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.reply_to_comment);
+      const [, , , handler] = call!;
+      mockGitApi.createComment.mockResolvedValue({ id: 789, content: "Reply" });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 456, threadId: 789, content: "Reply", aiGenerated: true, aiAuthor: "@test-user" });
+      expect(mockGitApi.createComment).toHaveBeenCalledWith({ content: "Reply\n\n---\n🤖 *This content was generated with AI assistance on behalf of @test-user.*" }, "repo123", 456, 789, undefined);
+    });
   });
 
   describe("repo_create_pull_request_thread", () => {
@@ -5037,6 +5179,36 @@ describe("repos tools", () => {
         content: [{ type: "text", text: "rightFileStartLine must be greater than or equal to 1." }],
         isError: true,
       });
+    });
+
+    it("should append AI attribution marker to thread content when aiGenerated is true", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
+      const [, , , handler] = call!;
+      mockGitApi.createThread.mockResolvedValue({ id: 123, status: 1 });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 456, content: "AI review comment", aiGenerated: true });
+      expect(mockGitApi.createThread).toHaveBeenCalledWith(
+        expect.objectContaining({ comments: [{ content: "AI review comment\n\n---\n🤖 *This content was generated with AI assistance.*" }] }),
+        "repo123",
+        456,
+        undefined
+      );
+    });
+
+    it("should include aiAuthor in AI attribution marker for thread when provided", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request_thread);
+      const [, , , handler] = call!;
+      mockGitApi.createThread.mockResolvedValue({ id: 123, status: 1 });
+
+      await handler({ repositoryId: "repo123", pullRequestId: 456, content: "AI review comment", aiGenerated: true, aiAuthor: "@copilot" });
+      expect(mockGitApi.createThread).toHaveBeenCalledWith(
+        expect.objectContaining({ comments: [{ content: "AI review comment\n\n---\n🤖 *This content was generated with AI assistance on behalf of @copilot.*" }] }),
+        "repo123",
+        456,
+        undefined
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Adds optional `aiGenerated` and `aiAuthor` parameters to 4 PR-related tools, enabling AI agents to transparently disclose when content was generated with AI assistance.

Closes #1221

## Changes

### New helper function
- `applyAiAttribution(content, aiGenerated?, aiAuthor?)`  appends attribution marker when enabled

### Shared schema (DRY)
- `aiAttributionSchema` constant with Zod definitions, spread into all 4 tools

### Tools updated

| Tool | Parameter applied to |
|------|---------------------|
| `repo_create_pull_request` | description |
| `repo_update_pull_request` | description |
| `repo_reply_to_comment` | comment content |
| `repo_create_pull_request_thread` | thread content |

### Marker formats
- Default: ` *This content was generated with AI assistance.*`
- With author: ` *This content was generated with AI assistance on behalf of @username.*`

### Behavior
- `aiGenerated` defaults to `false`  no change to existing behavior
- `aiAuthor` is optional; only used when `aiGenerated=true`
- Empty/whitespace-only `aiAuthor` falls back to default marker
- Empty string description is preserved (no marker-only content)

## Tests
- 9 new tests covering all 4 tools (positive, negative, and aiAuthor scenarios)
- All 952 tests pass
- Formatting clean (`npm run format`  no changes)