### PR TITLE
fix: add names for pull request status enums

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -112,6 +112,31 @@ function pullRequestStatusStringToInt(status: string): number {
   }
 }
 
+const pullRequestStatusNames: Record<number, string> = {
+  0: "NotSet",
+  1: "Active",
+  2: "Abandoned",
+  3: "Completed",
+  4: "All",
+};
+
+const pullRequestMergeStatusNames: Record<number, string> = {
+  0: "NotSet",
+  1: "Queued",
+  2: "Conflicts",
+  3: "Succeeded",
+  4: "RejectedByPolicy",
+  5: "Failure",
+};
+
+function addPullRequestStatusNames<T extends Record<string, unknown>>(pr: T): T & { statusName?: string; mergeStatusName?: string } {
+  return {
+    ...pr,
+    ...(typeof pr.status === "number" ? { statusName: pullRequestStatusNames[pr.status] ?? `Unknown(${pr.status})` } : {}),
+    ...(typeof pr.mergeStatus === "number" ? { mergeStatusName: pullRequestMergeStatusNames[pr.mergeStatus] ?? `Unknown(${pr.mergeStatus})` } : {}),
+  };
+}
+
 function filterReposByName(repositories: GitRepository[], repoNameFilter: string): GitRepository[] {
   const lowerCaseFilter = repoNameFilter.toLowerCase();
   const filteredByName = repositories?.filter((repo) => repo.name?.toLowerCase().includes(lowerCaseFilter));
@@ -1029,7 +1054,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         const gitApi = await connection.getGitApi();
         const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, project, undefined, undefined, undefined, undefined, includeWorkItemRefs);
 
-        let enhancedResponse: Record<string, unknown> = { ...pullRequest };
+        let enhancedResponse: Record<string, unknown> = addPullRequestStatusNames({ ...pullRequest });
 
         if (includeLabels) {
           try {

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -3566,6 +3566,7 @@ describe("repos tools", () => {
         pullRequestId: 123,
         title: "Test PR",
         status: 1,
+        mergeStatus: 3,
       };
       mockGitApi.getPullRequest.mockResolvedValue(mockPR);
 
@@ -3578,7 +3579,11 @@ describe("repos tools", () => {
       const result = await handler(params);
 
       expect(mockGitApi.getPullRequest).toHaveBeenCalledWith("repo123", 123, undefined, undefined, undefined, undefined, undefined, false);
-      expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        ...mockPR,
+        statusName: "Active",
+        mergeStatusName: "Succeeded",
+      });
     });
 
     it("should pass project parameter when provided", async () => {
@@ -3605,7 +3610,7 @@ describe("repos tools", () => {
       const result = await handler(params);
 
       expect(mockGitApi.getPullRequest).toHaveBeenCalledWith("my-repo-name", 456, "my-project", undefined, undefined, undefined, undefined, false);
-      expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
+      expect(JSON.parse(result.content[0].text)).toEqual({ ...mockPR, statusName: "Active" });
     });
 
     it("should include work item refs when requested", async () => {
@@ -3668,6 +3673,7 @@ describe("repos tools", () => {
 
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {
           labels: ["bug", "enhancement"],
           labelCount: 2,
@@ -3703,7 +3709,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.getPullRequest).toHaveBeenCalledWith("repo123", 123, undefined, undefined, undefined, undefined, undefined, undefined);
       expect(mockGitApi.getPullRequestLabels).not.toHaveBeenCalled();
-      expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify({ ...mockPR, statusName: "Active" }, null, 2));
     });
 
     it("should include labels by default when includeLabels is explicitly set to default value true", async () => {
@@ -3743,6 +3749,7 @@ describe("repos tools", () => {
 
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {
           labels: ["documentation"],
           labelCount: 1,
@@ -3778,7 +3785,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.getPullRequest).toHaveBeenCalledWith("repo123", 123, undefined, undefined, undefined, undefined, undefined, false);
       expect(mockGitApi.getPullRequestLabels).not.toHaveBeenCalled();
-      expect(result.content[0].text).toBe(JSON.stringify(mockPR, null, 2));
+      expect(result.content[0].text).toBe(JSON.stringify({ ...mockPR, statusName: "Active" }, null, 2));
     });
 
     it("should handle empty labels array", async () => {
@@ -3816,6 +3823,7 @@ describe("repos tools", () => {
 
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {
           labels: [],
           labelCount: 0,
@@ -3862,6 +3870,7 @@ describe("repos tools", () => {
 
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {
           labels: ["bug", "feature"], // undefined name filtered out
           labelCount: 2,
@@ -3910,6 +3919,7 @@ describe("repos tools", () => {
       // Should fall back to empty labelSummary
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {},
       };
 
@@ -3955,6 +3965,7 @@ describe("repos tools", () => {
 
       const expectedResponse = {
         ...mockPR,
+        statusName: "Active",
         labelSummary: {
           labels: ["urgent"],
           labelCount: 1,


### PR DESCRIPTION
## Summary
- add `statusName` to `repo_get_pull_request_by_id` responses when Azure DevOps returns a numeric PR status
- add `mergeStatusName` when Azure DevOps returns a numeric merge status
- cover the named status fields in the repository tool tests

Fixes #1263. Related duplicate: #1242.

## Validation
- `npm ci`
- `npm test -- --runTestsByPath test/src/tools/repositories.test.ts --runInBand` (242 passed)
- `git diff --check`
- `npm run build`

Confidence: 91/100 (code/tests category). The change is backwards-compatible because it preserves existing numeric enum fields and only adds sibling name fields for LLM-readable context.