### PR TITLE
feat: add Enterprise Live Migration (ELM) domain with 15 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ For example, use `"-d", "core", "work", "work-items"` to load only Work Item rel
 }
 ```
 
-Domains that are available are: `core`, `work`, `work-items`, `search`, `test-plans`, `repositories`, `wiki`, `pipelines`, `advanced-security`
+Domains that are available are: `core`, `work`, `work-items`, `search`, `test-plans`, `repositories`, `wiki`, `pipelines`, `advanced-security`, `enterprise-live-migration`
 
 We recommend that you always enable `core` tools so that you can fetch project level information.
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -15,6 +15,7 @@ This guide offers step-by-step examples for using the Azure DevOps MCP Server to
 - [Remove Links from a Work Item](#remove-one-or-more-links-from-a-work-item)
 - [Adding Artifact Links](#adding-artifact-links)
 - [Reading, Creating, and Updating Wiki Page Content](#reading-creating-and-updating-wiki-page-content)
+- [Enterprise Live Migration](#enterprise-live-migration)
 
 ## 🙋‍♂️ Projects and Teams
 
@@ -217,3 +218,83 @@ Create new wiki page called 'how to bake a cake' and add the following content:
 ```
 
 📽️ [Azure Devops MCP Server: Reading, creating, and updating wiki pages](https://youtu.be/z_WQ_QefpGU)
+
+## 🚀 Enterprise Live Migration
+
+Enterprise Live Migration (ELM) tools help you migrate Azure DevOps Git repositories to GitHub. Enable the `enterprise-live-migration` domain in your `mcp.json` to use these tools.
+
+### List Migrations
+
+See all active and recent migrations in your organization:
+
+```text
+List all ELM migrations
+```
+
+Filter to a specific project:
+
+```text
+List ELM migrations for project Contoso
+```
+
+### Check Migration Status
+
+Get detailed status for a specific repository's migration:
+
+```text
+What is the ELM migration status for repo d8ad85a3-1b56-4ca5-aac2-64f63e847b9e?
+```
+
+### Create a Validate-Only Migration
+
+Run pre-migration validation checks without starting a full sync:
+
+```text
+Create a validate-only ELM migration for repo 5a139f93-d787-4de4-ab94-cba75ca89d29 to https://example.ghe.com/org/my-repo with owner ghuser
+```
+
+### Create a Full Migration
+
+Start a full migration with synchronization:
+
+```text
+Create an ELM migration for repo 5a139f93-d787-4de4-ab94-cba75ca89d29 to https://example.ghe.com/org/my-repo with owner ghuser and schedule cutover for 2026-07-01
+```
+
+### Pause and Resume
+
+```text
+Pause the ELM migration for repo 5a139f93-d787-4de4-ab94-cba75ca89d29
+```
+
+```text
+Resume the ELM migration for repo 5a139f93-d787-4de4-ab94-cba75ca89d29
+```
+
+### Schedule and Cancel Cutover
+
+```text
+Schedule cutover for repo 5a139f93-d787-4de4-ab94-cba75ca89d29 on July 1st 2026 at midnight UTC
+```
+
+```text
+Cancel the scheduled cutover for repo 5a139f93-d787-4de4-ab94-cba75ca89d29
+```
+
+### Review and Approve Cutover
+
+When a migration reaches the ReviewForCutover stage, review pending issues and approve:
+
+```text
+Show the cutover review for repo d8ad85a3-1b56-4ca5-aac2-64f63e847b9e
+```
+
+```text
+Approve cutover for repo d8ad85a3-1b56-4ca5-aac2-64f63e847b9e with 2 accepted failures
+```
+
+### Abandon a Migration
+
+```text
+Abandon the ELM migration for repo 5a139f93-d787-4de4-ab94-cba75ca89d29
+```

--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -109,6 +109,103 @@ Get detailed information about a specific Advanced Security alert.
 - **Required**: `project`, `repository`, `alertId`
 - **Optional**: `ref`
 
+## Enterprise Live Migration
+
+### mcp_ado_enterprise-live-migration_list
+
+List all Enterprise Live Migration (ELM) migrations for the organization. By default returns only the latest migration per repository.
+
+- **Optional**: `includeAllMigrations`, `project`
+
+### mcp_ado_enterprise-live-migration_status
+
+Get the status of an Enterprise Live Migration for a specific repository.
+
+- **Required**: `repositoryId`
+
+### mcp_ado_enterprise-live-migration_create
+
+Create a new Enterprise Live Migration to migrate an Azure DevOps Git repository to GitHub.
+
+- **Required**: `repositoryId`, `targetRepository`
+- **Optional**: `targetOwnerUserId`, `gitHubUserToken`, `validateOnly`, `scheduledCutoverDate`, `skipValidation`, `agentPool`, `serviceEndpointId`, `pipelineServiceConnectionId`, `configOptions`
+
+### mcp_ado_enterprise-live-migration_pause
+
+Pause an active Enterprise Live Migration. The migration can be resumed later.
+
+- **Required**: `repositoryId`
+
+### mcp_ado_enterprise-live-migration_resume
+
+Resume a paused Enterprise Live Migration.
+
+- **Required**: `repositoryId`
+- **Optional**: `validateOnly`
+
+### mcp_ado_enterprise-live-migration_cutover_set
+
+Schedule the cutover date for an Enterprise Live Migration.
+
+- **Required**: `repositoryId`, `scheduledCutoverDate`
+
+### mcp_ado_enterprise-live-migration_cutover_cancel
+
+Cancel a previously scheduled cutover for an Enterprise Live Migration.
+
+- **Required**: `repositoryId`
+
+### mcp_ado_enterprise-live-migration_abandon
+
+Abandon (delete) an Enterprise Live Migration. This cannot be undone.
+
+- **Required**: `repositoryId`
+- **Optional**: `removeReadOnly`
+
+### mcp_ado_enterprise-live-migration_get_cutover_review
+
+Get the cutover review showing failed, blocked, and pending items that may need approval before cutover.
+
+- **Required**: `repositoryId`
+
+### mcp_ado_enterprise-live-migration_approve_cutover
+
+Approve cutover by accepting the specified number of failures.
+
+- **Required**: `repositoryId`, `cutoverFailureAcceptedCount`
+
+### mcp_ado_enterprise-live-migration_device_flow_config
+
+Get the GitHub App device flow configuration needed to authenticate for a migration.
+
+- **Required**: `targetRepository`
+
+### mcp_ado_enterprise-live-migration_pipelines_list
+
+List pipelines and their rewiring status for an Enterprise Live Migration.
+
+- **Required**: `repositoryId`
+
+### mcp_ado_enterprise-live-migration_pipelines_submit
+
+Submit pipelines for rewiring as part of an Enterprise Live Migration.
+
+- **Required**: `repositoryId`, `pipelineIds`, `serviceConnectionId`
+- **Optional**: `repositoryMappings`
+
+### mcp_ado_enterprise-live-migration_pipelines_update
+
+Update the pipeline rewiring configuration for an Enterprise Live Migration.
+
+- **Required**: `repositoryId`
+- **Optional**: `addPipelineIds`, `removePipelineIds`, `serviceConnectionId`, `repositoryMappings`, `retryFailedPipelineIds`, `acknowledgePipelineIds`
+
+### mcp_ado_enterprise-live-migration_pipelines_delete
+
+Delete all pipeline clone definitions and config. Only allowed for terminal migrations (Failed or Completed).
+
+- **Required**: `repositoryId`, `migrationId`
+
 ## Core
 
 ### mcp_ado_core_list_projects

--- a/src/shared/domains.ts
+++ b/src/shared/domains.ts
@@ -17,6 +17,7 @@ export enum Domain {
   WORK = "work",
   WORK_ITEMS = "work-items",
   MCP_APPS = "mcp-apps",
+  ENTERPRISE_LIVE_MIGRATION = "enterprise-live-migration",
 }
 
 export const ALL_DOMAINS = "all";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,6 +15,7 @@ import { configureTestPlanTools } from "./tools/test-plans.js";
 import { configureWikiTools } from "./tools/wiki.js";
 import { configureWorkTools } from "./tools/work.js";
 import { configureWorkItemTools } from "./tools/work-items.js";
+import { configureEnterpriseLiveMigrationTools } from "./tools/enterprise-live-migration.js";
 
 function configureAllTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string, enabledDomains: Set<string>) {
   const configureIfDomainEnabled = (domain: string, configureFn: () => void) => {
@@ -33,6 +34,7 @@ function configureAllTools(server: McpServer, tokenProvider: () => Promise<strin
   configureIfDomainEnabled(Domain.TEST_PLANS, () => configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.SEARCH, () => configureSearchTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.ADVANCED_SECURITY, () => configureAdvSecTools(server, tokenProvider, connectionProvider));
+  configureIfDomainEnabled(Domain.ENTERPRISE_LIVE_MIGRATION, () => configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider));
 }
 
 export { configureAllTools };

--- a/src/tools/enterprise-live-migration.ts
+++ b/src/tools/enterprise-live-migration.ts
@@ -1,0 +1,516 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebApi } from "azure-devops-node-api";
+import { z } from "zod";
+import { apiVersion } from "../utils.js";
+
+const ELM_TOOLS = {
+  list: "enterprise-live-migration_list",
+  status: "enterprise-live-migration_status",
+  create: "enterprise-live-migration_create",
+  pause: "enterprise-live-migration_pause",
+  resume: "enterprise-live-migration_resume",
+  cutover_set: "enterprise-live-migration_cutover_set",
+  cutover_cancel: "enterprise-live-migration_cutover_cancel",
+  abandon: "enterprise-live-migration_abandon",
+  get_cutover_review: "enterprise-live-migration_get_cutover_review",
+  approve_cutover: "enterprise-live-migration_approve_cutover",
+  device_flow_config: "enterprise-live-migration_device_flow_config",
+  pipelines_list: "enterprise-live-migration_pipelines_list",
+  pipelines_submit: "enterprise-live-migration_pipelines_submit",
+  pipelines_update: "enterprise-live-migration_pipelines_update",
+  pipelines_delete: "enterprise-live-migration_pipelines_delete",
+};
+
+/**
+ * Bitmask values for skipping specific validation checks when creating a migration.
+ */
+const SKIP_VALIDATION_FLAGS: Record<string, number> = {
+  ActivePullRequestCount: 1,
+  PullRequestDeltaSize: 2,
+  AgentPoolExists: 4,
+  MaxFileSize: 8,
+  MaxPullRequestSize: 16,
+  MaxPushPackSize: 32,
+  MaxReferenceNameLength: 64,
+  TargetRepositoryDoesNotExist: 256,
+  SourceRepositoryContainsLfsObjects: 512,
+  SourceRepositoryNotReadOnly: 1024,
+  BoardsGitHubConnectionProvisioning: 2048,
+  All: 2147483647,
+};
+
+const skipValidationFlagNames = Object.keys(SKIP_VALIDATION_FLAGS) as [string, ...string[]];
+
+/**
+ * Convert an array of skip-validation flag names to the combined bitmask value.
+ */
+function toSkipValidationBitmask(flags: string[]): number {
+  let mask = 0;
+  for (const flag of flags) {
+    const value = SKIP_VALIDATION_FLAGS[flag];
+    if (value !== undefined) {
+      mask |= value;
+    }
+  }
+  return mask;
+}
+
+/**
+ * Make an authenticated fetch request to the ELM REST API.
+ */
+async function elmFetch(orgUrl: string, path: string, token: string, userAgent: string, options: { method?: string; body?: unknown } = {}): Promise<Response> {
+  const url = `${orgUrl}/_apis/elm/migrations${path}?api-version=${apiVersion}`;
+  return fetch(url, {
+    method: options.method ?? "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`,
+      "User-Agent": userAgent,
+    },
+    ...(options.body !== undefined && { body: JSON.stringify(options.body) }),
+  });
+}
+
+/**
+ * Handle the fetch response: throw on error, return JSON text on success.
+ */
+async function handleResponse(response: Response, action: string): Promise<{ content: { type: "text"; text: string }[] }> {
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to ${action}: ${response.status} ${errorText}`);
+  }
+  const text = await response.text();
+  // Try to pretty-print JSON, fall back to raw text
+  let formatted: string;
+  try {
+    formatted = JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    formatted = text;
+  }
+  return { content: [{ type: "text", text: formatted }] };
+}
+
+function configureEnterpriseLiveMigrationTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
+  // Helper to get org URL, token, and user agent for every tool
+  async function getContext() {
+    const [token, connection] = await Promise.all([tokenProvider(), connectionProvider()]);
+    return { orgUrl: connection.serverUrl, token, userAgent: userAgentProvider() };
+  }
+
+  // ── 1. List migrations ──────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.list,
+    "List all Enterprise Live Migration (ELM) migrations for the organization. ELM migrates Azure DevOps Git repositories to GitHub. By default returns only the latest migration per repository.",
+    {
+      includeAllMigrations: z.boolean().optional().describe("If true, returns all migration records including historical entries. Defaults to false (latest per repository only)."),
+      project: z.string().optional().describe("Optional project name or ID to filter migrations to a specific project."),
+    },
+    async ({ includeAllMigrations, project }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const params = new URLSearchParams();
+        if (includeAllMigrations) params.set("includeAllMigrations", "true");
+        if (project) params.set("project", project);
+        const query = params.toString();
+        const suffix = query ? `&${query}` : "";
+        const url = `${orgUrl}/_apis/elm/migrations?api-version=${apiVersion}${suffix}`;
+        const response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,
+            "User-Agent": userAgent,
+          },
+        });
+        return await handleResponse(response, "list migrations");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error listing migrations: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 2. Get migration status ─────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.status,
+    "Get the status of an Enterprise Live Migration (ELM) for a specific repository.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the Azure DevOps repository."),
+    },
+    async ({ repositoryId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent);
+        return await handleResponse(response, "get migration status");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error getting migration status: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 3. Create migration ─────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.create,
+    "Create a new Enterprise Live Migration (ELM) to migrate an Azure DevOps Git repository to GitHub. Starts validation and synchronization.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the Azure DevOps repository to migrate."),
+      targetRepository: z.string().describe("The full target GitHub repository URL (e.g. https://example.ghe.com/orgname/reponame)."),
+      targetOwnerUserId: z.string().optional().describe("The GitHub login of the migration owner. Required when GitHubUserToken is not provided."),
+      gitHubUserToken: z
+        .string()
+        .optional()
+        .describe("A GitHub token (Device Flow or PAT with read:org scope) to verify the migration owner's identity. When provided, targetOwnerUserId is set automatically by the server."),
+      validateOnly: z.boolean().optional().describe("If true, only validate the migration without starting synchronization."),
+      scheduledCutoverDate: z.string().optional().describe("ISO 8601 date-time for the scheduled cutover (must be in the future)."),
+      skipValidation: z
+        .array(z.enum(skipValidationFlagNames))
+        .optional()
+        .describe(
+          "Validation checks to skip. Options: ActivePullRequestCount, PullRequestDeltaSize, AgentPoolExists, MaxFileSize, MaxPullRequestSize, MaxPushPackSize, MaxReferenceNameLength, TargetRepositoryDoesNotExist, SourceRepositoryContainsLfsObjects, SourceRepositoryNotReadOnly, BoardsGitHubConnectionProvisioning, All."
+        ),
+      agentPool: z.string().optional().describe("The agent pool name to use for the migration pipeline."),
+      serviceEndpointId: z.string().optional().describe("The ID (GUID) of a GitHub Enterprise Server service connection for GHES migrations."),
+      pipelineServiceConnectionId: z.string().optional().describe("The ID (GUID) of a GitHub service connection for pipeline rewiring."),
+      configOptions: z
+        .object({
+          enableAutoDiscoverPipelines: z.boolean().optional().describe("Enable automatic pipeline discovery for rewiring."),
+          skipSourceRepoLockdown: z.boolean().optional().describe("Skip setting the source ADO repo to read-only during cutover."),
+          skipBranchPolicyMigration: z.boolean().optional().describe("Skip migrating branch policies to GitHub rulesets."),
+          enableBoardsGitHubConnection: z.boolean().optional().describe("Enable automatic Azure Boards GitHub connection on cutover."),
+        })
+        .optional()
+        .describe("Optional configuration options for the migration."),
+    },
+    async ({
+      repositoryId,
+      targetRepository,
+      targetOwnerUserId,
+      gitHubUserToken,
+      validateOnly,
+      scheduledCutoverDate,
+      skipValidation,
+      agentPool,
+      serviceEndpointId,
+      pipelineServiceConnectionId,
+      configOptions,
+    }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body: Record<string, unknown> = { targetRepository };
+        if (targetOwnerUserId !== undefined) body.targetOwnerUserId = targetOwnerUserId;
+        if (gitHubUserToken !== undefined) body.gitHubUserToken = gitHubUserToken;
+        if (validateOnly !== undefined) body.validateOnly = validateOnly;
+        if (scheduledCutoverDate !== undefined) body.scheduledCutoverDate = scheduledCutoverDate;
+        if (skipValidation !== undefined) body.skipValidation = toSkipValidationBitmask(skipValidation);
+        if (agentPool !== undefined) body.agentPoolName = agentPool;
+        if (serviceEndpointId !== undefined) body.serviceEndpointId = serviceEndpointId;
+        if (pipelineServiceConnectionId !== undefined) body.pipelineServiceConnectionId = pipelineServiceConnectionId;
+        if (configOptions !== undefined) body.configOptions = configOptions;
+
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "POST", body });
+        return await handleResponse(response, "create migration");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error creating migration: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 4. Pause migration ──────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.pause,
+    "Pause (suspend) an active Enterprise Live Migration. The migration can be resumed later.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose migration to pause."),
+    },
+    async ({ repositoryId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body = { statusRequested: "Paused" };
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "pause migration");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error pausing migration: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 5. Resume migration ─────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.resume,
+    "Resume a paused Enterprise Live Migration.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose migration to resume."),
+      validateOnly: z.boolean().optional().describe("If true, resume in validate-only mode instead of full migration mode."),
+    },
+    async ({ repositoryId, validateOnly }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body: Record<string, unknown> = { statusRequested: "Active" };
+        if (validateOnly !== undefined) body.validateOnly = validateOnly;
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "resume migration");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error resuming migration: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 6. Set cutover date ─────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.cutover_set,
+    "Schedule the cutover date for an Enterprise Live Migration. The cutover date must be in the future.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose migration cutover to schedule."),
+      scheduledCutoverDate: z.string().describe("ISO 8601 date-time for the scheduled cutover (must be in the future)."),
+    },
+    async ({ repositoryId, scheduledCutoverDate }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body = { scheduledCutoverDate };
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "set cutover date");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error setting cutover date: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 7. Cancel cutover ───────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.cutover_cancel,
+    "Cancel a previously scheduled cutover for an Enterprise Live Migration.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose cutover to cancel."),
+    },
+    async ({ repositoryId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        // DateTimeOffset.MinValue ("0001-01-01T00:00:00+00:00") is the server sentinel for "clear cutover date"
+        const body = { scheduledCutoverDate: "0001-01-01T00:00:00+00:00" };
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "cancel cutover");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error canceling cutover: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 8. Abandon migration ────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.abandon,
+    "Abandon (delete) an Enterprise Live Migration. This cannot be undone.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose migration to abandon."),
+      removeReadOnly: z.boolean().optional().describe("If true and the migration has reached the Migrated stage, takes the source ADO repository out of read-only mode."),
+    },
+    async ({ repositoryId, removeReadOnly }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const params = removeReadOnly ? `&removeReadOnly=true` : "";
+        const url = `${orgUrl}/_apis/elm/migrations/${repositoryId}?api-version=${apiVersion}${params}`;
+        const response = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,
+            "User-Agent": userAgent,
+          },
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Failed to abandon migration: ${response.status} ${errorText}`);
+        }
+        return { content: [{ type: "text", text: "Migration abandoned successfully." }] };
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error abandoning migration: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 9. Get cutover review ───────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.get_cutover_review,
+    "Get the cutover review for an Enterprise Live Migration. Shows failed, blocked, and pending items that may need approval before cutover can proceed.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository to get the cutover review for."),
+    },
+    async ({ repositoryId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const response = await elmFetch(orgUrl, `/${repositoryId}/cutoverReview`, token, userAgent);
+        return await handleResponse(response, "get cutover review");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error getting cutover review: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 10. Approve cutover ─────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.approve_cutover,
+    "Approve cutover for an Enterprise Live Migration by accepting the specified number of failures. The count must be >= the total unprocessed items from the cutover review.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository whose cutover to approve."),
+      cutoverFailureAcceptedCount: z.number().int().min(0).describe("The number of cutover failures to accept. Must be >= totalUnprocessedCount from the cutover review."),
+    },
+    async ({ repositoryId, cutoverFailureAcceptedCount }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body = { cutoverFailureAcceptedCount };
+        const response = await elmFetch(orgUrl, `/${repositoryId}`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "approve cutover");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error approving cutover: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 11. Get device flow config ──────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.device_flow_config,
+    "Get the GitHub App device flow configuration (client ID and enterprise URL) needed to authenticate for a migration.",
+    {
+      targetRepository: z.string().describe("The full target repository URL (e.g. https://example.ghe.com/orgname/reponame)."),
+    },
+    async ({ targetRepository }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const url = `${orgUrl}/_apis/elm/migrations/deviceFlowConfig?api-version=${apiVersion}&targetRepository=${encodeURIComponent(targetRepository)}`;
+        const response = await fetch(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,
+            "User-Agent": userAgent,
+          },
+        });
+        return await handleResponse(response, "get device flow config");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error getting device flow config: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 12. List pipelines ──────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.pipelines_list,
+    "List pipelines and their rewiring status for an Enterprise Live Migration.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository."),
+    },
+    async ({ repositoryId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const response = await elmFetch(orgUrl, `/${repositoryId}/pipelines`, token, userAgent);
+        return await handleResponse(response, "list pipelines");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error listing pipelines: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 13. Submit pipelines ────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.pipelines_submit,
+    "Submit pipelines for rewiring as part of an Enterprise Live Migration. Triggers classification and pre-checks.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository."),
+      pipelineIds: z.array(z.number().int()).describe("The build definition IDs of the pipelines to rewire."),
+      serviceConnectionId: z.string().describe("The ID (GUID) of the GitHub service connection for the rewired pipelines."),
+      repositoryMappings: z
+        .array(
+          z.object({
+            sourceRepositoryId: z.string().describe("The AzDO repository GUID of the source repository."),
+            targetRepository: z.string().describe("The GitHub target repository in 'owner/repo' format."),
+          })
+        )
+        .optional()
+        .describe("Cross-repo mappings for pipelines that reference other AzDO repositories."),
+    },
+    async ({ repositoryId, pipelineIds, serviceConnectionId, repositoryMappings }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body: Record<string, unknown> = { pipelineIds, serviceConnectionId };
+        if (repositoryMappings !== undefined) body.repositoryMappings = repositoryMappings;
+        const response = await elmFetch(orgUrl, `/${repositoryId}/pipelines`, token, userAgent, { method: "POST", body });
+        return await handleResponse(response, "submit pipelines");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error submitting pipelines: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 14. Update pipelines ────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.pipelines_update,
+    "Update the pipeline rewiring configuration for an Enterprise Live Migration.",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository."),
+      addPipelineIds: z.array(z.number().int()).optional().describe("Pipeline definition IDs to add to the rewiring selection."),
+      removePipelineIds: z.array(z.number().int()).optional().describe("Pipeline definition IDs to remove. Clones will be deleted."),
+      serviceConnectionId: z.string().optional().describe("Updated GitHub service connection ID."),
+      repositoryMappings: z
+        .array(
+          z.object({
+            sourceRepositoryId: z.string().describe("The AzDO repository GUID."),
+            targetRepository: z.string().describe("The GitHub target repository in 'owner/repo' format."),
+          })
+        )
+        .optional()
+        .describe("Repository mappings to add or update."),
+      retryFailedPipelineIds: z.array(z.number().int()).optional().describe("Pipeline IDs in Failed status to retry on the next sync cycle."),
+      acknowledgePipelineIds: z.array(z.number().int()).optional().describe("Pipeline IDs to acknowledge so they do not block cutover."),
+    },
+    async ({ repositoryId, addPipelineIds, removePipelineIds, serviceConnectionId, repositoryMappings, retryFailedPipelineIds, acknowledgePipelineIds }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const body: Record<string, unknown> = {};
+        if (addPipelineIds !== undefined) body.addPipelineIds = addPipelineIds;
+        if (removePipelineIds !== undefined) body.removePipelineIds = removePipelineIds;
+        if (serviceConnectionId !== undefined) body.serviceConnectionId = serviceConnectionId;
+        if (repositoryMappings !== undefined) body.repositoryMappings = repositoryMappings;
+        if (retryFailedPipelineIds !== undefined) body.retryFailedPipelineIds = retryFailedPipelineIds;
+        if (acknowledgePipelineIds !== undefined) body.acknowledgePipelineIds = acknowledgePipelineIds;
+        const response = await elmFetch(orgUrl, `/${repositoryId}/pipelines`, token, userAgent, { method: "PUT", body });
+        return await handleResponse(response, "update pipelines");
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error updating pipelines: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+
+  // ── 15. Delete pipelines ────────────────────────────────────────────
+  server.tool(
+    ELM_TOOLS.pipelines_delete,
+    "Delete all pipeline clone definitions and config for an Enterprise Live Migration. Only allowed for terminal migrations (Failed or Completed).",
+    {
+      repositoryId: z.string().describe("The ID (GUID) of the repository."),
+      migrationId: z.number().int().describe("The migration ID to delete pipelines for."),
+    },
+    async ({ repositoryId, migrationId }) => {
+      try {
+        const { orgUrl, token, userAgent } = await getContext();
+        const url = `${orgUrl}/_apis/elm/migrations/${repositoryId}/pipelines?api-version=${apiVersion}&migrationId=${migrationId}`;
+        const response = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,
+            "User-Agent": userAgent,
+          },
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Failed to delete pipelines: ${response.status} ${errorText}`);
+        }
+        return { content: [{ type: "text", text: "Pipeline configurations deleted successfully." }] };
+      } catch (error) {
+        return { content: [{ type: "text", text: `Error deleting pipelines: ${error instanceof Error ? error.message : String(error)}` }], isError: true };
+      }
+    }
+  );
+}
+
+export { configureEnterpriseLiveMigrationTools };

--- a/test/src/domains.test.ts
+++ b/test/src/domains.test.ts
@@ -29,7 +29,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager();
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("advanced-security")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
       expect(enabledDomains.has("core")).toBe(true);
@@ -45,8 +45,8 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(undefined);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
-      expect(Array.from(enabledDomains).sort()).toEqual(["advanced-security", "core", "pipelines", "repositories", "search", "test-plans", "wiki", "work", "work-items"]);
+      expect(enabledDomains.size).toBe(10);
+      expect(Array.from(enabledDomains).sort()).toEqual(["advanced-security", "core", "enterprise-live-migration", "pipelines", "repositories", "search", "test-plans", "wiki", "work", "work-items"]);
     });
 
     it("enables all domains when null is passed as argument (legacy support)", () => {
@@ -54,7 +54,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(null);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -63,7 +63,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("repositories")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
     });
@@ -88,9 +88,9 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("invalid-domain");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(errorSpy).toHaveBeenCalledWith(
-        "Error: Specified invalid domain 'invalid-domain'. Please specify exactly as available domains: advanced-security, pipelines, core, repositories, search, test-plans, wiki, work, work-items"
+        "Error: Specified invalid domain 'invalid-domain'. Please specify exactly as available domains: advanced-security, pipelines, core, repositories, search, test-plans, wiki, work, work-items, enterprise-live-migration"
       );
     });
   });
@@ -100,7 +100,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["all"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("repositories")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
     });
@@ -120,7 +120,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager([]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("filters out invalid domains and enables only valid ones when mixed array is passed", () => {
@@ -164,8 +164,8 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
     it("returns the full list of available domains", () => {
       const availableDomains = DomainsManager.getAvailableDomains();
 
-      expect(availableDomains).toEqual(["advanced-security", "pipelines", "core", "repositories", "search", "test-plans", "wiki", "work", "work-items", "mcp-apps"]);
-      expect(availableDomains.length).toBe(10);
+      expect(availableDomains).toEqual(["advanced-security", "pipelines", "core", "repositories", "search", "test-plans", "wiki", "work", "work-items", "mcp-apps", "enterprise-live-migration"]);
+      expect(availableDomains.length).toBe(11);
     });
   });
 
@@ -213,7 +213,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -222,21 +222,21 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["all"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when 'all' is passed together with other valid domains", () => {
       const manager = new DomainsManager(["all", "pipelines"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when 'all' is passed along with invalid domains", () => {
       const manager = new DomainsManager(["a", "all", "wiki"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -272,14 +272,14 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["repositories", "all", "pipelines"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when all specified domains are invalid", () => {
       const manager = new DomainsManager(["invalid1", "invalid2"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(errorSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -287,7 +287,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("processes 'all' through validateAndAddDomains when passed as uppercase string", () => {
@@ -296,7 +296,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("processes 'all' through validateAndAddDomains in comma-separated string", () => {
@@ -304,7 +304,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("repositories,all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("hits handleStringInput with exact 'all' string", () => {
@@ -312,7 +312,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("tests direct parseDomainsInput with empty string", () => {
@@ -320,7 +320,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("tests comma-separated string input with 'all' keyword", () => {
@@ -331,7 +331,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       // Test that this actually gets processed correctly
       const manager = new DomainsManager("repositories,all,core");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9); // Should enable all because 'all' is present
+      expect(enabledDomains.size).toBe(10); // Should enable all because 'all' is present
     });
   });
 
@@ -339,19 +339,19 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
     it("when an empty array is passed", () => {
       const manager = new DomainsManager([]);
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("when a string with only a break line is passed", () => {
       const manager = new DomainsManager("\n");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("when an empty string is passed", () => {
       const manager = new DomainsManager("");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 });

--- a/test/src/tools/enterprise-live-migration.test.ts
+++ b/test/src/tools/enterprise-live-migration.test.ts
@@ -1,0 +1,472 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, beforeEach } from "@jest/globals";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebApi } from "azure-devops-node-api";
+import { configureEnterpriseLiveMigrationTools } from "../../../src/tools/enterprise-live-migration";
+import { apiVersion } from "../../../src/utils.js";
+
+// Mock fetch globally
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+type TokenProviderMock = () => Promise<string>;
+type ConnectionProviderMock = () => Promise<WebApi>;
+
+function getToolHandler(server: McpServer, toolName: string) {
+  const call = (server.tool as jest.Mock).mock.calls.find(([name]: [string]) => name === toolName);
+  if (!call) throw new Error(`${toolName} tool not registered`);
+  return call[3]; // handler is the 4th argument
+}
+
+function mockFetchResponse(ok: boolean, body: unknown, status = 200) {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok,
+    status,
+    text: jest.fn().mockResolvedValue(text),
+  } as unknown as Response;
+}
+
+describe("configureEnterpriseLiveMigrationTools", () => {
+  let server: McpServer;
+  let tokenProvider: TokenProviderMock;
+  let connectionProvider: ConnectionProviderMock;
+  let userAgentProvider: () => string;
+  let mockConnection: { serverUrl: string };
+
+  beforeEach(() => {
+    server = { tool: jest.fn() } as unknown as McpServer;
+    tokenProvider = jest.fn().mockResolvedValue("mock-token") as TokenProviderMock;
+    userAgentProvider = () => "Jest";
+    mockConnection = { serverUrl: "https://dev.azure.com/test-org" };
+    connectionProvider = jest.fn().mockResolvedValue(mockConnection) as ConnectionProviderMock;
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockClear();
+  });
+
+  describe("tool registration", () => {
+    it("registers all 15 ELM tools on the server", () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      expect(server.tool as jest.Mock).toHaveBeenCalledTimes(15);
+    });
+
+    it("registers tools with correct names", () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const registeredNames = (server.tool as jest.Mock).mock.calls.map(([name]: [string]) => name);
+      expect(registeredNames).toEqual([
+        "enterprise-live-migration_list",
+        "enterprise-live-migration_status",
+        "enterprise-live-migration_create",
+        "enterprise-live-migration_pause",
+        "enterprise-live-migration_resume",
+        "enterprise-live-migration_cutover_set",
+        "enterprise-live-migration_cutover_cancel",
+        "enterprise-live-migration_abandon",
+        "enterprise-live-migration_get_cutover_review",
+        "enterprise-live-migration_approve_cutover",
+        "enterprise-live-migration_device_flow_config",
+        "enterprise-live-migration_pipelines_list",
+        "enterprise-live-migration_pipelines_submit",
+        "enterprise-live-migration_pipelines_update",
+        "enterprise-live-migration_pipelines_delete",
+      ]);
+    });
+  });
+
+  describe("enterprise-live-migration_list", () => {
+    it("should call the correct URL with no params", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_list");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, [{ repositoryId: "repo-1", status: "Active" }]));
+
+      await handler({});
+
+      expect(global.fetch).toHaveBeenCalledWith(`https://dev.azure.com/test-org/_apis/elm/migrations?api-version=${apiVersion}`, expect.objectContaining({ method: "GET" }));
+    });
+
+    it("should include query params when provided", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_list");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, []));
+
+      await handler({ includeAllMigrations: true, project: "my-project" });
+
+      const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("includeAllMigrations=true");
+      expect(calledUrl).toContain("project=my-project");
+    });
+
+    it("should return error on HTTP failure", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_list");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(false, "Not Found", 404));
+
+      const result = await handler({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Error listing migrations");
+    });
+  });
+
+  describe("enterprise-live-migration_status", () => {
+    it("should call the correct URL with repositoryId", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_status");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123", status: "Active" }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      expect(global.fetch).toHaveBeenCalledWith(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123?api-version=${apiVersion}`, expect.objectContaining({ method: "GET" }));
+    });
+  });
+
+  describe("enterprise-live-migration_create", () => {
+    it("should POST with required and optional fields", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_create");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123", status: "Active" }));
+
+      await handler({
+        repositoryId: "abc-123",
+        targetRepository: "https://example.ghe.com/org/repo",
+        targetOwnerUserId: "ghuser",
+        validateOnly: true,
+        agentPool: "my-pool",
+      });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123?api-version=${apiVersion}`);
+      expect(options?.method).toBe("POST");
+      const body = JSON.parse(options?.body as string);
+      expect(body.targetRepository).toBe("https://example.ghe.com/org/repo");
+      expect(body.targetOwnerUserId).toBe("ghuser");
+      expect(body.validateOnly).toBe(true);
+      expect(body.agentPoolName).toBe("my-pool");
+    });
+
+    it("should convert skipValidation flags to bitmask", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_create");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123" }));
+
+      await handler({
+        repositoryId: "abc-123",
+        targetRepository: "https://example.ghe.com/org/repo",
+        skipValidation: ["ActivePullRequestCount", "MaxFileSize"],
+      });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.skipValidation).toBe(1 | 8); // ActivePullRequestCount=1, MaxFileSize=8
+    });
+
+    it("should pass configOptions when provided", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_create");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123" }));
+
+      await handler({
+        repositoryId: "abc-123",
+        targetRepository: "https://example.ghe.com/org/repo",
+        configOptions: { enableAutoDiscoverPipelines: true, skipSourceRepoLockdown: false },
+      });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.configOptions).toEqual({ enableAutoDiscoverPipelines: true, skipSourceRepoLockdown: false });
+    });
+
+    it("should pass gitHubUserToken when provided", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_create");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123" }));
+
+      await handler({
+        repositoryId: "abc-123",
+        targetRepository: "https://example.ghe.com/org/repo",
+        gitHubUserToken: "ghu_abc123",
+      });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.gitHubUserToken).toBe("ghu_abc123");
+      expect(body.targetOwnerUserId).toBeUndefined();
+    });
+  });
+
+  describe("enterprise-live-migration_pause", () => {
+    it("should PUT with statusRequested=Paused", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pause");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { status: "Paused" }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123?api-version=${apiVersion}`);
+      expect(options?.method).toBe("PUT");
+      expect(JSON.parse(options?.body as string)).toEqual({ statusRequested: "Paused" });
+    });
+  });
+
+  describe("enterprise-live-migration_resume", () => {
+    it("should PUT with statusRequested=Active", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_resume");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { status: "Active" }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.statusRequested).toBe("Active");
+    });
+
+    it("should include validateOnly when provided", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_resume");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { status: "Active" }));
+
+      await handler({ repositoryId: "abc-123", validateOnly: false });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.validateOnly).toBe(false);
+    });
+  });
+
+  describe("enterprise-live-migration_cutover_set", () => {
+    it("should PUT with scheduledCutoverDate", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_cutover_set");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { scheduledCutoverDate: "2026-06-01T00:00:00Z" }));
+
+      await handler({ repositoryId: "abc-123", scheduledCutoverDate: "2026-06-01T00:00:00Z" });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.scheduledCutoverDate).toBe("2026-06-01T00:00:00Z");
+    });
+  });
+
+  describe("enterprise-live-migration_cutover_cancel", () => {
+    it("should PUT with DateTimeOffset.MinValue sentinel", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_cutover_cancel");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { scheduledCutoverDate: null }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.scheduledCutoverDate).toBe("0001-01-01T00:00:00+00:00");
+    });
+  });
+
+  describe("enterprise-live-migration_abandon", () => {
+    it("should DELETE the migration", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_abandon");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, ""));
+
+      const result = await handler({ repositoryId: "abc-123" });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123?api-version=${apiVersion}`);
+      expect(options?.method).toBe("DELETE");
+      expect(result.content[0].text).toBe("Migration abandoned successfully.");
+    });
+
+    it("should include removeReadOnly query param when true", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_abandon");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, ""));
+
+      await handler({ repositoryId: "abc-123", removeReadOnly: true });
+
+      const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("removeReadOnly=true");
+    });
+
+    it("should return error on failure", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_abandon");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(false, "Migration in Cutover stage", 400));
+
+      const result = await handler({ repositoryId: "abc-123" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Error abandoning migration");
+    });
+  });
+
+  describe("enterprise-live-migration_get_cutover_review", () => {
+    it("should GET the cutover review endpoint", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_get_cutover_review");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { failedCount: 2, blockedCount: 0, totalUnprocessedCount: 2 }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      expect(global.fetch).toHaveBeenCalledWith(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123/cutoverReview?api-version=${apiVersion}`, expect.objectContaining({ method: "GET" }));
+    });
+  });
+
+  describe("enterprise-live-migration_approve_cutover", () => {
+    it("should PUT with cutoverFailureAcceptedCount", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_approve_cutover");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { stage: "ReadyForCutover" }));
+
+      await handler({ repositoryId: "abc-123", cutoverFailureAcceptedCount: 3 });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.cutoverFailureAcceptedCount).toBe(3);
+    });
+  });
+
+  describe("enterprise-live-migration_device_flow_config", () => {
+    it("should GET the device flow config endpoint with encoded targetRepository", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_device_flow_config");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { clientId: "abc", enterpriseUrl: "https://example.ghe.com" }));
+
+      await handler({ targetRepository: "https://example.ghe.com/org/repo" });
+
+      const calledUrl = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/_apis/elm/migrations/deviceFlowConfig");
+      expect(calledUrl).toContain(encodeURIComponent("https://example.ghe.com/org/repo"));
+    });
+  });
+
+  describe("enterprise-live-migration_pipelines_list", () => {
+    it("should GET the pipelines endpoint", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_list");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { pipelines: [] }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      expect(global.fetch).toHaveBeenCalledWith(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123/pipelines?api-version=${apiVersion}`, expect.objectContaining({ method: "GET" }));
+    });
+  });
+
+  describe("enterprise-live-migration_pipelines_submit", () => {
+    it("should POST with pipelineIds and serviceConnectionId", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_submit");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, [{ definitionId: 1, status: "Pending" }]));
+
+      await handler({
+        repositoryId: "abc-123",
+        pipelineIds: [1, 2, 3],
+        serviceConnectionId: "sc-guid",
+      });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123/pipelines?api-version=${apiVersion}`);
+      expect(options?.method).toBe("POST");
+      const body = JSON.parse(options?.body as string);
+      expect(body.pipelineIds).toEqual([1, 2, 3]);
+      expect(body.serviceConnectionId).toBe("sc-guid");
+    });
+
+    it("should include repositoryMappings when provided", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_submit");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, []));
+
+      await handler({
+        repositoryId: "abc-123",
+        pipelineIds: [1],
+        serviceConnectionId: "sc-guid",
+        repositoryMappings: [{ sourceRepositoryId: "repo-A", targetRepository: "org/repo-B" }],
+      });
+
+      const body = JSON.parse((global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.body as string);
+      expect(body.repositoryMappings).toEqual([{ sourceRepositoryId: "repo-A", targetRepository: "org/repo-B" }]);
+    });
+  });
+
+  describe("enterprise-live-migration_pipelines_update", () => {
+    it("should PUT with update fields", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_update");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, []));
+
+      await handler({
+        repositoryId: "abc-123",
+        addPipelineIds: [4, 5],
+        removePipelineIds: [1],
+        retryFailedPipelineIds: [2],
+        acknowledgePipelineIds: [3],
+      });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123/pipelines?api-version=${apiVersion}`);
+      expect(options?.method).toBe("PUT");
+      const body = JSON.parse(options?.body as string);
+      expect(body.addPipelineIds).toEqual([4, 5]);
+      expect(body.removePipelineIds).toEqual([1]);
+      expect(body.retryFailedPipelineIds).toEqual([2]);
+      expect(body.acknowledgePipelineIds).toEqual([3]);
+    });
+  });
+
+  describe("enterprise-live-migration_pipelines_delete", () => {
+    it("should DELETE with migrationId query param", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_delete");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, ""));
+
+      const result = await handler({ repositoryId: "abc-123", migrationId: 42 });
+
+      const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+      expect(url).toBe(`https://dev.azure.com/test-org/_apis/elm/migrations/abc-123/pipelines?api-version=${apiVersion}&migrationId=42`);
+      expect(options?.method).toBe("DELETE");
+      expect(result.content[0].text).toBe("Pipeline configurations deleted successfully.");
+    });
+
+    it("should return error on failure", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_pipelines_delete");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(false, "Migration is active", 409));
+
+      const result = await handler({ repositoryId: "abc-123", migrationId: 42 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Error deleting pipelines");
+    });
+  });
+
+  describe("auth headers", () => {
+    it("should include Bearer token and User-Agent in all requests", async () => {
+      configureEnterpriseLiveMigrationTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const handler = getToolHandler(server, "enterprise-live-migration_status");
+
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockFetchResponse(true, { repositoryId: "abc-123" }));
+
+      await handler({ repositoryId: "abc-123" });
+
+      const headers = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer mock-token");
+      expect(headers["User-Agent"]).toBe("Jest");
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+  });
+});


