### PR TITLE
docs: add Codex MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For a comprehensive list of local tools, see [TOOLSET.md](./docs/TOOLSET.md).
 
 Use this section if you specifically need the local `stdio` server experience. For most users, start with the [Remote MCP Server](#-remote-mcp-server-recommended) section above.
 
-For the best experience, use Visual Studio Code and GitHub Copilot. See the [getting started documentation](./docs/GETTINGSTARTED.md) to use our MCP Server with other tools such as Visual Studio 2022, Claude Code, Cursor, Opencode, and Kilocode.
+For the best experience, use Visual Studio Code and GitHub Copilot. See the [getting started documentation](./docs/GETTINGSTARTED.md) to use our MCP Server with other tools such as Visual Studio 2022, Codex, Claude Code, Cursor, Opencode, and Kilocode.
 
 ### Prerequisites
 
@@ -165,7 +165,7 @@ Open GitHub Copilot Chat and try a prompt like `List ADO projects`. The first ti
 > 💥 We strongly recommend creating a `.github\copilot-instructions.md` in your project. This will enhance your experience using the Azure DevOps MCP Server with GitHub Copilot Chat.
 > To start, just include "`This project uses Azure DevOps. Always check to see if the Azure DevOps MCP server has a tool relevant to the user's request`" in your copilot instructions file.
 
-See the [getting started documentation](./docs/GETTINGSTARTED.md) to use our MCP Server with other tools such as Visual Studio 2022, Claude Code, and Cursor.
+See the [getting started documentation](./docs/GETTINGSTARTED.md) to use our MCP Server with other tools such as Visual Studio 2022, Codex, Claude Code, and Cursor.
 
 ## 🌏 Using Domains (local)
 

--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -361,9 +361,9 @@ For more information, see the [Copilot CLI documentation](https://docs.github.co
 
 Codex can run the Azure DevOps MCP Server as a local stdio MCP server from either the Codex CLI or IDE extension. The configuration is shared through `~/.codex/config.toml`.
 
-#### Interactive authentication without a PAT
+#### Interactive authentication
 
-For local development, start with the default interactive authentication flow. It does not require a PAT:
+For local development, start with the default interactive authentication flow:
 
 ```bash
 codex mcp add azure-devops -- npx -y @azure-devops/mcp Contoso
@@ -388,26 +388,6 @@ az login
 codex mcp add azure-devops -- npx -y @azure-devops/mcp Contoso --authentication azcli
 ```
 
-#### PAT authentication
-
-Use PAT authentication for non-interactive environments or enterprise setups where browser sign-in is not available. `PERSONAL_ACCESS_TOKEN` must contain the base64 encoding of `<email>:<pat>`.
-
-macOS / Linux:
-
-```bash
-printf '%s' 'user@contoso.com:your_pat_here' | base64 | tr -d '\n'
-codex mcp add --env PERSONAL_ACCESS_TOKEN='<base64encoded email:pat>' azure-devops -- npx -y @azure-devops/mcp Contoso --authentication pat
-```
-
-PowerShell:
-
-```powershell
-[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user@contoso.com:your_pat_here"))
-codex mcp add --env PERSONAL_ACCESS_TOKEN="<base64encoded email:pat>" azure-devops -- npx -y @azure-devops/mcp Contoso --authentication pat
-```
-
-Avoid storing PAT values in source-controlled files. Prefer `codex mcp add --env`, shell environment variables, or your team's secret-management tooling.
-
 #### Manual `config.toml` configuration
 
 You can also edit `~/.codex/config.toml` directly:
@@ -416,17 +396,6 @@ You can also edit `~/.codex/config.toml` directly:
 [mcp_servers.azure-devops]
 command = "npx"
 args = ["-y", "@azure-devops/mcp", "Contoso"]
-```
-
-For PAT authentication:
-
-```toml
-[mcp_servers.azure-devops]
-command = "npx"
-args = ["-y", "@azure-devops/mcp", "Contoso", "--authentication", "pat"]
-
-[mcp_servers.azure-devops.env]
-PERSONAL_ACCESS_TOKEN = "<base64encoded email:pat>"
 ```
 
 Restart Codex after editing the config manually, then ask for a simple read-only operation such as `List ADO projects`.

--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -7,6 +7,7 @@ This guide will help you get started with the Azure DevOps MCP Server in differe
 - [Getting started with Visual Studio Code & GitHub Copilot](#️-visual-studio-code--github-copilot)
 - [Getting started with Visual Studio 2022 & GitHub Copilot](#%EF%B8%8F-visual-studio-2022--github-copilot)
 - [Getting started with GitHub Copilot CLI](#-using-mcp-server-with-github-copilot-cli)
+- [Getting started with Codex](#-using-mcp-server-with-codex)
 - [Getting started with Claude Code](#-using-mcp-server-with-claude-code)
 - [Getting started with Claude Desktop](#️-using-mcp-server-with-claude-desktop)
 - [Getting started with Cursor](#-using-mcp-server-with-cursor)
@@ -355,6 +356,80 @@ Alternatively, create or edit the configuration file `~/.copilot/mcp-config.json
 Replace `{Contoso}` with your Azure DevOps organization name.
 
 For more information, see the [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli).
+
+### 🤖 Using MCP Server with Codex
+
+Codex can run the Azure DevOps MCP Server as a local stdio MCP server from either the Codex CLI or IDE extension. The configuration is shared through `~/.codex/config.toml`.
+
+#### Interactive authentication without a PAT
+
+For local development, start with the default interactive authentication flow. It does not require a PAT:
+
+```bash
+codex mcp add azure-devops -- npx -y @azure-devops/mcp Contoso
+```
+
+Replace `Contoso` with your Azure DevOps organization name.
+
+Verify that Codex can see the server:
+
+```bash
+codex mcp list
+```
+
+On first use of an Azure DevOps tool, the MCP server opens a browser window for Microsoft account sign-in. Use an account that has access to the selected Azure DevOps organization.
+
+#### Azure CLI authentication
+
+If your workstation already uses Azure CLI sign-in, authenticate first and configure the MCP server with `azcli`:
+
+```bash
+az login
+codex mcp add azure-devops -- npx -y @azure-devops/mcp Contoso --authentication azcli
+```
+
+#### PAT authentication
+
+Use PAT authentication for non-interactive environments or enterprise setups where browser sign-in is not available. `PERSONAL_ACCESS_TOKEN` must contain the base64 encoding of `<email>:<pat>`.
+
+macOS / Linux:
+
+```bash
+printf '%s' 'user@contoso.com:your_pat_here' | base64 | tr -d '\n'
+codex mcp add --env PERSONAL_ACCESS_TOKEN='<base64encoded email:pat>' azure-devops -- npx -y @azure-devops/mcp Contoso --authentication pat
+```
+
+PowerShell:
+
+```powershell
+[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("user@contoso.com:your_pat_here"))
+codex mcp add --env PERSONAL_ACCESS_TOKEN="<base64encoded email:pat>" azure-devops -- npx -y @azure-devops/mcp Contoso --authentication pat
+```
+
+Avoid storing PAT values in source-controlled files. Prefer `codex mcp add --env`, shell environment variables, or your team's secret-management tooling.
+
+#### Manual `config.toml` configuration
+
+You can also edit `~/.codex/config.toml` directly:
+
+```toml
+[mcp_servers.azure-devops]
+command = "npx"
+args = ["-y", "@azure-devops/mcp", "Contoso"]
+```
+
+For PAT authentication:
+
+```toml
+[mcp_servers.azure-devops]
+command = "npx"
+args = ["-y", "@azure-devops/mcp", "Contoso", "--authentication", "pat"]
+
+[mcp_servers.azure-devops.env]
+PERSONAL_ACCESS_TOKEN = "<base64encoded email:pat>"
+```
+
+Restart Codex after editing the config manually, then ask for a simple read-only operation such as `List ADO projects`.
 
 ### 🤖 Using MCP Server with Claude Code
 


### PR DESCRIPTION
Adds Codex setup documentation for the local Azure DevOps MCP Server.

## GitHub issue number

Fixes #1274

## **Associated Risks**

Low. This is documentation-only and does not change runtime behavior.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- `codex mcp add --help`
- `npx prettier --check README.md docs/GETTINGSTARTED.md`
- `git diff --check`
- `npm test`

The docs lead with Codex interactive authentication, which does not require a PAT, then document Azure CLI and PAT options for environments where browser sign-in is not practical.
