### PR TITLE
Add statusName mapping for pull requests and update tests

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -123,11 +123,20 @@ function trimPullRequest(pr: GitPullRequest | null | undefined, includeDescripti
   if (!pr) {
     return null;
   }
+
+  const statusMap: Record<number, string> = {
+    1: "Active",
+    2: "Abandoned",
+    3: "Completed",
+    4: "NotSet", // Add other statuses as needed
+  };
+
   return {
     pullRequestId: pr.pullRequestId,
     codeReviewId: pr.codeReviewId,
     repository: pr.repository?.name,
     status: pr.status,
+    statusName: statusMap[pr.status as number] || "Unknown",
     createdBy: {
       displayName: pr.createdBy?.displayName,
       uniqueName: pr.createdBy?.uniqueName,

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -124,19 +124,14 @@ function trimPullRequest(pr: GitPullRequest | null | undefined, includeDescripti
     return null;
   }
 
-  const statusMap: Record<number, string> = {
-    1: "Active",
-    2: "Abandoned",
-    3: "Completed",
-    4: "NotSet", // Add other statuses as needed
-  };
+  const statusName = typeof pr.status === "number" ? (PullRequestStatus[pr.status] ?? "Unknown") : "Unknown";
 
   return {
     pullRequestId: pr.pullRequestId,
     codeReviewId: pr.codeReviewId,
     repository: pr.repository?.name,
     status: pr.status,
-    statusName: statusMap[pr.status as number] || "Unknown",
+    statusName,
     createdBy: {
       displayName: pr.createdBy?.displayName,
       uniqueName: pr.createdBy?.uniqueName,

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -109,6 +109,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -151,6 +152,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -178,6 +180,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -213,6 +216,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -240,6 +244,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -275,6 +280,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -302,6 +308,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Abandoned,
+        statusName: "Abandoned",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -337,6 +344,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: PullRequestStatus.Abandoned,
+        statusName: "Abandoned",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -364,6 +372,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -401,6 +410,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -598,6 +608,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -645,6 +656,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -735,6 +747,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -793,6 +806,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -859,6 +873,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -913,6 +928,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -961,6 +977,7 @@ describe("repos tools", () => {
         codeReviewId: 456,
         repository: { name: "test-repo" },
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1004,6 +1021,7 @@ describe("repos tools", () => {
         codeReviewId: 456,
         repository: "test-repo",
         status: 1,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1030,6 +1048,7 @@ describe("repos tools", () => {
         codeReviewId: 456,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1083,6 +1102,7 @@ describe("repos tools", () => {
         codeReviewId: 456,
         repository: "test-repo",
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1131,6 +1151,7 @@ describe("repos tools", () => {
         codeReviewId: 789,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1170,6 +1191,7 @@ describe("repos tools", () => {
         codeReviewId: 789,
         repository: "test-repo",
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -1674,6 +1696,7 @@ describe("repos tools", () => {
           pullRequestId: 123,
           codeReviewId: 456,
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
           creationDate: "2023-01-01T00:00:00Z",
           title: "Feature PR",
@@ -2043,6 +2066,7 @@ describe("repos tools", () => {
           codeReviewId: 456,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
           creationDate: "2023-01-01T00:00:00Z",
           title: "Feature PR",
@@ -2070,6 +2094,7 @@ describe("repos tools", () => {
           codeReviewId: 456,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
           creationDate: "2023-01-01T00:00:00Z",
           title: "Feature PR",
@@ -2095,6 +2120,7 @@ describe("repos tools", () => {
           codeReviewId: 456,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Test User", uniqueName: "testuser@example.com" },
           creationDate: "2023-01-01T00:00:00Z",
           title: "My Feature PR",
@@ -2124,6 +2150,7 @@ describe("repos tools", () => {
           codeReviewId: 456,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Test User", uniqueName: "testuser@example.com" },
           creationDate: "2023-01-01T00:00:00Z",
           title: "My Feature PR",
@@ -2149,6 +2176,7 @@ describe("repos tools", () => {
           codeReviewId: 789,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Other User", uniqueName: "other@example.com" },
           creationDate: "2023-01-02T00:00:00Z",
           title: "Review Me PR",
@@ -2178,6 +2206,7 @@ describe("repos tools", () => {
           codeReviewId: 789,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Other User", uniqueName: "other@example.com" },
           creationDate: "2023-01-02T00:00:00Z",
           title: "Review Me PR",
@@ -2203,6 +2232,7 @@ describe("repos tools", () => {
           codeReviewId: 101112,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Test User", uniqueName: "testuser@example.com" },
           creationDate: "2023-01-03T00:00:00Z",
           title: "Both Creator and Reviewer PR",
@@ -2233,6 +2263,7 @@ describe("repos tools", () => {
           codeReviewId: 101112,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Test User", uniqueName: "testuser@example.com" },
           creationDate: "2023-01-03T00:00:00Z",
           title: "Both Creator and Reviewer PR",
@@ -2261,6 +2292,7 @@ describe("repos tools", () => {
           codeReviewId: 888,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Specific User", uniqueName: "specific@example.com" },
           creationDate: "2023-01-04T00:00:00Z",
           title: "Specific User PR",
@@ -2292,6 +2324,7 @@ describe("repos tools", () => {
           codeReviewId: 888,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Specific User", uniqueName: "specific@example.com" },
           creationDate: "2023-01-04T00:00:00Z",
           title: "Specific User PR",
@@ -2450,6 +2483,7 @@ describe("repos tools", () => {
           codeReviewId: 666,
           repository: { name: "test-repo" },
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Another User", uniqueName: "another@example.com" },
           creationDate: "2023-01-05T00:00:00Z",
           title: "PR Reviewed by Specific User",
@@ -2479,6 +2513,7 @@ describe("repos tools", () => {
           codeReviewId: 666,
           repository: "test-repo",
           status: PullRequestStatus.Active,
+          statusName: "Active",
           createdBy: { displayName: "Another User", uniqueName: "another@example.com" },
           creationDate: "2023-01-05T00:00:00Z",
           title: "PR Reviewed by Specific User",
@@ -6481,6 +6516,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: { name: "test-repo" },
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",
@@ -6527,6 +6563,7 @@ describe("repos tools", () => {
         codeReviewId: 123,
         repository: "test-repo",
         status: PullRequestStatus.Active,
+        statusName: "Active",
         createdBy: {
           displayName: "Test User",
           uniqueName: "testuser@example.com",

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -1633,6 +1633,7 @@ describe("repos tools", () => {
 
       const params = {
         project: "test-project",
+        status: "Active",
         top: 100,
         skip: 0,
       };
@@ -2100,6 +2101,133 @@ describe("repos tools", () => {
           title: "Feature PR",
           isDraft: false,
           sourceRefName: "refs/heads/feature-branch",
+          targetRefName: "refs/heads/main",
+        },
+      ];
+
+      expect(result.content[0].text).toBe(JSON.stringify(expectedResult, null, 2));
+    });
+
+    it("should map statusName from PullRequestStatus enum values", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
+      if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
+      const [, , , handler] = call;
+
+      const mockPRs = [
+        {
+          pullRequestId: 123,
+          codeReviewId: 456,
+          repository: { name: "test-repo" },
+          status: PullRequestStatus.NotSet,
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "NotSet PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/notset-branch",
+          targetRefName: "refs/heads/main",
+        },
+        {
+          pullRequestId: 124,
+          codeReviewId: 457,
+          repository: { name: "test-repo" },
+          status: PullRequestStatus.All,
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "All PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/all-branch",
+          targetRefName: "refs/heads/main",
+        },
+      ];
+      mockGitApi.getPullRequestsByProject.mockResolvedValue(mockPRs);
+
+      const params = {
+        project: "test-project",
+        status: "Active",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const expectedResult = [
+        {
+          pullRequestId: 123,
+          codeReviewId: 456,
+          repository: "test-repo",
+          status: PullRequestStatus.NotSet,
+          statusName: "NotSet",
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "NotSet PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/notset-branch",
+          targetRefName: "refs/heads/main",
+        },
+        {
+          pullRequestId: 124,
+          codeReviewId: 457,
+          repository: "test-repo",
+          status: PullRequestStatus.All,
+          statusName: "All",
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "All PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/all-branch",
+          targetRefName: "refs/heads/main",
+        },
+      ];
+
+      expect(result.content[0].text).toBe(JSON.stringify(expectedResult, null, 2));
+    });
+
+    it("should return Unknown statusName for unrecognized pull request status", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.list_pull_requests_by_repo_or_project);
+      if (!call) throw new Error("repo_list_pull_requests_by_repo_or_project tool not registered");
+      const [, , , handler] = call;
+
+      const mockPRs = [
+        {
+          pullRequestId: 123,
+          codeReviewId: 456,
+          repository: { name: "test-repo" },
+          status: 999,
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "Unknown Status PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/unknown-status",
+          targetRefName: "refs/heads/main",
+        },
+      ];
+      mockGitApi.getPullRequestsByProject.mockResolvedValue(mockPRs as any);
+
+      const params = {
+        project: "test-project",
+        status: "Active",
+        top: 100,
+        skip: 0,
+      };
+
+      const result = await handler(params);
+
+      const expectedResult = [
+        {
+          pullRequestId: 123,
+          codeReviewId: 456,
+          repository: "test-repo",
+          status: 999,
+          statusName: "Unknown",
+          createdBy: { displayName: "John Doe", uniqueName: "john@example.com" },
+          creationDate: "2023-01-01T00:00:00Z",
+          title: "Unknown Status PR",
+          isDraft: false,
+          sourceRefName: "refs/heads/unknown-status",
           targetRefName: "refs/heads/main",
         },
       ];


### PR DESCRIPTION
This pull request adds a human-readable `statusName` field to the trimmed pull request objects returned by the `trimPullRequest` function in `src/tools/repositories.ts`. The new field maps the numeric pull request status codes to descriptive string values (e.g., "Active", "Abandoned"). Comprehensive updates were made to the test suite to reflect this new field, ensuring consistency and correctness across all relevant test cases.

Key changes:

**Feature Addition:**
* Added a `statusName` property to the object returned by `trimPullRequest`, mapping numeric status codes to human-readable strings using a new `statusMap`.

**Testing Updates:**
* Updated all relevant test cases in `repositories.test.ts` to include and assert the new `statusName` field for both numeric and enum-based status values. 

## GitHub issue number

#1263

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Updated auto tests and did a manual check across several PRs
