### PR TITLE
Add service-connections domain to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ For example, use `"-d", "core", "work", "work-items"` to load only Work Item rel
 }
 ```
 
-Domains that are available are: `core`, `work`, `work-items`, `search`, `test-plans`, `repositories`, `wiki`, `pipelines`, `advanced-security`
+Domains that are available are: `core`, `work`, `work-items`, `search`, `test-plans`, `repositories`, `wiki`, `pipelines`, `advanced-security`, `service-connections`
 
 We recommend that you always enable `core` tools so that you can fetch project level information.
 

--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -2,96 +2,122 @@
 
 ## Overview
 
-| Functional Area   | Tool                                                                                                      | Description                                                       |
-| ----------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Advanced Security | [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)                                                   | Retrieve Advanced Security alerts for a repository                |
-| Advanced Security | [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details)                                     | Get detailed information about a specific security alert          |
-| Core              | [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)                                                 | List all projects in the organization                             |
-| Core              | [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams)                                       | List teams within a project                                       |
-| Core              | [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)                                           | Retrieve identity IDs by search filter                            |
-| Pipelines         | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                                   | Create a new pipeline with YAML configuration                     |
-| Pipelines         | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                             | Retrieve a list of builds with optional filters                   |
-| Pipelines         | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                                 | Get the status of a specific build                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                       | Retrieve complete logs for a build                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                           | Get a specific build log by log ID                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                               | Get changes (commits) associated with a build                     |
-| Pipelines         | [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                       | List build/pipeline definitions in a project                      |
-| Pipelines         | [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions)     | Get revision history of a build definition                        |
-| Pipelines         | [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                         | Start a new pipeline run with optional parameters                 |
-| Pipelines         | [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                                   | Get details of a specific pipeline run                            |
-| Pipelines         | [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                               | List recent runs for a pipeline                                   |
-| Pipelines         | [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                             | Update a build stage (cancel, retry, or run)                      |
-| Repositories      | [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                 | List all repositories in a project                                |
-| Repositories      | [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                               | Get repository details by name or ID                              |
-| Repositories      | [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                 | List all branches in a repository                                 |
-| Repositories      | [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                           | List branches created by current user                             |
-| Repositories      | [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                       | Get details of a specific branch                                  |
-| Repositories      | [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                 | Create a new branch from a source branch                          |
-| Repositories      | [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                               | Search for commits with comprehensive filters                     |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project) | List pull requests with optional filters                          |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                 | Find pull requests containing specific commits                    |
-| Repositories      | [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                               | Get details of a specific pull request                            |
-| Repositories      | [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                           | Get file changes (diff) for a pull request                        |
-| Repositories      | [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                     | Create a new pull request                                         |
-| Repositories      | [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                     | Update pull request properties and settings                       |
-| Repositories      | [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                 | Add or remove reviewers from a pull request                       |
-| Repositories      | [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                         | Cast a vote on a pull request                                     |
-| Repositories      | [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                         | List comment threads on a pull request                            |
-| Repositories      | [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)         | List comments in a specific thread                                |
-| Repositories      | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request                     |
-| Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread                    |
-| Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                                   |
-| Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                             |
-| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version                            |
-| Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                               |
-| Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                                     |
-| Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                             |
-| Test Plans        | [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                     | List test plans in a project                                      |
-| Test Plans        | [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                                   | Create a new test plan                                            |
-| Test Plans        | [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                                   | List test suites in a test plan                                   |
-| Test Plans        | [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                                 | Create a test suite within a test plan                            |
-| Test Plans        | [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                     | Add test cases to a test suite                                    |
-| Test Plans        | [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                     | List test cases in a test suite                                   |
-| Test Plans        | [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                                   | Create a new test case work item                                  |
-| Test Plans        | [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                       | Update steps of an existing test case                             |
-| Test Plans        | [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id)     | Get test results for a specific build                             |
-| Wiki              | [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                                                       | List wikis in organization or project                             |
-| Wiki              | [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                                                           | Get details of a specific wiki                                    |
-| Wiki              | [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                                                       | List pages in a wiki                                              |
-| Wiki              | [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                                                           | Get wiki page metadata (without content)                          |
-| Wiki              | [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)                                           | Retrieve wiki page content                                        |
-| Wiki              | [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page)                                 | Create or update a wiki page                                      |
-| Work Items        | [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                                   | Get a work item by ID                                             |
-| Work Items        | [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)                       | Retrieve multiple work items by IDs                               |
-| Work Items        | [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                                             | Create a new work item                                            |
-| Work Items        | [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                                             | Update fields of a work item                                      |
-| Work Items        | [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)                               | Update multiple work items in batch                               |
-| Work Items        | [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                                     | Create child work items under a parent                            |
-| Work Items        | [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                                               | Link work items together                                          |
-| Work Items        | [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                                             | Remove links from a work item                                     |
-| Work Items        | [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                                           | Link artifacts (commits, builds, PRs) to work items               |
-| Work Items        | [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request)                 | Link a work item to a pull request                                |
-| Work Items        | [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)                               | List comments on a work item                                      |
-| Work Items        | [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                                   | Add a comment to a work item                                      |
-| Work Items        | [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)                             | Update an existing comment on a work item                         |
-| Work Items        | [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)                             | Get revision history of a work item                               |
-| Work Items        | [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                                         | Get details of a work item type                                   |
-| Work Items        | [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                                   | List work items relevant to current user                          |
-| Work Items        | [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)                     | Get work items in a specific iteration                            |
-| Work Items        | [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                                   | List backlogs for a team                                          |
-| Work Items        | [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)                               | Get work items in a backlog                                       |
-| Work Items        | [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                                           | Get a work item query by ID or path                               |
-| Work Items        | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                               | Execute a query and get results                                   |
-| Work Items        | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                   | Execute a WIQL query and return matching work items               |
-| Work Items        | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                             | Download a work item attachment; save locally or return as base64 |
-| Work              | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                             | List all iterations in a project                                  |
-| Work              | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                         | Create new iterations in a project                                |
-| Work              | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                   | List iterations assigned to a team                                |
-| Work              | [mcp_ado_work_assign_iterations](#mcp_ado_work_assign_iterations)                                         | Assign iterations to a team                                       |
-| Work              | [mcp_ado_work_get_iteration_capacities](#mcp_ado_work_get_iteration_capacities)                           | Get capacity for all teams in an iteration                        |
-| Work              | [mcp_ado_work_get_team_capacity](#mcp_ado_work_get_team_capacity)                                         | Get capacity for a specific team in iteration                     |
-| Work              | [mcp_ado_work_update_team_capacity](#mcp_ado_work_update_team_capacity)                                   | Update team member capacity for iteration                         |
-| Work              | [mcp_ado_work_get_team_settings](#mcp_ado_work_get_team_settings)                                         | Get team settings including default iteration and area            |
+| Functional Area     | Tool                                                                                                                  | Description                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Advanced Security   | [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)                                                               | Retrieve Advanced Security alerts for a repository                |
+| Advanced Security   | [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details)                                                 | Get detailed information about a specific security alert          |
+| Core                | [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)                                                             | List all projects in the organization                             |
+| Core                | [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams)                                                   | List teams within a project                                       |
+| Core                | [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)                                                       | Retrieve identity IDs by search filter                            |
+| Pipelines           | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                                               | Create a new pipeline with YAML configuration                     |
+| Pipelines           | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                                         | Retrieve a list of builds with optional filters                   |
+| Pipelines           | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                                             | Get the status of a specific build                                |
+| Pipelines           | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                                   | Retrieve complete logs for a build                                |
+| Pipelines           | [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                                       | Get a specific build log by log ID                                |
+| Pipelines           | [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                                           | Get changes (commits) associated with a build                     |
+| Pipelines           | [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                                   | List build/pipeline definitions in a project                      |
+| Pipelines           | [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions)                 | Get revision history of a build definition                        |
+| Pipelines           | [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                                     | Start a new pipeline run with optional parameters                 |
+| Pipelines           | [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                                               | Get details of a specific pipeline run                            |
+| Pipelines           | [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                                           | List recent runs for a pipeline                                   |
+| Pipelines           | [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                                         | Update a build stage (cancel, retry, or run)                      |
+| Repositories        | [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                             | List all repositories in a project                                |
+| Repositories        | [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                                           | Get repository details by name or ID                              |
+| Repositories        | [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                             | List all branches in a repository                                 |
+| Repositories        | [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                                       | List branches created by current user                             |
+| Repositories        | [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                                   | Get details of a specific branch                                  |
+| Repositories        | [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                             | Create a new branch from a source branch                          |
+| Repositories        | [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                                           | Search for commits with comprehensive filters                     |
+| Repositories        | [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project)             | List pull requests with optional filters                          |
+| Repositories        | [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                             | Find pull requests containing specific commits                    |
+| Repositories        | [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                                           | Get details of a specific pull request                            |
+| Repositories        | [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                                       | Get file changes (diff) for a pull request                        |
+| Repositories        | [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                                 | Create a new pull request                                         |
+| Repositories        | [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                                 | Update pull request properties and settings                       |
+| Repositories        | [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                             | Add or remove reviewers from a pull request                       |
+| Repositories        | [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                                     | Cast a vote on a pull request                                     |
+| Repositories        | [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                                     | List comment threads on a pull request                            |
+| Repositories        | [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)                     | List comments in a specific thread                                |
+| Repositories        | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                                   | Create a new comment thread on a pull request                     |
+| Repositories        | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                                   | Update an existing pull request comment thread                    |
+| Repositories        | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                                       | Reply to a pull request comment                                   |
+| Repositories        | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                                           | List files and folders in a directory                             |
+| Repositories        | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                                       | Get file content at a specific version                            |
+| Search              | [mcp_ado_search_code](#mcp_ado_search_code)                                                                           | Search for code across repositories                               |
+| Search              | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                                           | Search wiki pages by keywords                                     |
+| Search              | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                                   | Search work items by text and filters                             |
+| Service Connections | [mcp_ado_service_connections_list](#mcp_ado_service_connections_list)                                                 | List service connections in a project                             |
+| Service Connections | [mcp_ado_service_connections_get_details](#mcp_ado_service_connections_get_details)                                   | Get details of a specific service connection                      |
+| Service Connections | [mcp_ado_service_connections_list_by_type_and_owner](#mcp_ado_service_connections_list_by_type_and_owner)             | List org-scoped service connections by type and owner             |
+| Service Connections | [mcp_ado_service_connections_refresh_authentication](#mcp_ado_service_connections_refresh_authentication)             | Refresh authentication parameters for service connections         |
+| Service Connections | [mcp_ado_service_connections_create](#mcp_ado_service_connections_create)                                             | Create a new service connection                                   |
+| Service Connections | [mcp_ado_service_connections_update](#mcp_ado_service_connections_update)                                             | Update an existing service connection                             |
+| Service Connections | [mcp_ado_service_connections_update_many](#mcp_ado_service_connections_update_many)                                   | Update multiple service connections in one call                   |
+| Service Connections | [mcp_ado_service_connections_delete](#mcp_ado_service_connections_delete)                                             | Delete a service connection from one or more projects             |
+| Service Connections | [mcp_ado_service_connections_share](#mcp_ado_service_connections_share)                                               | Share a service connection across multiple projects               |
+| Service Connections | [mcp_ado_service_connections_share_with_project](#mcp_ado_service_connections_share_with_project)                     | Share a service connection from one project with another          |
+| Service Connections | [mcp_ado_service_connections_query_shared_projects](#mcp_ado_service_connections_query_shared_projects)               | List projects a service connection is shared with                 |
+| Service Connections | [mcp_ado_service_connections_list_execution_records](#mcp_ado_service_connections_list_execution_records)             | List execution records for a service connection                   |
+| Service Connections | [mcp_ado_service_connections_add_execution_records](#mcp_ado_service_connections_add_execution_records)               | Add execution records for service connections                     |
+| Service Connections | [mcp_ado_service_connections_execute_request](#mcp_ado_service_connections_execute_request)                           | Proxy a GET request through a service connection                  |
+| Service Connections | [mcp_ado_service_connections_query](#mcp_ado_service_connections_query)                                               | Query a service connection via a data source binding              |
+| Service Connections | [mcp_ado_service_connections_list_types](#mcp_ado_service_connections_list_types)                                     | Get available service connection types                            |
+| Service Connections | [mcp_ado_service_connections_list_filtered_types](#mcp_ado_service_connections_list_filtered_types)                   | Get service connection types filtered by name                     |
+| Service Connections | [mcp_ado_service_connections_list_azure_subscriptions](#mcp_ado_service_connections_list_azure_subscriptions)         | List discoverable Azure subscriptions                             |
+| Service Connections | [mcp_ado_service_connections_list_azure_management_groups](#mcp_ado_service_connections_list_azure_management_groups) | List discoverable Azure management groups                         |
+| Service Connections | [mcp_ado_service_connections_get_aad_tenant_id](#mcp_ado_service_connections_get_aad_tenant_id)                       | Get the AAD tenant ID of the organization                         |
+| Service Connections | [mcp_ado_service_connections_create_aad_oauth_request](#mcp_ado_service_connections_create_aad_oauth_request)         | Create an AAD OAuth authorization request URL                     |
+| Service Connections | [mcp_ado_service_connections_oauth_create](#mcp_ado_service_connections_oauth_create)                                 | Create a new OAuth configuration                                  |
+| Service Connections | [mcp_ado_service_connections_oauth_update](#mcp_ado_service_connections_oauth_update)                                 | Update an existing OAuth configuration                            |
+| Service Connections | [mcp_ado_service_connections_oauth_delete](#mcp_ado_service_connections_oauth_delete)                                 | Delete an OAuth configuration                                     |
+| Service Connections | [mcp_ado_service_connections_oauth_get](#mcp_ado_service_connections_oauth_get)                                       | Get an OAuth configuration by ID                                  |
+| Service Connections | [mcp_ado_service_connections_oauth_list](#mcp_ado_service_connections_oauth_list)                                     | List OAuth configurations                                         |
+| Test Plans          | [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                                 | List test plans in a project                                      |
+| Test Plans          | [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                                               | Create a new test plan                                            |
+| Test Plans          | [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                                               | List test suites in a test plan                                   |
+| Test Plans          | [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                                             | Create a test suite within a test plan                            |
+| Test Plans          | [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                                 | Add test cases to a test suite                                    |
+| Test Plans          | [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                                 | List test cases in a test suite                                   |
+| Test Plans          | [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                                               | Create a new test case work item                                  |
+| Test Plans          | [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                                   | Update steps of an existing test case                             |
+| Test Plans          | [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id)                 | Get test results for a specific build                             |
+| Wiki                | [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                                                                   | List wikis in organization or project                             |
+| Wiki                | [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                                                                       | Get details of a specific wiki                                    |
+| Wiki                | [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                                                                   | List pages in a wiki                                              |
+| Wiki                | [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                                                                       | Get wiki page metadata (without content)                          |
+| Wiki                | [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)                                                       | Retrieve wiki page content                                        |
+| Wiki                | [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page)                                             | Create or update a wiki page                                      |
+| Work Items          | [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                                               | Get a work item by ID                                             |
+| Work Items          | [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)                                   | Retrieve multiple work items by IDs                               |
+| Work Items          | [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                                                         | Create a new work item                                            |
+| Work Items          | [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                                                         | Update fields of a work item                                      |
+| Work Items          | [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)                                           | Update multiple work items in batch                               |
+| Work Items          | [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                                                 | Create child work items under a parent                            |
+| Work Items          | [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                                                           | Link work items together                                          |
+| Work Items          | [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                                                         | Remove links from a work item                                     |
+| Work Items          | [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                                                       | Link artifacts (commits, builds, PRs) to work items               |
+| Work Items          | [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request)                             | Link a work item to a pull request                                |
+| Work Items          | [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)                                           | List comments on a work item                                      |
+| Work Items          | [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                                               | Add a comment to a work item                                      |
+| Work Items          | [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)                                         | Update an existing comment on a work item                         |
+| Work Items          | [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)                                         | Get revision history of a work item                               |
+| Work Items          | [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                                                     | Get details of a work item type                                   |
+| Work Items          | [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                                               | List work items relevant to current user                          |
+| Work Items          | [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)                                 | Get work items in a specific iteration                            |
+| Work Items          | [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                                               | List backlogs for a team                                          |
+| Work Items          | [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)                                           | Get work items in a backlog                                       |
+| Work Items          | [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                                                       | Get a work item query by ID or path                               |
+| Work Items          | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                                           | Execute a query and get results                                   |
+| Work Items          | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                               | Execute a WIQL query and return matching work items               |
+| Work Items          | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                                         | Download a work item attachment; save locally or return as base64 |
+| Work                | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                                         | List all iterations in a project                                  |
+| Work                | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                                     | Create new iterations in a project                                |
+| Work                | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                               | List iterations assigned to a team                                |
+| Work                | [mcp_ado_work_assign_iterations](#mcp_ado_work_assign_iterations)                                                     | Assign iterations to a team                                       |
+| Work                | [mcp_ado_work_get_iteration_capacities](#mcp_ado_work_get_iteration_capacities)                                       | Get capacity for all teams in an iteration                        |
+| Work                | [mcp_ado_work_get_team_capacity](#mcp_ado_work_get_team_capacity)                                                     | Get capacity for a specific team in iteration                     |
+| Work                | [mcp_ado_work_update_team_capacity](#mcp_ado_work_update_team_capacity)                                               | Update team member capacity for iteration                         |
+| Work                | [mcp_ado_work_get_team_settings](#mcp_ado_work_get_team_settings)                                                     | Get team settings including default iteration and area            |
 
 ## Advanced Security
 
@@ -420,6 +446,190 @@ Get Azure DevOps Work Item search results for a given search text.
 
 - **Required**: `searchText`
 - **Optional**: `areaPath`, `assignedTo`, `includeFacets`, `project`, `skip`, `state`, `top`, `workItemType`
+
+## Service Connections
+
+### mcp_ado_service_connections_list
+
+List service connections (service endpoints) in an Azure DevOps project. Supports filtering by type, authorization scheme, owner, endpoint IDs, and endpoint names. Secret/credential fields are never returned by the API.
+
+- **Required**: `project`
+- **Optional**: `type`, `authSchemes`, `endpointIds`, `endpointNames`, `owner`, `includeFailed`, `actionFilter`
+
+### mcp_ado_service_connections_get_details
+
+Get details of a specific service connection by its ID within a project. Secret/credential fields are never returned by the API.
+
+- **Required**: `project`, `endpointId`
+- **Optional**: `actionFilter`
+
+### mcp_ado_service_connections_list_by_type_and_owner
+
+Get organization-scoped service connections by type and owner. Returns only id, name, and url (used internally by licensing).
+
+- **Required**: `type`, `owner`
+- **Optional**: None
+
+### mcp_ado_service_connections_refresh_authentication
+
+Get service connections with refreshed authentication parameters (e.g., short-lived OAuth tokens).
+
+- **Required**: `project`, `endpointIds`, `refreshAuthenticationParameters`
+- **Optional**: None
+
+### mcp_ado_service_connections_create
+
+Create a new service connection. The `endpoint` body must match the ServiceEndpoint schema for the target type and include authorization fields.
+
+- **Required**: `endpoint`
+- **Optional**: None
+
+### mcp_ado_service_connections_update
+
+Update an existing service connection.
+
+- **Required**: `endpointId`, `endpoint`
+- **Optional**: `operation`
+
+### mcp_ado_service_connections_update_many
+
+Update multiple service connections in a single call.
+
+- **Required**: `endpoints`
+- **Optional**: None
+
+### mcp_ado_service_connections_delete
+
+Delete a service connection from one or more projects.
+
+- **Required**: `endpointId`, `projectIds`
+- **Optional**: `deep`
+
+### mcp_ado_service_connections_share
+
+Share a service connection across one or more projects using project references.
+
+- **Required**: `endpointId`, `endpointProjectReferences`
+- **Optional**: None
+
+### mcp_ado_service_connections_share_with_project
+
+Share a service connection from one project with another project.
+
+- **Required**: `endpointId`, `fromProject`, `withProject`
+- **Optional**: None
+
+### mcp_ado_service_connections_query_shared_projects
+
+List the projects a service connection is shared with.
+
+- **Required**: `endpointId`, `project`
+- **Optional**: None
+
+### mcp_ado_service_connections_list_execution_records
+
+Get execution records for a service connection (paginated).
+
+- **Required**: `project`, `endpointId`
+- **Optional**: `top`, `continuationToken`
+
+### mcp_ado_service_connections_add_execution_records
+
+Add execution records for one or more service connections.
+
+- **Required**: `project`, `input`
+- **Optional**: None
+
+### mcp_ado_service_connections_execute_request
+
+Proxy a GET request through a service connection. The request is authorized using the connection's credentials.
+
+- **Required**: `project`, `endpointId`, `serviceEndpointRequest`
+- **Optional**: None
+
+### mcp_ado_service_connections_query
+
+Proxy a GET defined by a data source binding on a service connection. The response is filtered via XPath/JSON selector.
+
+- **Required**: `project`, `binding`
+- **Optional**: None
+
+### mcp_ado_service_connections_list_types
+
+Get available service connection (endpoint) types.
+
+- **Required**: None
+- **Optional**: `type`, `scheme`
+
+### mcp_ado_service_connections_list_filtered_types
+
+Get service connection types filtered to a specific list of type names.
+
+- **Required**: `typesFilter`
+- **Optional**: None
+
+### mcp_ado_service_connections_list_azure_subscriptions
+
+List Azure subscriptions discoverable by the organization for use in Azure-based service connections.
+
+- **Required**: None
+- **Optional**: None
+
+### mcp_ado_service_connections_list_azure_management_groups
+
+List Azure management groups discoverable by the organization.
+
+- **Required**: None
+- **Optional**: None
+
+### mcp_ado_service_connections_get_aad_tenant_id
+
+Get the AAD tenant ID associated with the organization.
+
+- **Required**: None
+- **Optional**: None
+
+### mcp_ado_service_connections_create_aad_oauth_request
+
+Create an AAD OAuth authorization request URL for use during service connection setup.
+
+- **Required**: `tenantId`, `redirectUri`
+- **Optional**: `completeCallbackPayload`, `completeCallbackByAuthCode`
+
+### mcp_ado_service_connections_oauth_create
+
+Create a new OAuth configuration (organization-scoped).
+
+- **Required**: `configurationParams`
+- **Optional**: None
+
+### mcp_ado_service_connections_oauth_update
+
+Update an existing OAuth configuration.
+
+- **Required**: `configurationId`, `configurationParams`
+- **Optional**: None
+
+### mcp_ado_service_connections_oauth_delete
+
+Delete an OAuth configuration.
+
+- **Required**: `configurationId`
+- **Optional**: None
+
+### mcp_ado_service_connections_oauth_get
+
+Get an OAuth configuration by ID.
+
+- **Required**: `configurationId`
+- **Optional**: None
+
+### mcp_ado_service_connections_oauth_list
+
+List OAuth configurations, optionally filtered by endpoint type and/or action filter.
+
+- **Required**: None
+- **Optional**: `endpointType`, `actionFilter`
 
 ## Test Plans
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "azure-devops-extension-api": "^5.272.3",
         "azure-devops-extension-sdk": "^4.0.2",
-        "azure-devops-node-api": "^15.1.2",
+        "azure-devops-node-api": "^16.0.0",
         "winston": "^3.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.63",
@@ -2741,13 +2741,13 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "15.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-15.1.2.tgz",
-      "integrity": "sha512-PfJTGK8oaBB3e0hilF5QE5BT0axpxssZlc0pRq3Rb0XsKr4qk1Cma+jBRRz0hE+zuUsu/7cz0WTCVo+kcVvOjw==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-16.0.0.tgz",
+      "integrity": "sha512-JQAKzfkQuOXqjf6nBPuGe+BYnwdzvrg2b1+cAYEiDNsji9uBw5va2MG1LcNCh8jS+mMUvoY/o771+3N8GFHLsA==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "2.2.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -8569,14 +8569,14 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
+      "integrity": "sha512-/e2Rk9g20N0r44kaQLb3v6QGuryOD8SPb53t43Y5kqXXA+SqWuU7zLiMxetw61jNn/JFrxTdr5nPDhGY/eTNhQ==",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "^6.14.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "azure-devops-extension-api": "^5.272.3",
     "azure-devops-extension-sdk": "^4.0.2",
-    "azure-devops-node-api": "^15.1.2",
+    "azure-devops-node-api": "^16.0.0",
     "winston": "^3.18.3",
     "yargs": "^18.0.0",
     "zod": "^3.25.63",

--- a/src/shared/domains.ts
+++ b/src/shared/domains.ts
@@ -16,6 +16,7 @@ export enum Domain {
   WIKI = "wiki",
   WORK = "work",
   WORK_ITEMS = "work-items",
+  SERVICE_CONNECTIONS = "service-connections",
   MCP_APPS = "mcp-apps",
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,6 +11,7 @@ import { configurePipelineTools } from "./tools/pipelines.js";
 import { configureCoreTools } from "./tools/core.js";
 import { configureRepoTools } from "./tools/repositories.js";
 import { configureSearchTools } from "./tools/search.js";
+import { configureServiceConnectionTools } from "./tools/service-connections.js";
 import { configureTestPlanTools } from "./tools/test-plans.js";
 import { configureWikiTools } from "./tools/wiki.js";
 import { configureWorkTools } from "./tools/work.js";
@@ -33,6 +34,7 @@ function configureAllTools(server: McpServer, tokenProvider: () => Promise<strin
   configureIfDomainEnabled(Domain.TEST_PLANS, () => configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.SEARCH, () => configureSearchTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.ADVANCED_SECURITY, () => configureAdvSecTools(server, tokenProvider, connectionProvider));
+  configureIfDomainEnabled(Domain.SERVICE_CONNECTIONS, () => configureServiceConnectionTools(server, tokenProvider, connectionProvider));
 }
 
 export { configureAllTools };

--- a/src/tools/service-connections.ts
+++ b/src/tools/service-connections.ts
@@ -1,0 +1,1005 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebApi } from "azure-devops-node-api";
+import { AadLoginPromptOption, OAuthConfigurationActionFilter, ServiceEndpointActionFilter } from "azure-devops-node-api/interfaces/ServiceEndpointInterfaces.js";
+import { z } from "zod";
+import { getEnumKeys, mapStringToEnum } from "../utils.js";
+
+const SERVICE_CONNECTION_TOOLS = {
+  list_service_connections: "service_connections_list",
+  get_service_connection_details: "service_connections_get_details",
+  list_by_type_and_owner: "service_connections_list_by_type_and_owner",
+  list_with_refreshed_authentication: "service_connections_refresh_authentication",
+  create_service_connection: "service_connections_create",
+  update_service_connection: "service_connections_update",
+  update_service_connections: "service_connections_update_many",
+  delete_service_connection: "service_connections_delete",
+  share_service_connection: "service_connections_share",
+  share_endpoint_with_project: "service_connections_share_with_project",
+  query_shared_projects: "service_connections_query_shared_projects",
+  list_execution_records: "service_connections_list_execution_records",
+  add_execution_records: "service_connections_add_execution_records",
+  execute_request: "service_connections_execute_request",
+  query: "service_connections_query",
+  list_types: "service_connections_list_types",
+  list_filtered_types: "service_connections_list_filtered_types",
+  list_azure_subscriptions: "service_connections_list_azure_subscriptions",
+  list_azure_management_groups: "service_connections_list_azure_management_groups",
+  get_aad_tenant_id: "service_connections_get_aad_tenant_id",
+  create_aad_oauth_request: "service_connections_create_aad_oauth_request",
+  oauth_create: "service_connections_oauth_create",
+  oauth_update: "service_connections_oauth_update",
+  oauth_delete: "service_connections_oauth_delete",
+  oauth_get: "service_connections_oauth_get",
+  oauth_list: "service_connections_oauth_list",
+};
+
+const passthroughObject = z.record(z.unknown());
+
+function configureServiceConnectionTools(server: McpServer, _tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_service_connections,
+    "List service connections (service endpoints) in an Azure DevOps project. Supports filtering by type, authorization scheme, owner, endpoint IDs, and endpoint names. Secret/credential fields are never returned by the API.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      type: z.string().optional().describe("Filter by service connection type (e.g., 'azurerm', 'github', 'dockerregistry')."),
+      authSchemes: z.array(z.string()).optional().describe("Filter by authorization schemes (e.g., 'ServicePrincipal', 'WorkloadIdentityFederation', 'PersonalAccessToken')."),
+      endpointIds: z.array(z.string()).optional().describe("Filter by specific service endpoint IDs (GUIDs)."),
+      endpointNames: z.array(z.string()).optional().describe("Filter by service endpoint names. When provided, uses the get-by-names API."),
+      owner: z.string().optional().describe("Filter by owner of the service connection."),
+      includeFailed: z.boolean().optional().describe("Whether to include service connections with failed authentication."),
+      actionFilter: z
+        .enum(getEnumKeys(ServiceEndpointActionFilter) as [string, ...string[]])
+        .optional()
+        .describe("Filter endpoints by the action the caller is allowed to perform: 'None', 'Manage', 'Use', or 'View'."),
+    },
+    async ({ project, type, authSchemes, endpointIds, endpointNames, owner, includeFailed, actionFilter }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const endpoints =
+          endpointNames && endpointNames.length > 0
+            ? await api.getServiceEndpointsByNames(project, endpointNames, type, authSchemes, owner, includeFailed, false)
+            : await api.getServiceEndpoints(project, type, authSchemes, endpointIds, owner, includeFailed, false, mapStringToEnum(actionFilter, ServiceEndpointActionFilter));
+
+        if (!endpoints || endpoints.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No service connections found.",
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(endpoints, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing service connections: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.get_service_connection_details,
+    "Get details of a specific service connection (service endpoint) by its ID within a project. Secret/credential fields are never returned by the API.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      endpointId: z.string().describe("The GUID of the service connection (service endpoint)."),
+      actionFilter: z
+        .enum(getEnumKeys(ServiceEndpointActionFilter) as [string, ...string[]])
+        .optional()
+        .describe("Filter by the action the caller is allowed to perform: 'None', 'Manage', 'Use', or 'View'."),
+    },
+    async ({ project, endpointId, actionFilter }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const endpoint = await api.getServiceEndpointDetails(project, endpointId, mapStringToEnum(actionFilter, ServiceEndpointActionFilter));
+
+        if (!endpoint) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Service connection '${endpointId}' not found in project '${project}'.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(endpoint, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error getting service connection details: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_by_type_and_owner,
+    "Get organization-scoped service connections by type and owner. Returns only id, name, and url (used internally by licensing).",
+    {
+      type: z.string().describe("Type of the service connections (e.g., 'azurerm')."),
+      owner: z.string().describe("Owner of the service connections."),
+    },
+    async ({ type, owner }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const endpoints = await api.getServiceEndpointsByTypeAndOwner(type, owner);
+
+        if (!endpoints || endpoints.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No service connections found.",
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(endpoints, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing service connections by type and owner: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_with_refreshed_authentication,
+    "Get service connections with refreshed authentication parameters (e.g., short-lived OAuth tokens).",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      endpointIds: z.array(z.string()).describe("IDs of the service connections to refresh."),
+      refreshAuthenticationParameters: z
+        .array(
+          z.object({
+            endpointId: z.string().optional().describe("Endpoint ID which needs new authentication params."),
+            scope: z.array(z.number()).optional().describe("Scope of the token requested."),
+            tokenValidityInMinutes: z.number().optional().describe("Requested validity window for the token in minutes."),
+          })
+        )
+        .describe("Per-endpoint refresh parameters."),
+    },
+    async ({ project, endpointIds, refreshAuthenticationParameters }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const endpoints = await api.getServiceEndpointsWithRefreshedAuthentication(refreshAuthenticationParameters, project, endpointIds);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(endpoints, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error refreshing service connection authentication: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.create_service_connection,
+    "Create a new service connection (service endpoint). The 'endpoint' body must match the ServiceEndpoint schema for the target type and include authorization fields.",
+    {
+      endpoint: passthroughObject.describe("Full ServiceEndpoint payload (name, type, url, authorization, serviceEndpointProjectReferences, etc.)."),
+    },
+    async ({ endpoint }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const created = await api.createServiceEndpoint(endpoint as never);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(created, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error creating service connection: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.update_service_connection,
+    "Update an existing service connection (service endpoint).",
+    {
+      endpointId: z.string().describe("ID of the service connection to update."),
+      endpoint: passthroughObject.describe("Updated ServiceEndpoint payload."),
+      operation: z.string().optional().describe("Optional operation type (e.g., 'rename')."),
+    },
+    async ({ endpointId, endpoint, operation }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const updated = await api.updateServiceEndpoint(endpoint as never, endpointId, operation);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(updated, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error updating service connection: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.update_service_connections,
+    "Update multiple service connections in a single call.",
+    {
+      endpoints: z.array(passthroughObject).describe("Array of ServiceEndpoint payloads to update."),
+    },
+    async ({ endpoints }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const updated = await api.updateServiceEndpoints(endpoints as never);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(updated, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error updating service connections: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.delete_service_connection,
+    "Delete a service connection from one or more projects.",
+    {
+      endpointId: z.string().describe("ID of the service connection to delete."),
+      projectIds: z.array(z.string()).describe("Project IDs from which the service connection should be deleted."),
+      deep: z.boolean().optional().describe("If true, also delete the underlying service principal (where applicable)."),
+    },
+    async ({ endpointId, projectIds, deep }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        await api.deleteServiceEndpoint(endpointId, projectIds, deep);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Service connection '${endpointId}' deleted from project(s): ${projectIds.join(", ")}.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error deleting service connection: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.share_service_connection,
+    "Share a service connection across one or more projects using project references.",
+    {
+      endpointId: z.string().describe("ID of the service connection to share."),
+      endpointProjectReferences: z
+        .array(
+          z
+            .object({
+              name: z.string().optional().describe("Name to give the connection in the target project."),
+              description: z.string().optional().describe("Description for the shared connection."),
+              projectReference: z.object({ id: z.string().optional(), name: z.string().optional() }).passthrough().optional().describe("Reference to the target project (id and/or name)."),
+            })
+            .passthrough()
+        )
+        .describe("Target project references."),
+    },
+    async ({ endpointId, endpointProjectReferences }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        await api.shareServiceEndpoint(endpointProjectReferences as never, endpointId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Service connection '${endpointId}' shared with ${endpointProjectReferences.length} project(s).`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error sharing service connection: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.share_endpoint_with_project,
+    "Share a service connection from one project with another project.",
+    {
+      endpointId: z.string().describe("ID of the service connection to share."),
+      fromProject: z.string().describe("Source project (id or name) currently owning the connection."),
+      withProject: z.string().describe("Target project (id or name) to share the connection with."),
+    },
+    async ({ endpointId, fromProject, withProject }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        await api.shareEndpointWithProject(endpointId, fromProject, withProject);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Service connection '${endpointId}' shared from '${fromProject}' with '${withProject}'.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error sharing service connection with project: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.query_shared_projects,
+    "List the projects a service connection is shared with.",
+    {
+      endpointId: z.string().describe("ID of the service connection."),
+      project: z.string().describe("Source project (id or name) owning the connection."),
+    },
+    async ({ endpointId, project }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const projects = await api.querySharedProjects(endpointId, project);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(projects, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error querying shared projects: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_execution_records,
+    "Get execution records for a service connection (paginated).",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      endpointId: z.string().describe("ID of the service connection."),
+      top: z.coerce.number().optional().describe("Maximum number of execution records to return."),
+      continuationToken: z.coerce.number().optional().describe("Continuation token from a previous call."),
+    },
+    async ({ project, endpointId, top, continuationToken }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const records = await api.getServiceEndpointExecutionRecords(project, endpointId, top, continuationToken);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(records, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing service connection execution records: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.add_execution_records,
+    "Add execution records for one or more service connections.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      input: z
+        .object({
+          endpointIds: z.array(z.string()).optional().describe("IDs of the service connections to attribute the execution to."),
+          data: passthroughObject.optional().describe("ServiceEndpointExecutionData payload (planId, definitionId, result, etc.)."),
+        })
+        .passthrough()
+        .describe("ServiceEndpointExecutionRecordsInput payload."),
+    },
+    async ({ project, input }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const records = await api.addServiceEndpointExecutionRecords(input as never, project);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(records, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error adding service connection execution records: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.execute_request,
+    "Proxy a GET request through a service connection. The request is authorized using the connection's credentials.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      endpointId: z.string().describe("ID of the service connection."),
+      serviceEndpointRequest: passthroughObject.describe("ServiceEndpointRequest payload (dataSourceDetails, resultTransformationDetails, serviceEndpointDetails)."),
+    },
+    async ({ project, endpointId, serviceEndpointRequest }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const result = await api.executeServiceEndpointRequest(serviceEndpointRequest as never, project, endpointId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error executing service connection request: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.query,
+    "Proxy a GET defined by a data source binding on a service connection. The response is filtered via XPath/JSON selector.",
+    {
+      project: z.string().describe("The name or ID of the Azure DevOps project."),
+      binding: passthroughObject.describe("DataSourceBinding payload (target, endpointId, dataSourceName, parameters, etc.)."),
+    },
+    async ({ project, binding }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const result = await api.queryServiceEndpoint(binding as never, project);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error querying service connection: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_types,
+    "Get available service connection (endpoint) types.",
+    {
+      type: z.string().optional().describe("Optional type filter (e.g., 'azurerm')."),
+      scheme: z.string().optional().describe("Optional authentication scheme filter."),
+    },
+    async ({ type, scheme }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const types = await api.getServiceEndpointTypes(type, scheme);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(types, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing service connection types: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.list_filtered_types,
+    "Get service connection types filtered to a specific list of type names.",
+    {
+      typesFilter: z.array(z.string()).describe("Type names to include."),
+    },
+    async ({ typesFilter }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const types = await api.getFilteredServiceEndpointTypes(typesFilter);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(types, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing filtered service connection types: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(SERVICE_CONNECTION_TOOLS.list_azure_subscriptions, "List Azure subscriptions discoverable by the organization for use in Azure-based service connections.", {}, async () => {
+    try {
+      const api = await (await connectionProvider()).getServiceEndpointApi();
+      const result = await api.getAzureSubscriptions();
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error listing Azure subscriptions: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  server.tool(SERVICE_CONNECTION_TOOLS.list_azure_management_groups, "List Azure management groups discoverable by the organization.", {}, async () => {
+    try {
+      const api = await (await connectionProvider()).getServiceEndpointApi();
+      const result = await api.getAzureManagementGroups();
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error listing Azure management groups: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  server.tool(SERVICE_CONNECTION_TOOLS.get_aad_tenant_id, "Get the AAD tenant ID associated with the organization.", {}, async () => {
+    try {
+      const api = await (await connectionProvider()).getServiceEndpointApi();
+      const tenantId = await api.getVstsAadTenantId();
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ tenantId }, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting AAD tenant ID: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  });
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.create_aad_oauth_request,
+    "Create an AAD OAuth authorization request URL for use during service connection setup.",
+    {
+      tenantId: z.string().describe("AAD tenant ID."),
+      redirectUri: z.string().describe("Redirect URI for the OAuth flow."),
+      promptOption: z
+        .enum(getEnumKeys(AadLoginPromptOption) as [string, ...string[]])
+        .optional()
+        .describe("Login prompt option: 'NoOption', 'Login', 'SelectAccount', 'FreshLogin', or 'FreshLoginWithMfa'."),
+      completeCallbackPayload: z.string().optional().describe("Optional callback payload to round-trip through the OAuth flow."),
+      completeCallbackByAuthCode: z.boolean().optional().describe("If true, the callback completes by auth code instead of token."),
+    },
+    async ({ tenantId, redirectUri, promptOption, completeCallbackPayload, completeCallbackByAuthCode }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const url = await api.createAadOAuthRequest(tenantId, redirectUri, mapStringToEnum(promptOption, AadLoginPromptOption), completeCallbackPayload, completeCallbackByAuthCode);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ url }, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error creating AAD OAuth request: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // OAuth configuration tools (organization-scoped)
+
+  const oauthConfigurationParamsSchema = z
+    .object({
+      clientId: z.string().describe("OAuth client ID."),
+      clientSecret: z.string().describe("OAuth client secret."),
+      endpointType: z.string().describe("Endpoint type the configuration is for (e.g., 'github')."),
+      name: z.string().describe("Display name of the OAuth configuration."),
+      url: z.string().optional().describe("Authorization URL."),
+    })
+    .passthrough();
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.oauth_create,
+    "Create a new OAuth configuration (organization-scoped).",
+    {
+      configurationParams: oauthConfigurationParamsSchema.describe("OAuthConfigurationParams payload."),
+    },
+    async ({ configurationParams }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const created = await api.createOAuthConfiguration(configurationParams as never);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(created, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error creating OAuth configuration: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.oauth_update,
+    "Update an existing OAuth configuration.",
+    {
+      configurationId: z.string().describe("ID of the OAuth configuration to update."),
+      configurationParams: oauthConfigurationParamsSchema.describe("Updated OAuthConfigurationParams payload."),
+    },
+    async ({ configurationId, configurationParams }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const updated = await api.updateOAuthConfiguration(configurationParams as never, configurationId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(updated, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error updating OAuth configuration: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.oauth_delete,
+    "Delete an OAuth configuration.",
+    {
+      configurationId: z.string().describe("ID of the OAuth configuration to delete."),
+    },
+    async ({ configurationId }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const deleted = await api.deleteOAuthConfiguration(configurationId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(deleted, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error deleting OAuth configuration: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.oauth_get,
+    "Get an OAuth configuration by ID.",
+    {
+      configurationId: z.string().describe("ID of the OAuth configuration."),
+    },
+    async ({ configurationId }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const configuration = await api.getOAuthConfiguration(configurationId);
+
+        if (!configuration) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `OAuth configuration '${configurationId}' not found.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(configuration, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error getting OAuth configuration: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    SERVICE_CONNECTION_TOOLS.oauth_list,
+    "List OAuth configurations, optionally filtered by endpoint type and/or action filter.",
+    {
+      endpointType: z.string().optional().describe("Filter by endpoint type (e.g., 'github')."),
+      actionFilter: z
+        .enum(getEnumKeys(OAuthConfigurationActionFilter) as [string, ...string[]])
+        .optional()
+        .describe("Action filter: 'None', 'Manage', or 'Use'."),
+    },
+    async ({ endpointType, actionFilter }) => {
+      try {
+        const api = await (await connectionProvider()).getServiceEndpointApi();
+        const configurations = await api.getOAuthConfigurations(endpointType, mapStringToEnum(actionFilter, OAuthConfigurationActionFilter));
+
+        if (!configurations || configurations.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "No OAuth configurations found.",
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(configurations, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error listing OAuth configurations: ${error instanceof Error ? error.message : "Unknown error occurred"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+export { SERVICE_CONNECTION_TOOLS, configureServiceConnectionTools };

--- a/test/src/domains.test.ts
+++ b/test/src/domains.test.ts
@@ -29,7 +29,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager();
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("advanced-security")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
       expect(enabledDomains.has("core")).toBe(true);
@@ -45,8 +45,8 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(undefined);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
-      expect(Array.from(enabledDomains).sort()).toEqual(["advanced-security", "core", "pipelines", "repositories", "search", "test-plans", "wiki", "work", "work-items"]);
+      expect(enabledDomains.size).toBe(10);
+      expect(Array.from(enabledDomains).sort()).toEqual(["advanced-security", "core", "pipelines", "repositories", "search", "service-connections", "test-plans", "wiki", "work", "work-items"]);
     });
 
     it("enables all domains when null is passed as argument (legacy support)", () => {
@@ -54,7 +54,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(null);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -63,7 +63,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("repositories")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
     });
@@ -88,9 +88,9 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("invalid-domain");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(errorSpy).toHaveBeenCalledWith(
-        "Error: Specified invalid domain 'invalid-domain'. Please specify exactly as available domains: advanced-security, pipelines, core, repositories, search, test-plans, wiki, work, work-items"
+        "Error: Specified invalid domain 'invalid-domain'. Please specify exactly as available domains: advanced-security, pipelines, core, repositories, search, test-plans, wiki, work, work-items, service-connections"
       );
     });
   });
@@ -100,7 +100,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["all"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(enabledDomains.has("repositories")).toBe(true);
       expect(enabledDomains.has("pipelines")).toBe(true);
     });
@@ -120,7 +120,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager([]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("filters out invalid domains and enables only valid ones when mixed array is passed", () => {
@@ -164,8 +164,8 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
     it("returns the full list of available domains", () => {
       const availableDomains = DomainsManager.getAvailableDomains();
 
-      expect(availableDomains).toEqual(["advanced-security", "pipelines", "core", "repositories", "search", "test-plans", "wiki", "work", "work-items", "mcp-apps"]);
-      expect(availableDomains.length).toBe(10);
+      expect(availableDomains).toEqual(["advanced-security", "pipelines", "core", "repositories", "search", "test-plans", "wiki", "work", "work-items", "service-connections", "mcp-apps"]);
+      expect(availableDomains.length).toBe(11);
     });
   });
 
@@ -213,7 +213,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -222,21 +222,21 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["all"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when 'all' is passed together with other valid domains", () => {
       const manager = new DomainsManager(["all", "pipelines"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when 'all' is passed along with invalid domains", () => {
       const manager = new DomainsManager(["a", "all", "wiki"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 
@@ -272,14 +272,14 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager(["repositories", "all", "pipelines"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("enables all domains when all specified domains are invalid", () => {
       const manager = new DomainsManager(["invalid1", "invalid2"]);
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
       expect(errorSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -287,7 +287,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("processes 'all' through validateAndAddDomains when passed as uppercase string", () => {
@@ -296,7 +296,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("ALL");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("processes 'all' through validateAndAddDomains in comma-separated string", () => {
@@ -304,7 +304,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("repositories,all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("hits handleStringInput with exact 'all' string", () => {
@@ -312,7 +312,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("all");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("tests direct parseDomainsInput with empty string", () => {
@@ -320,7 +320,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       const manager = new DomainsManager("");
       const enabledDomains = manager.getEnabledDomains();
 
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("tests comma-separated string input with 'all' keyword", () => {
@@ -331,7 +331,7 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
       // Test that this actually gets processed correctly
       const manager = new DomainsManager("repositories,all,core");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9); // Should enable all because 'all' is present
+      expect(enabledDomains.size).toBe(10); // Should enable all because 'all' is present
     });
   });
 
@@ -339,19 +339,19 @@ describe("DomainsManager: backward compatibility and domain enabling", () => {
     it("when an empty array is passed", () => {
       const manager = new DomainsManager([]);
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("when a string with only a break line is passed", () => {
       const manager = new DomainsManager("\n");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
 
     it("when an empty string is passed", () => {
       const manager = new DomainsManager("");
       const enabledDomains = manager.getEnabledDomains();
-      expect(enabledDomains.size).toBe(9);
+      expect(enabledDomains.size).toBe(10);
     });
   });
 });

--- a/test/src/tools/service-connections.test.ts
+++ b/test/src/tools/service-connections.test.ts
@@ -388,4 +388,112 @@ describe("configureServiceConnectionTools", () => {
       expect(result.content[0].text).toBe("No OAuth configurations found.");
     });
   });
+
+  describe("empty-result branches", () => {
+    it("service_connections_list_by_type_and_owner reports empty results", async () => {
+      const handler = getHandler("service_connections_list_by_type_and_owner");
+      mockApi.getServiceEndpointsByTypeAndOwner.mockResolvedValue([]);
+      const result = await handler({ type: "azurerm", owner: "Library" });
+      expect(result.content[0].text).toBe("No service connections found.");
+    });
+  });
+
+  describe("error paths", () => {
+    type ErrorCase = {
+      tool: string;
+      method: keyof ServiceEndpointApiMock;
+      prefix: string;
+      args: Record<string, unknown>;
+    };
+
+    const cases: ErrorCase[] = [
+      { tool: "service_connections_get_details", method: "getServiceEndpointDetails", prefix: "Error getting service connection details:", args: { project: "P", endpointId: "ep1" } },
+      {
+        tool: "service_connections_list_by_type_and_owner",
+        method: "getServiceEndpointsByTypeAndOwner",
+        prefix: "Error listing service connections by type and owner:",
+        args: { type: "t", owner: "o" },
+      },
+      {
+        tool: "service_connections_refresh_authentication",
+        method: "getServiceEndpointsWithRefreshedAuthentication",
+        prefix: "Error refreshing service connection authentication:",
+        args: { project: "P", endpointIds: ["ep1"], refreshAuthenticationParameters: [] },
+      },
+      { tool: "service_connections_create", method: "createServiceEndpoint", prefix: "Error creating service connection:", args: { endpoint: {} } },
+      { tool: "service_connections_update", method: "updateServiceEndpoint", prefix: "Error updating service connection:", args: { endpointId: "ep1", endpoint: {} } },
+      { tool: "service_connections_update_many", method: "updateServiceEndpoints", prefix: "Error updating service connections:", args: { endpoints: [] } },
+      { tool: "service_connections_delete", method: "deleteServiceEndpoint", prefix: "Error deleting service connection:", args: { endpointId: "ep1", projectIds: ["p1"] } },
+      { tool: "service_connections_share", method: "shareServiceEndpoint", prefix: "Error sharing service connection:", args: { endpointId: "ep1", endpointProjectReferences: [] } },
+      {
+        tool: "service_connections_share_with_project",
+        method: "shareEndpointWithProject",
+        prefix: "Error sharing service connection with project:",
+        args: { endpointId: "ep1", fromProject: "P1", withProject: "P2" },
+      },
+      { tool: "service_connections_query_shared_projects", method: "querySharedProjects", prefix: "Error querying shared projects:", args: { endpointId: "ep1", project: "P" } },
+      {
+        tool: "service_connections_list_execution_records",
+        method: "getServiceEndpointExecutionRecords",
+        prefix: "Error listing service connection execution records:",
+        args: { project: "P", endpointId: "ep1" },
+      },
+      {
+        tool: "service_connections_add_execution_records",
+        method: "addServiceEndpointExecutionRecords",
+        prefix: "Error adding service connection execution records:",
+        args: { project: "P", input: {} },
+      },
+      {
+        tool: "service_connections_execute_request",
+        method: "executeServiceEndpointRequest",
+        prefix: "Error executing service connection request:",
+        args: { project: "P", endpointId: "ep1", serviceEndpointRequest: {} },
+      },
+      { tool: "service_connections_query", method: "queryServiceEndpoint", prefix: "Error querying service connection:", args: { project: "P", binding: {} } },
+      { tool: "service_connections_list_types", method: "getServiceEndpointTypes", prefix: "Error listing service connection types:", args: {} },
+      { tool: "service_connections_list_filtered_types", method: "getFilteredServiceEndpointTypes", prefix: "Error listing filtered service connection types:", args: { typesFilter: ["t"] } },
+      { tool: "service_connections_list_azure_subscriptions", method: "getAzureSubscriptions", prefix: "Error listing Azure subscriptions:", args: {} },
+      { tool: "service_connections_list_azure_management_groups", method: "getAzureManagementGroups", prefix: "Error listing Azure management groups:", args: {} },
+      { tool: "service_connections_get_aad_tenant_id", method: "getVstsAadTenantId", prefix: "Error getting AAD tenant ID:", args: {} },
+      {
+        tool: "service_connections_create_aad_oauth_request",
+        method: "createAadOAuthRequest",
+        prefix: "Error creating AAD OAuth request:",
+        args: { tenantId: "t", redirectUri: "r" },
+      },
+      {
+        tool: "service_connections_oauth_create",
+        method: "createOAuthConfiguration",
+        prefix: "Error creating OAuth configuration:",
+        args: { configurationParams: { clientId: "c", clientSecret: "s", endpointType: "github", name: "n" } },
+      },
+      {
+        tool: "service_connections_oauth_update",
+        method: "updateOAuthConfiguration",
+        prefix: "Error updating OAuth configuration:",
+        args: { configurationId: "oc1", configurationParams: { clientId: "c", clientSecret: "s", endpointType: "github", name: "n" } },
+      },
+      { tool: "service_connections_oauth_delete", method: "deleteOAuthConfiguration", prefix: "Error deleting OAuth configuration:", args: { configurationId: "oc1" } },
+      { tool: "service_connections_oauth_get", method: "getOAuthConfiguration", prefix: "Error getting OAuth configuration:", args: { configurationId: "oc1" } },
+      { tool: "service_connections_oauth_list", method: "getOAuthConfigurations", prefix: "Error listing OAuth configurations:", args: {} },
+    ];
+
+    it.each(cases)("$tool surfaces upstream errors", async ({ tool, method, prefix, args }) => {
+      const handler = getHandler(tool);
+      mockApi[method].mockRejectedValue(new Error("boom"));
+      const result = await handler(args);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain(prefix);
+      expect(result.content[0].text).toContain("boom");
+    });
+
+    it("falls back to 'Unknown error occurred' when a non-Error value is thrown", async () => {
+      const handler = getHandler("service_connections_list");
+      mockApi.getServiceEndpoints.mockRejectedValue("not-an-error");
+      const result = await handler({ project: "P" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
+  });
 });

--- a/test/src/tools/service-connections.test.ts
+++ b/test/src/tools/service-connections.test.ts
@@ -40,6 +40,13 @@ interface ServiceEndpointApiMock {
   getOAuthConfigurations: jest.Mock;
 }
 
+interface ErrorCase {
+  tool: string;
+  method: keyof ServiceEndpointApiMock;
+  prefix: string;
+  args: Record<string, unknown>;
+}
+
 describe("configureServiceConnectionTools", () => {
   let server: McpServer;
   let tokenProvider: TokenProviderMock;
@@ -399,13 +406,6 @@ describe("configureServiceConnectionTools", () => {
   });
 
   describe("error paths", () => {
-    type ErrorCase = {
-      tool: string;
-      method: keyof ServiceEndpointApiMock;
-      prefix: string;
-      args: Record<string, unknown>;
-    };
-
     const cases: ErrorCase[] = [
       { tool: "service_connections_get_details", method: "getServiceEndpointDetails", prefix: "Error getting service connection details:", args: { project: "P", endpointId: "ep1" } },
       {
@@ -488,7 +488,16 @@ describe("configureServiceConnectionTools", () => {
       expect(result.content[0].text).toContain("boom");
     });
 
-    it("falls back to 'Unknown error occurred' when a non-Error value is thrown", async () => {
+    it.each(cases)("$tool falls back to 'Unknown error occurred' when a non-Error value is thrown", async ({ tool, method, prefix, args }) => {
+      const handler = getHandler(tool);
+      mockApi[method].mockRejectedValue("not-an-error");
+      const result = await handler(args);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain(prefix);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
+
+    it("service_connections_list falls back to 'Unknown error occurred' when a non-Error value is thrown", async () => {
       const handler = getHandler("service_connections_list");
       mockApi.getServiceEndpoints.mockRejectedValue("not-an-error");
       const result = await handler({ project: "P" });

--- a/test/src/tools/service-connections.test.ts
+++ b/test/src/tools/service-connections.test.ts
@@ -1,0 +1,391 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, beforeEach, jest } from "@jest/globals";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { configureServiceConnectionTools } from "../../../src/tools/service-connections";
+import { WebApi } from "azure-devops-node-api";
+import { AadLoginPromptOption, OAuthConfigurationActionFilter, ServiceEndpointActionFilter } from "azure-devops-node-api/interfaces/ServiceEndpointInterfaces";
+
+type TokenProviderMock = () => Promise<string>;
+type ConnectionProviderMock = () => Promise<WebApi>;
+
+interface ServiceEndpointApiMock {
+  getServiceEndpoints: jest.Mock;
+  getServiceEndpointsByNames: jest.Mock;
+  getServiceEndpointDetails: jest.Mock;
+  getServiceEndpointsByTypeAndOwner: jest.Mock;
+  getServiceEndpointsWithRefreshedAuthentication: jest.Mock;
+  createServiceEndpoint: jest.Mock;
+  updateServiceEndpoint: jest.Mock;
+  updateServiceEndpoints: jest.Mock;
+  deleteServiceEndpoint: jest.Mock;
+  shareServiceEndpoint: jest.Mock;
+  shareEndpointWithProject: jest.Mock;
+  querySharedProjects: jest.Mock;
+  getServiceEndpointExecutionRecords: jest.Mock;
+  addServiceEndpointExecutionRecords: jest.Mock;
+  executeServiceEndpointRequest: jest.Mock;
+  queryServiceEndpoint: jest.Mock;
+  getServiceEndpointTypes: jest.Mock;
+  getFilteredServiceEndpointTypes: jest.Mock;
+  getAzureSubscriptions: jest.Mock;
+  getAzureManagementGroups: jest.Mock;
+  getVstsAadTenantId: jest.Mock;
+  createAadOAuthRequest: jest.Mock;
+  createOAuthConfiguration: jest.Mock;
+  updateOAuthConfiguration: jest.Mock;
+  deleteOAuthConfiguration: jest.Mock;
+  getOAuthConfiguration: jest.Mock;
+  getOAuthConfigurations: jest.Mock;
+}
+
+describe("configureServiceConnectionTools", () => {
+  let server: McpServer;
+  let tokenProvider: TokenProviderMock;
+  let connectionProvider: ConnectionProviderMock;
+  let mockApi: ServiceEndpointApiMock;
+
+  beforeEach(() => {
+    server = { tool: jest.fn(), server: { elicitInput: jest.fn() } } as unknown as McpServer;
+    tokenProvider = jest.fn() as TokenProviderMock;
+
+    mockApi = {
+      getServiceEndpoints: jest.fn(),
+      getServiceEndpointsByNames: jest.fn(),
+      getServiceEndpointDetails: jest.fn(),
+      getServiceEndpointsByTypeAndOwner: jest.fn(),
+      getServiceEndpointsWithRefreshedAuthentication: jest.fn(),
+      createServiceEndpoint: jest.fn(),
+      updateServiceEndpoint: jest.fn(),
+      updateServiceEndpoints: jest.fn(),
+      deleteServiceEndpoint: jest.fn(),
+      shareServiceEndpoint: jest.fn(),
+      shareEndpointWithProject: jest.fn(),
+      querySharedProjects: jest.fn(),
+      getServiceEndpointExecutionRecords: jest.fn(),
+      addServiceEndpointExecutionRecords: jest.fn(),
+      executeServiceEndpointRequest: jest.fn(),
+      queryServiceEndpoint: jest.fn(),
+      getServiceEndpointTypes: jest.fn(),
+      getFilteredServiceEndpointTypes: jest.fn(),
+      getAzureSubscriptions: jest.fn(),
+      getAzureManagementGroups: jest.fn(),
+      getVstsAadTenantId: jest.fn(),
+      createAadOAuthRequest: jest.fn(),
+      createOAuthConfiguration: jest.fn(),
+      updateOAuthConfiguration: jest.fn(),
+      deleteOAuthConfiguration: jest.fn(),
+      getOAuthConfiguration: jest.fn(),
+      getOAuthConfigurations: jest.fn(),
+    };
+
+    const mockConnection = { getServiceEndpointApi: jest.fn().mockResolvedValue(mockApi) };
+    connectionProvider = jest.fn().mockResolvedValue(mockConnection) as ConnectionProviderMock;
+  });
+
+  function getHandler(toolName: string) {
+    configureServiceConnectionTools(server, tokenProvider, connectionProvider);
+    const call = (server.tool as jest.Mock).mock.calls.find(([name]) => name === toolName);
+    if (!call) throw new Error(`${toolName} not registered`);
+    return call[3] as (args: Record<string, unknown>) => Promise<{ content: { type: string; text: string }[]; isError?: boolean }>;
+  }
+
+  describe("tool registration", () => {
+    it("registers all service connection tools on the server", () => {
+      configureServiceConnectionTools(server, tokenProvider, connectionProvider);
+      const names = (server.tool as jest.Mock).mock.calls.map(([n]) => n);
+      const expected = [
+        "service_connections_list",
+        "service_connections_get_details",
+        "service_connections_list_by_type_and_owner",
+        "service_connections_refresh_authentication",
+        "service_connections_create",
+        "service_connections_update",
+        "service_connections_update_many",
+        "service_connections_delete",
+        "service_connections_share",
+        "service_connections_share_with_project",
+        "service_connections_query_shared_projects",
+        "service_connections_list_execution_records",
+        "service_connections_add_execution_records",
+        "service_connections_execute_request",
+        "service_connections_query",
+        "service_connections_list_types",
+        "service_connections_list_filtered_types",
+        "service_connections_list_azure_subscriptions",
+        "service_connections_list_azure_management_groups",
+        "service_connections_get_aad_tenant_id",
+        "service_connections_create_aad_oauth_request",
+        "service_connections_oauth_create",
+        "service_connections_oauth_update",
+        "service_connections_oauth_delete",
+        "service_connections_oauth_get",
+        "service_connections_oauth_list",
+      ];
+      for (const n of expected) expect(names).toContain(n);
+    });
+  });
+
+  describe("read tools", () => {
+    it("service_connections_list calls getServiceEndpoints by default", async () => {
+      const handler = getHandler("service_connections_list");
+      const endpoints = [{ id: "ep1", name: "MyAzureRM" }];
+      mockApi.getServiceEndpoints.mockResolvedValue(endpoints);
+
+      const result = await handler({ project: "P", type: "azurerm", authSchemes: ["ServicePrincipal"], endpointIds: ["ep1"], owner: "Library", includeFailed: false, actionFilter: "Use" });
+
+      expect(mockApi.getServiceEndpoints).toHaveBeenCalledWith("P", "azurerm", ["ServicePrincipal"], ["ep1"], "Library", false, false, ServiceEndpointActionFilter.Use);
+      expect(result.content[0].text).toBe(JSON.stringify(endpoints, null, 2));
+    });
+
+    it("service_connections_list uses getServiceEndpointsByNames when endpointNames provided", async () => {
+      const handler = getHandler("service_connections_list");
+      mockApi.getServiceEndpointsByNames.mockResolvedValue([{ id: "ep1" }]);
+      await handler({ project: "P", endpointNames: ["MyAzureRM"] });
+      expect(mockApi.getServiceEndpointsByNames).toHaveBeenCalledWith("P", ["MyAzureRM"], undefined, undefined, undefined, undefined, false);
+      expect(mockApi.getServiceEndpoints).not.toHaveBeenCalled();
+    });
+
+    it("service_connections_list reports empty results", async () => {
+      const handler = getHandler("service_connections_list");
+      mockApi.getServiceEndpoints.mockResolvedValue([]);
+      const result = await handler({ project: "P" });
+      expect(result.content[0].text).toBe("No service connections found.");
+    });
+
+    it("service_connections_list reports errors", async () => {
+      const handler = getHandler("service_connections_list");
+      mockApi.getServiceEndpoints.mockRejectedValue(new Error("boom"));
+      const result = await handler({ project: "P" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Error listing service connections: boom");
+    });
+
+    it("service_connections_get_details returns endpoint", async () => {
+      const handler = getHandler("service_connections_get_details");
+      const ep = { id: "ep1" };
+      mockApi.getServiceEndpointDetails.mockResolvedValue(ep);
+      const result = await handler({ project: "P", endpointId: "ep1", actionFilter: "Manage" });
+      expect(mockApi.getServiceEndpointDetails).toHaveBeenCalledWith("P", "ep1", ServiceEndpointActionFilter.Manage);
+      expect(result.content[0].text).toBe(JSON.stringify(ep, null, 2));
+    });
+
+    it("service_connections_get_details reports not found", async () => {
+      const handler = getHandler("service_connections_get_details");
+      mockApi.getServiceEndpointDetails.mockResolvedValue(undefined);
+      const result = await handler({ project: "P", endpointId: "missing" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("not found");
+    });
+
+    it("service_connections_list_by_type_and_owner returns endpoints", async () => {
+      const handler = getHandler("service_connections_list_by_type_and_owner");
+      mockApi.getServiceEndpointsByTypeAndOwner.mockResolvedValue([{ id: "ep1" }]);
+      const result = await handler({ type: "azurerm", owner: "Library" });
+      expect(mockApi.getServiceEndpointsByTypeAndOwner).toHaveBeenCalledWith("azurerm", "Library");
+      expect(result.content[0].text).toContain("ep1");
+    });
+
+    it("service_connections_refresh_authentication forwards parameters", async () => {
+      const handler = getHandler("service_connections_refresh_authentication");
+      const refreshed = [{ id: "ep1", authorization: { scheme: "OAuth" } }];
+      const refreshParams = [{ endpointId: "ep1", scope: [123], tokenValidityInMinutes: 60 }];
+      mockApi.getServiceEndpointsWithRefreshedAuthentication.mockResolvedValue(refreshed);
+      const result = await handler({ project: "P", endpointIds: ["ep1"], refreshAuthenticationParameters: refreshParams });
+      expect(mockApi.getServiceEndpointsWithRefreshedAuthentication).toHaveBeenCalledWith(refreshParams, "P", ["ep1"]);
+      expect(result.content[0].text).toContain("ep1");
+    });
+
+    it("service_connections_query_shared_projects returns projects", async () => {
+      const handler = getHandler("service_connections_query_shared_projects");
+      mockApi.querySharedProjects.mockResolvedValue([{ id: "proj1" }]);
+      const result = await handler({ endpointId: "ep1", project: "P" });
+      expect(mockApi.querySharedProjects).toHaveBeenCalledWith("ep1", "P");
+      expect(result.content[0].text).toContain("proj1");
+    });
+
+    it("service_connections_list_execution_records returns records", async () => {
+      const handler = getHandler("service_connections_list_execution_records");
+      mockApi.getServiceEndpointExecutionRecords.mockResolvedValue([{ id: 1 }]);
+      const result = await handler({ project: "P", endpointId: "ep1", top: 25, continuationToken: 5 });
+      expect(mockApi.getServiceEndpointExecutionRecords).toHaveBeenCalledWith("P", "ep1", 25, 5);
+      expect(result.content[0].text).toContain('"id": 1');
+    });
+
+    it("service_connections_list_types returns types", async () => {
+      const handler = getHandler("service_connections_list_types");
+      mockApi.getServiceEndpointTypes.mockResolvedValue([{ name: "azurerm" }]);
+      await handler({ type: "azurerm", scheme: "ServicePrincipal" });
+      expect(mockApi.getServiceEndpointTypes).toHaveBeenCalledWith("azurerm", "ServicePrincipal");
+    });
+
+    it("service_connections_list_filtered_types forwards filter", async () => {
+      const handler = getHandler("service_connections_list_filtered_types");
+      mockApi.getFilteredServiceEndpointTypes.mockResolvedValue([{ name: "azurerm" }]);
+      await handler({ typesFilter: ["azurerm", "github"] });
+      expect(mockApi.getFilteredServiceEndpointTypes).toHaveBeenCalledWith(["azurerm", "github"]);
+    });
+
+    it("service_connections_list_azure_subscriptions calls API", async () => {
+      const handler = getHandler("service_connections_list_azure_subscriptions");
+      mockApi.getAzureSubscriptions.mockResolvedValue({ value: [{ subscriptionId: "sub1" }] });
+      const result = await handler({});
+      expect(mockApi.getAzureSubscriptions).toHaveBeenCalled();
+      expect(result.content[0].text).toContain("sub1");
+    });
+
+    it("service_connections_list_azure_management_groups calls API", async () => {
+      const handler = getHandler("service_connections_list_azure_management_groups");
+      mockApi.getAzureManagementGroups.mockResolvedValue({ value: [{ id: "mg1" }] });
+      const result = await handler({});
+      expect(mockApi.getAzureManagementGroups).toHaveBeenCalled();
+      expect(result.content[0].text).toContain("mg1");
+    });
+
+    it("service_connections_get_aad_tenant_id returns the tenant id", async () => {
+      const handler = getHandler("service_connections_get_aad_tenant_id");
+      mockApi.getVstsAadTenantId.mockResolvedValue("tenant-123");
+      const result = await handler({});
+      expect(result.content[0].text).toContain("tenant-123");
+    });
+  });
+
+  describe("write tools", () => {
+    it("service_connections_create calls createServiceEndpoint", async () => {
+      const handler = getHandler("service_connections_create");
+      const endpoint = { name: "X", type: "azurerm" };
+      mockApi.createServiceEndpoint.mockResolvedValue({ id: "new", ...endpoint });
+      const result = await handler({ endpoint });
+      expect(mockApi.createServiceEndpoint).toHaveBeenCalledWith(endpoint);
+      expect(result.content[0].text).toContain('"id": "new"');
+    });
+
+    it("service_connections_update forwards id, body, and operation", async () => {
+      const handler = getHandler("service_connections_update");
+      const endpoint = { name: "Renamed" };
+      mockApi.updateServiceEndpoint.mockResolvedValue({ id: "ep1", ...endpoint });
+      await handler({ endpointId: "ep1", endpoint, operation: "rename" });
+      expect(mockApi.updateServiceEndpoint).toHaveBeenCalledWith(endpoint, "ep1", "rename");
+    });
+
+    it("service_connections_update_many forwards endpoint array", async () => {
+      const handler = getHandler("service_connections_update_many");
+      const endpoints = [{ id: "ep1" }, { id: "ep2" }];
+      mockApi.updateServiceEndpoints.mockResolvedValue(endpoints);
+      await handler({ endpoints });
+      expect(mockApi.updateServiceEndpoints).toHaveBeenCalledWith(endpoints);
+    });
+
+    it("service_connections_delete calls deleteServiceEndpoint", async () => {
+      const handler = getHandler("service_connections_delete");
+      mockApi.deleteServiceEndpoint.mockResolvedValue(undefined);
+      const result = await handler({ endpointId: "ep1", projectIds: ["p1", "p2"], deep: true });
+      expect(mockApi.deleteServiceEndpoint).toHaveBeenCalledWith("ep1", ["p1", "p2"], true);
+      expect(result.content[0].text).toContain("deleted");
+    });
+
+    it("service_connections_share calls shareServiceEndpoint", async () => {
+      const handler = getHandler("service_connections_share");
+      const refs = [{ name: "Shared", projectReference: { id: "p2" } }];
+      mockApi.shareServiceEndpoint.mockResolvedValue(undefined);
+      const result = await handler({ endpointId: "ep1", endpointProjectReferences: refs });
+      expect(mockApi.shareServiceEndpoint).toHaveBeenCalledWith(refs, "ep1");
+      expect(result.content[0].text).toContain("shared with 1 project");
+    });
+
+    it("service_connections_share_with_project calls shareEndpointWithProject", async () => {
+      const handler = getHandler("service_connections_share_with_project");
+      mockApi.shareEndpointWithProject.mockResolvedValue(undefined);
+      const result = await handler({ endpointId: "ep1", fromProject: "P1", withProject: "P2" });
+      expect(mockApi.shareEndpointWithProject).toHaveBeenCalledWith("ep1", "P1", "P2");
+      expect(result.content[0].text).toContain("shared from 'P1' with 'P2'");
+    });
+
+    it("service_connections_add_execution_records forwards input and project", async () => {
+      const handler = getHandler("service_connections_add_execution_records");
+      const input = { endpointIds: ["ep1"], data: { planId: "plan1" } };
+      mockApi.addServiceEndpointExecutionRecords.mockResolvedValue([{ id: 1 }]);
+      await handler({ project: "P", input });
+      expect(mockApi.addServiceEndpointExecutionRecords).toHaveBeenCalledWith(input, "P");
+    });
+
+    it("service_connections_execute_request calls executeServiceEndpointRequest", async () => {
+      const handler = getHandler("service_connections_execute_request");
+      const req = { dataSourceDetails: {} };
+      mockApi.executeServiceEndpointRequest.mockResolvedValue({ statusCode: "Ok" });
+      await handler({ project: "P", endpointId: "ep1", serviceEndpointRequest: req });
+      expect(mockApi.executeServiceEndpointRequest).toHaveBeenCalledWith(req, "P", "ep1");
+    });
+
+    it("service_connections_query calls queryServiceEndpoint", async () => {
+      const handler = getHandler("service_connections_query");
+      const binding = { endpointId: "ep1", dataSourceName: "ds1" };
+      mockApi.queryServiceEndpoint.mockResolvedValue(["row1", "row2"]);
+      await handler({ project: "P", binding });
+      expect(mockApi.queryServiceEndpoint).toHaveBeenCalledWith(binding, "P");
+    });
+
+    it("service_connections_create_aad_oauth_request returns URL", async () => {
+      const handler = getHandler("service_connections_create_aad_oauth_request");
+      mockApi.createAadOAuthRequest.mockResolvedValue("https://login.example.com/oauth");
+      const result = await handler({ tenantId: "tenant", redirectUri: "https://r", promptOption: "SelectAccount", completeCallbackPayload: "payload", completeCallbackByAuthCode: true });
+      expect(mockApi.createAadOAuthRequest).toHaveBeenCalledWith("tenant", "https://r", AadLoginPromptOption.SelectAccount, "payload", true);
+      expect(result.content[0].text).toContain("https://login.example.com/oauth");
+    });
+  });
+
+  describe("OAuth configuration tools", () => {
+    const baseOAuthParams = { clientId: "cid", clientSecret: "csec", endpointType: "github", name: "n1" };
+
+    it("service_connections_oauth_create forwards params", async () => {
+      const handler = getHandler("service_connections_oauth_create");
+      mockApi.createOAuthConfiguration.mockResolvedValue({ id: "oc1", ...baseOAuthParams });
+      await handler({ configurationParams: baseOAuthParams });
+      expect(mockApi.createOAuthConfiguration).toHaveBeenCalledWith(baseOAuthParams);
+    });
+
+    it("service_connections_oauth_update forwards id and params", async () => {
+      const handler = getHandler("service_connections_oauth_update");
+      mockApi.updateOAuthConfiguration.mockResolvedValue({ id: "oc1", ...baseOAuthParams });
+      await handler({ configurationId: "oc1", configurationParams: baseOAuthParams });
+      expect(mockApi.updateOAuthConfiguration).toHaveBeenCalledWith(baseOAuthParams, "oc1");
+    });
+
+    it("service_connections_oauth_delete forwards id", async () => {
+      const handler = getHandler("service_connections_oauth_delete");
+      mockApi.deleteOAuthConfiguration.mockResolvedValue({ id: "oc1" });
+      await handler({ configurationId: "oc1" });
+      expect(mockApi.deleteOAuthConfiguration).toHaveBeenCalledWith("oc1");
+    });
+
+    it("service_connections_oauth_get returns configuration", async () => {
+      const handler = getHandler("service_connections_oauth_get");
+      mockApi.getOAuthConfiguration.mockResolvedValue({ id: "oc1" });
+      const result = await handler({ configurationId: "oc1" });
+      expect(mockApi.getOAuthConfiguration).toHaveBeenCalledWith("oc1");
+      expect(result.content[0].text).toContain('"id": "oc1"');
+    });
+
+    it("service_connections_oauth_get reports not found", async () => {
+      const handler = getHandler("service_connections_oauth_get");
+      mockApi.getOAuthConfiguration.mockResolvedValue(undefined);
+      const result = await handler({ configurationId: "missing" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("service_connections_oauth_list applies action filter", async () => {
+      const handler = getHandler("service_connections_oauth_list");
+      mockApi.getOAuthConfigurations.mockResolvedValue([{ id: "oc1" }]);
+      await handler({ endpointType: "github", actionFilter: "Use" });
+      expect(mockApi.getOAuthConfigurations).toHaveBeenCalledWith("github", OAuthConfigurationActionFilter.Use);
+    });
+
+    it("service_connections_oauth_list reports empty results", async () => {
+      const handler = getHandler("service_connections_oauth_list");
+      mockApi.getOAuthConfigurations.mockResolvedValue([]);
+      const result = await handler({});
+      expect(result.content[0].text).toBe("No OAuth configurations found.");
+    });
+  });
+});


### PR DESCRIPTION
Introduces a new **`service-connections`** domain that exposes Azure DevOps service endpoint management through the MCP server.
The domain registers 26 tools covering the full lifecycle of service connections - `list`/`get`/`create`/`update`/`delete`, sharing across projects, OAuth configuration management, execution-record tracking, Azure subscription/management-group discovery, AAD tenant lookup, and arbitrary endpoint request execution.

Changes:
- Added `src/tools/service-connections.ts` implementing all service-connection tools (`service_connections_*`) using `getServiceEndpointApi()` from `azure-devops-node-api`.
- Registered the new domain in `src/shared/domains.ts` (`Domain.SERVICE_CONNECTIONS = "service-connections"`) and wired it up in `src/tools.ts` via `configureIfDomainEnabled`.
- Bumped `azure-devops-node-api` from `^15.1.2` to `^16.0.0` (required for the newer service-endpoint interfaces, including OAuth configuration types and `AadLoginPromptOption`).
- Added unit tests in `test/src/tools/service-connections.test.ts` and updated `test/src/domains.test.ts` to cover the new domain.

## GitHub issue number
N/A

## **Associated Risks**

- **Dependency bump:** `azure-devops-node-api` major upgrade (15 → 16) may introduce breaking changes affecting other domains that share the same client.
- **Broad API surface:** 26 new tools (including destructive operations like `service_connections_delete`, `service_connections_update_many`, and `service_connections_oauth_delete`) increase the blast radius for MCP functionality.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested by connecting the MCP server to GitHub Copilot CLI and executing commands that explicitly invoked the new `service_connections_*` tools.
Verified end-to-end behavior against a live Azure DevOps organization across the major tool groups (list/get/create/update/delete, sharing, OAuth configuration, and Azure subscription/management-group discovery).