### PR DESCRIPTION
# Add Enterprise Live Migration (ELM) domain with 15 tools

## Description

Add `enterprise-live-migration` domain to the Azure DevOps MCP server, providing 15 tools for managing Git repository migrations from Azure DevOps to GitHub via the Enterprise Live Migration (ELM) REST API.

### Core migration tools (11)
| Tool | Method | Description |
|------|--------|-------------|
| `enterprise-live-migration_list` | GET | List migrations with optional project filter and history |
| `enterprise-live-migration_status` | GET | Get migration status for a specific repository |
| `enterprise-live-migration_create` | POST | Create a new migration (full or validate-only) |
| `enterprise-live-migration_pause` | PUT | Pause an active migration |
| `enterprise-live-migration_resume` | PUT | Resume a paused migration |
| `enterprise-live-migration_cutover_set` | PUT | Schedule a cutover date |
| `enterprise-live-migration_cutover_cancel` | PUT | Cancel a scheduled cutover |
| `enterprise-live-migration_get_cutover_review` | GET | Review failed/blocked items before cutover |
| `enterprise-live-migration_approve_cutover` | PUT | Accept failures and approve cutover |
| `enterprise-live-migration_device_flow_config` | GET | Get GitHub App device flow config for auth |
| `enterprise-live-migration_abandon` | DELETE | Abandon a migration |

