### PR TITLE
feat: support visualstudio.com org URLs alongside dev.azure.com

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ dist/
 coverage/
 
 *.log*
+
+# Symlink — not parseable as JSON
+.vscode/mcp.json

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ const argv = yargs(hideBin(process.argv))
   .parseSync();
 
 export const orgName = argv.organization as string;
-const orgUrl = "https://dev.azure.com/" + orgName;
+// Suporta tanto dev.azure.com quanto visualstudio.com
+const orgUrl = orgName.includes(".") ? `https://${orgName}` : `https://${orgName}.visualstudio.com`;
 
 const domainsManager = new DomainsManager(argv.domains);
 export const enabledDomains = domainsManager.getEnabledDomains();

--- a/src/org-tenants.ts
+++ b/src/org-tenants.ts
@@ -35,7 +35,8 @@ async function trySavingCache(cache: OrgTenantCache): Promise<void> {
 }
 
 async function fetchTenantFromApi(orgName: string): Promise<string> {
-  const url = `https://vssps.dev.azure.com/${orgName}`;
+  const baseUrl = orgName.includes(".visualstudio.com") ? orgName.replace(".visualstudio.com", "") : orgName;
+  const url = `https://vssps.${orgName.includes(".visualstudio.com") ? "visualstudio.com" : "dev.azure.com"}/${baseUrl}`;
 
   try {
     const response = await fetch(url, { method: "HEAD" });


### PR DESCRIPTION
Allow organizations that use the legacy isualstudio.com URL scheme (e.g. db1global.visualstudio.com) to authenticate and connect alongside the standard dev.azure.com format.

## GitHub issue number

N/A

## **Associated Risks**

- Org names that contain a dot but are **not** a isualstudio.com hostname could be misrouted. This is unlikely in practice since Azure DevOps org names do not contain dots.

## ? **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] ?? Code hygiene
- [ ] ?? Telemetry added, updated, or N/A
- [ ] ?? Documentation added, updated, or N/A
- [ ] ??? Automated tests added, or N/A

## ?? **How did you test it?**

Tested locally against db1global.visualstudio.com using --authentication interactive. The MCP server connected successfully and listed projects/work items.

**Changes:**
- src/index.ts: derive orgUrl from the org name - if the name contains a dot it is treated as a full hostname (https://<orgName>), otherwise falls back to https://<orgName>.visualstudio.com
- src/org-tenants.ts: apply the same logic when resolving the ssps tenant URL
- .prettierignore: exclude .vscode/mcp.json which is a symlink whose content (../mcp.json) is not valid JSON, causing the prettier pre-commit hook to fail