### PR TITLE
Enhance error handling for pull request creation and update tests

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -184,6 +184,9 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
         const workItemRefs = workItems ? workItems.split(" ").map((id) => ({ id: id.trim() })) : [];
+        const noDataErrorMessage =
+          `Pull request creation returned no data and no matching PR was found. This often means repositoryId=\"${repositoryId}\" was not resolvable. ` +
+          "Try the repository GUID from repo_list_repos_by_project instead of the Project/RepoName slash format.";
 
         const forkSource: GitForkRef | undefined = forkSourceRepositoryId
           ? {
@@ -217,7 +220,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
             pullRequest = prs[0];
           } else {
             return {
-              content: [{ type: "text", text: "Pull request created but API returned no data." }],
+              content: [{ type: "text", text: noDataErrorMessage }],
+              isError: true,
             };
           }
         }
@@ -226,7 +230,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
         if (!trimmedPullRequest) {
           return {
-            content: [{ type: "text", text: "Pull request created but API returned no data." }],
+            content: [{ type: "text", text: noDataErrorMessage }],
+            isError: true,
           };
         }
 

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -1184,7 +1184,7 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(expectedTrimmedPR, null, 2));
     });
 
-    it("should return no-data message when createPullRequest returns null and fallback finds no PRs", async () => {
+    it("should return error when createPullRequest returns null and fallback finds no PRs", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.create_pull_request);
@@ -1203,8 +1203,9 @@ describe("repos tools", () => {
 
       const result = await handler(params);
 
-      expect(result.content[0].text).toBe("Pull request created but API returned no data.");
-      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('repositoryId="repo123"');
+      expect(result.content[0].text).toContain("repo_list_repos_by_project");
+      expect(result.isError).toBe(true);
     });
   });
 


### PR DESCRIPTION
This pull request improves error handling and messaging for pull request creation failures in the repository tools. When the API does not return data and no matching pull request is found, the user is now given a more informative error message, and the response is explicitly marked as an error. Corresponding tests have been updated to validate these changes.

## GitHub issue number
#1245 

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manual tested and updated and ran automated tests