### Pipeline rewiring tools (4)
| Tool | Method | Description |
|------|--------|-------------|
| `enterprise-live-migration_pipelines_list` | GET | List pipelines and rewiring status |
| `enterprise-live-migration_pipelines_submit` | POST | Submit pipelines for rewiring |
| `enterprise-live-migration_pipelines_update` | PUT | Add/remove/retry/acknowledge pipelines |
| `enterprise-live-migration_pipelines_delete` | DELETE | Delete pipeline clone definitions |

### Implementation details
- All tools use direct `fetch()` to `/_apis/elm/migrations` endpoints (no Node SDK client exists for ELM)
- `skipValidation` param accepts friendly flag names and converts to bitmask internally
- `cutover_cancel` sends `DateTimeOffset.MinValue` sentinel as required by the server
- All `handleResponse` calls use `return await` for proper async error propagation in try/catch

### Files changed (8)
| File | Change |
|------|--------|
| `src/shared/domains.ts` | Added `ENTERPRISE_LIVE_MIGRATION` to Domain enum |
| `src/tools/enterprise-live-migration.ts` | **New** — 15 tools, 474 lines |
| `src/tools.ts` | Import + `configureIfDomainEnabled` wiring |
| `test/src/tools/enterprise-live-migration.test.ts` | **New** — 28 unit tests |
| `test/src/domains.test.ts` | Updated domain counts (9→10, 10→11) and arrays |
| `docs/TOOLSET.md` | Added documentation for all 15 tools |
| `docs/EXAMPLES.md` | Added ELM usage examples section |
| `README.md` | Added `enterprise-live-migration` to domains list |

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

### Unit tests
- 28 tests covering all 15 tools: registration, URL construction, HTTP methods, body serialization, query params, auth headers, error handling, skipValidation bitmask conversion
- All 982 tests pass (19 suites)

### Live API testing against `secretscantest-pfcca` org
| Tool | Result |
|------|--------|
| `list` | ✅ Found 1 active migration |
| `list` (includeAllMigrations) | ✅ Returns all records |
| `status` | ✅ Full migration details returned |
| `create` (validateOnly) | ✅ Migration created, validation completed successfully |
| `abandon` | ✅ Migration deleted |
| `get_cutover_review` | ✅ Returned 0 failures |
| `device_flow_config` | ✅ Returned clientId + enterpriseUrl |
| `pipelines_list` | ✅ Returned empty pipeline list |

Tested using MCP server in VS Code Agent mode with `-a azcli` authentication.
