### PR TITLE
Add support for default project and team configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ This TypeScript project provides a **local** MCP server for Azure DevOps, enabli
 4. [⚙️ Supported Tools](#️-supported-tools)
 5. [🔌 Installation & Getting Started](#-installation--getting-started)
 6. [🌏 Using Domains](#-using-domains)
-7. [📝 Troubleshooting](#-troubleshooting)
-8. [🎩 Examples & Best Practices](#-examples--best-practices)
-9. [🙋‍♀️ Frequently Asked Questions](#️-frequently-asked-questions)
-10. [📌 Contributing](#-contributing)
+7. [🐥 Project and Team Defaults](#-project-and-team-defaults)
+8. [📝 Troubleshooting](#-troubleshooting)
+9. [🎩 Examples & Best Practices](#-examples--best-practices)
+10. [🙋‍♀️ Frequently Asked Questions](#️-frequently-asked-questions)
+11. [📌 Contributing](#-contributing)
 
 ## 📺 Overview
 
@@ -169,6 +170,28 @@ Domains that are available are: `core`, `work`, `work-items`, `search`, `test-pl
 We recommend that you always enable `core` tools so that you can fetch project level information.
 
 > By default all domains are loaded
+
+## 🐥 Project and Team Defaults
+
+You can also configure default Azure DevOps project and team values from `.vscode/mcp.json` using `project` and `team`, so tools can skip selection prompts.
+
+### Example `.vscode/mcp.json`
+
+```json
+{
+  "servers": {
+    "ado": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@azure-devops/mcp", "myorg", "--authentication", "azcli"],
+      "env": {
+        "ado_mcp_project": "Contoso",
+        "ado_mcp_team": "Fabrikam Team"
+      }
+    }
+  }
+}
+```
 
 ## 📝 Troubleshooting
 

--- a/src/shared/elicitations.ts
+++ b/src/shared/elicitations.ts
@@ -15,6 +15,13 @@ interface ElicitResponse {
 export type ElicitResult = ElicitResolved | ElicitResponse;
 
 export async function elicitProject(server: McpServer, connection: WebApi, message?: string): Promise<ElicitResult> {
+  // Check for default project from environment variable
+  const defaultProject = process.env.ado_mcp_project;
+
+  if (defaultProject) {
+    return { resolved: defaultProject };
+  }
+
   const coreApi = await connection.getCoreApi();
   const projects = await coreApi.getProjects("wellFormed", 100, 0, undefined, false);
 
@@ -50,6 +57,13 @@ export async function elicitProject(server: McpServer, connection: WebApi, messa
 }
 
 export async function elicitTeam(server: McpServer, connection: WebApi, project: string, message?: string): Promise<ElicitResult> {
+  // Check for default team from environment variable
+  const defaultTeam = process.env.ado_mcp_team;
+
+  if (defaultTeam) {
+    return { resolved: defaultTeam };
+  }
+
   const coreApi = await connection.getCoreApi();
   const teams = await coreApi.getTeams(project, undefined, undefined, undefined, false);
 

--- a/test/src/elicitations.test.ts
+++ b/test/src/elicitations.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, expect, it, beforeEach } from "@jest/globals";
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { elicitProject, elicitTeam } from "../../src/shared/elicitations";
@@ -25,7 +25,18 @@ describe("elicitations", () => {
   });
 
   describe("elicitProject", () => {
+    const originalProjectEnv = process.env.ado_mcp_project;
+
+    afterEach(() => {
+      if (originalProjectEnv === undefined) {
+        delete process.env.ado_mcp_project;
+      } else {
+        process.env.ado_mcp_project = originalProjectEnv;
+      }
+    });
+
     it("should use default message when no message is provided", async () => {
+      delete process.env.ado_mcp_project;
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
@@ -37,10 +48,48 @@ describe("elicitations", () => {
       expect(callArgs.message).toBe("Select the Azure DevOps project.");
       expect(result).toEqual({ resolved: "ProjectAlpha" });
     });
+
+    it("should resolve to default project from ado_mcp_project env var without elicitation", async () => {
+      process.env.ado_mcp_project = "DefaultProject";
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+
+      const result = await elicitProject(server, mockConnection as unknown as WebApi);
+
+      expect(result).toEqual({ resolved: "DefaultProject" });
+      expect(mockConnection.getCoreApi).not.toHaveBeenCalled();
+      expect(mockCoreApi.getProjects).not.toHaveBeenCalled();
+      expect(elicitMock).not.toHaveBeenCalled();
+    });
+
+    it("should not use empty ado_mcp_project env var as default", async () => {
+      process.env.ado_mcp_project = "";
+      (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      elicitMock.mockResolvedValue({ action: "accept", content: { project: "ProjectAlpha" } });
+
+      const result = await elicitProject(server, mockConnection as unknown as WebApi);
+
+      expect(mockCoreApi.getProjects).toHaveBeenCalled();
+      expect(elicitMock).toHaveBeenCalled();
+      expect(result).toEqual({ resolved: "ProjectAlpha" });
+    });
   });
 
   describe("elicitTeam", () => {
+    const originalTeamEnv = process.env.ado_mcp_team;
+
+    afterEach(() => {
+      if (originalTeamEnv === undefined) {
+        delete process.env.ado_mcp_team;
+      } else {
+        process.env.ado_mcp_team = originalTeamEnv;
+      }
+    });
+
     it("should use default message when no message is provided", async () => {
+      delete process.env.ado_mcp_team;
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
 
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
@@ -54,6 +103,7 @@ describe("elicitations", () => {
     });
 
     it("should fall back to team id when name is missing", async () => {
+      delete process.env.ado_mcp_team;
       (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([
         { id: "team-1", name: undefined },
         { id: undefined, name: undefined },
@@ -70,6 +120,33 @@ describe("elicitations", () => {
       expect(oneOf[0]).toEqual({ const: "team-1", title: "team-1" });
       expect(oneOf[1]).toEqual({ const: "", title: "Unknown team" });
       expect(result).toEqual({ resolved: "team-1" });
+    });
+
+    it("should resolve to default team from ado_mcp_team env var without elicitation", async () => {
+      process.env.ado_mcp_team = "DefaultTeam";
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+
+      const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
+
+      expect(result).toEqual({ resolved: "DefaultTeam" });
+      expect(mockConnection.getCoreApi).not.toHaveBeenCalled();
+      expect(mockCoreApi.getTeams).not.toHaveBeenCalled();
+      expect(elicitMock).not.toHaveBeenCalled();
+    });
+
+    it("should not use empty ado_mcp_team env var as default", async () => {
+      process.env.ado_mcp_team = "";
+      (mockCoreApi.getTeams as jest.Mock).mockResolvedValue([{ id: "team-1", name: "Team One" }]);
+
+      const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
+      elicitMock.mockResolvedValue({ action: "accept", content: { team: "Team One" } });
+
+      const result = await elicitTeam(server, mockConnection as unknown as WebApi, "ProjectAlpha");
+
+      expect(mockCoreApi.getTeams).toHaveBeenCalled();
+      expect(elicitMock).toHaveBeenCalled();
+      expect(result).toEqual({ resolved: "Team One" });
     });
   });
 });


### PR DESCRIPTION
This pull request adds support for setting default Azure DevOps project and team values via environment variables and updates the documentation and tests accordingly. Now, if the environment variables are set, users will not be prompted to select a project or team, streamlining the workflow. The changes also document how to set these defaults in `.vscode/mcp.json` and ensure robust test coverage for the new behavior.

## GitHub issue number
#1195

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual testing and updated auto tests
