### PR TITLE
repo_search_commits: removing client-side-filters and updating the capabilities of the tool

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -277,10 +277,10 @@ Create a new branch in the repository.
 
 ### mcp_ado_repo_search_commits
 
-Search for commits in a repository with comprehensive filtering capabilities.
+Search for commits across projects and repositories with comprehensive filtering capabilities.
 
-- **Required**: `project`, `repository`
-- **Optional**: `author`, `authorEmail`, `commitIds`, `committer`, `committerEmail`, `fromCommit`, `fromDate`, `historySimplificationMode`, `includeLinks`, `includeWorkItems`, `searchText`, `skip`, `toCommit`, `toDate`, `top`, `version`, `versionType`
+- **Required**: `searchText`
+- **Optional**: `project`, `repository`, `branch`, `author`, `commitStartDate`, `commitEndDate`, `orderBy`, `includeFacets`, `skip`, `top`
 
 ### mcp_ado_repo_list_pull_requests_by_repo_or_project
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -53,5 +53,6 @@ module.exports = {
     "^(.+)/logger\\.js$": "$1/logger.ts",
     "^(.+)/elicitations\\.js$": "$1/elicitations.ts",
     "^(.+)/content-safety\\.js$": "$1/content-safety.ts",
+    "^(.+)/index\\.js$": "$1/index.ts",
   },
 };

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -10,6 +10,7 @@ import {
   GitQueryCommitsCriteria,
   GitVersionType,
   GitVersionDescriptor,
+  GitHistoryMode,
   GitPullRequestQuery,
   GitPullRequestQueryInput,
   GitPullRequestQueryType,
@@ -1740,11 +1741,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.search_commits,
-    "Search for commits in a repository with comprehensive filtering capabilities. Supports searching by description/comment text, time range, author, committer, specific commit IDs, and more. NOTE: searchText, authorEmail, committer, and committerEmail are client-side filters — they run against the commits already fetched from the API (limited by 'skip' and 'top'), not against the full repository history. Use API-level filters (fromDate, toDate, author, version) to narrow results before these filters apply.",
+    "Search for commits in a repository. All filters are passed directly to the Azure DevOps API (server-side). Supports filtering by date range, author, branch/tag/commit, commit ID range, and specific commit IDs.",
     {
       project: z.string().describe("Project name or ID"),
       repository: z.string().describe("Repository name or ID"),
-      // Existing parameters
       fromCommit: z.string().optional().describe("Starting commit ID"),
       toCommit: z.string().optional().describe("Ending commit ID"),
       version: z.string().optional().describe("The name of the branch, tag or commit to filter commits by"),
@@ -1757,38 +1757,14 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       top: z.coerce.number().optional().default(10).describe("Maximum number of commits to return"),
       includeLinks: z.boolean().optional().default(false).describe("Include commit links"),
       includeWorkItems: z.boolean().optional().default(false).describe("Include associated work items"),
-      // Enhanced search parameters
-      searchText: z.string().optional().describe("Search text to filter commits by description/comment. Supports partial matching. Client-side only: filters within the commits already fetched."),
-      author: z.string().optional().describe("Filter commits by author email or display name"),
-      authorEmail: z.string().optional().describe("Filter commits by exact author email address. Client-side only: filters within the commits already fetched."),
-      committer: z.string().optional().describe("Filter commits by committer email or display name. Client-side only: filters within the commits already fetched."),
-      committerEmail: z.string().optional().describe("Filter commits by exact committer email address. Client-side only: filters within the commits already fetched."),
+      author: z.string().optional().describe("Filter commits by author alias or display name."),
+      user: z.string().optional().describe("Filter commits by committer alias or display name."),
       fromDate: z.string().optional().describe("Filter commits from this date (ISO 8601 format, e.g., '2024-01-01T00:00:00Z')"),
       toDate: z.string().optional().describe("Filter commits to this date (ISO 8601 format, e.g., '2024-12-31T23:59:59Z')"),
       commitIds: z.array(z.string()).optional().describe("Array of specific commit IDs to retrieve. When provided, other filters are ignored except top/skip."),
-      historySimplificationMode: z.enum(["FirstParent", "SimplifyMerges", "FullHistory", "FullHistorySimplifyMerges"]).optional().describe("How to simplify the commit history"),
+      historyMode: z.enum(["SimplifiedHistory", "FirstParent", "FullHistory", "FullHistorySimplifyMerges"]).optional().describe("Git history traversal mode."),
     },
-    async ({
-      project,
-      repository,
-      fromCommit,
-      toCommit,
-      version,
-      versionType,
-      skip,
-      top,
-      includeLinks,
-      includeWorkItems,
-      searchText,
-      author,
-      authorEmail,
-      committer,
-      committerEmail,
-      fromDate,
-      toDate,
-      commitIds,
-      historySimplificationMode,
-    }) => {
+    async ({ project, repository, fromCommit, toCommit, version, versionType, skip, top, includeLinks, includeWorkItems, author, user, fromDate, toDate, commitIds, historyMode }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
@@ -1846,6 +1822,11 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
           searchCriteria.author = author;
         }
 
+        // Add committer filter
+        if (user) {
+          searchCriteria.user = user;
+        }
+
         // Add date range filters (ADO API expects ISO string format)
         if (fromDate) {
           searchCriteria.fromDate = fromDate;
@@ -1854,12 +1835,9 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
           searchCriteria.toDate = toDate;
         }
 
-        // Add history simplification if specified
-        if (historySimplificationMode) {
-          // Note: This parameter might not be directly supported by all ADO API versions
-          // but we'll include it in the criteria for forward compatibility
-          const extendedCriteria = searchCriteria as GitQueryCommitsCriteria & { historySimplificationMode?: string };
-          extendedCriteria.historySimplificationMode = historySimplificationMode;
+        // Add history mode if specified
+        if (historyMode) {
+          searchCriteria.historyMode = GitHistoryMode[historyMode as keyof typeof GitHistoryMode];
         }
 
         if (version) {
@@ -1872,33 +1850,8 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
         const commits = await gitApi.getCommits(repository, searchCriteria, project, skip, top);
 
-        // Additional client-side filtering for enhanced search capabilities
-        let filteredCommits = commits;
-
-        // Filter by search text in commit message if not handled by API
-        if (searchText && filteredCommits) {
-          filteredCommits = filteredCommits.filter((commit) => commit.comment?.toLowerCase().includes(searchText.toLowerCase()));
-        }
-
-        // Filter by author email if specified
-        if (authorEmail && filteredCommits) {
-          filteredCommits = filteredCommits.filter((commit) => commit.author?.email?.toLowerCase() === authorEmail.toLowerCase());
-        }
-
-        // Filter by committer if specified
-        if (committer && filteredCommits) {
-          filteredCommits = filteredCommits.filter(
-            (commit) => commit.committer?.name?.toLowerCase().includes(committer.toLowerCase()) || commit.committer?.email?.toLowerCase().includes(committer.toLowerCase())
-          );
-        }
-
-        // Filter by committer email if specified
-        if (committerEmail && filteredCommits) {
-          filteredCommits = filteredCommits.filter((commit) => commit.committer?.email?.toLowerCase() === committerEmail.toLowerCase());
-        }
-
         return {
-          content: [{ type: "text", text: JSON.stringify(filteredCommits, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(commits, null, 2) }],
         };
       } catch (error) {
         return {

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -28,7 +28,8 @@ import { z } from "zod";
 import { getCurrentUserDetails, getUserIdFromEmail } from "./auth.js";
 import { GitRepository } from "azure-devops-node-api/interfaces/TfvcInterfaces.js";
 import { WebApiTagDefinition } from "azure-devops-node-api/interfaces/CoreInterfaces.js";
-import { extractAdoStreamError, getEnumKeys, streamToString } from "../utils.js";
+import { extractAdoStreamError, getEnumKeys, streamToString, apiVersion } from "../utils.js";
+import { orgName } from "../index.js";
 
 const REPO_TOOLS = {
   list_repos_by_project: "repo_list_repos_by_project",
@@ -1741,129 +1742,66 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.search_commits,
-    "Search for commits in a repository. All filters are passed directly to the Azure DevOps API (server-side). Supports filtering by date range, author, branch/tag/commit, commit ID range, and specific commit IDs.",
+    "Search for commits in a repository with comprehensive filtering capabilities. Supports searching by description/comment text, time range, author and more.",
     {
-      project: z.string().describe("Project name or ID"),
-      repository: z.string().describe("Repository name or ID"),
-      fromCommit: z.string().optional().describe("Starting commit ID"),
-      toCommit: z.string().optional().describe("Ending commit ID"),
-      version: z.string().optional().describe("The name of the branch, tag or commit to filter commits by"),
-      versionType: z
-        .enum(gitVersionTypeStrings as [string, ...string[]])
+      searchText: z.string().describe("Keywords to search for in commit messages"),
+      project: z
+        .union([z.string().transform((value) => [value]), z.array(z.string())])
         .optional()
-        .default(GitVersionType[GitVersionType.Branch])
-        .describe("The meaning of the version parameter, e.g., branch, tag or commit"),
-      skip: z.coerce.number().optional().default(0).describe("Number of commits to skip"),
-      top: z.coerce.number().optional().default(10).describe("Maximum number of commits to return"),
-      includeLinks: z.boolean().optional().default(false).describe("Include commit links"),
-      includeWorkItems: z.boolean().optional().default(false).describe("Include associated work items"),
-      author: z.string().optional().describe("Filter commits by author alias or display name."),
-      user: z.string().optional().describe("Filter commits by committer alias or display name."),
-      fromDate: z.string().optional().describe("Filter commits from this date (ISO 8601 format, e.g., '2024-01-01T00:00:00Z')"),
-      toDate: z.string().optional().describe("Filter commits to this date (ISO 8601 format, e.g., '2024-12-31T23:59:59Z')"),
-      commitIds: z.array(z.string()).optional().describe("Array of specific commit IDs to retrieve. When provided, other filters are ignored except top/skip."),
-      historyMode: z.enum(["SimplifiedHistory", "FirstParent", "FullHistory", "FullHistorySimplifyMerges"]).optional().describe("Git history traversal mode."),
+        .describe("Filter by projects"),
+      repository: z.array(z.string()).optional().describe("Filter by repositories"),
+      branch: z.array(z.string()).optional().describe("Filter by branches"),
+      author: z.array(z.string()).optional().describe("Filter by commit authors. Only full display names are supported."),
+      commitStartDate: z.string().optional().describe("Filter commits from this date (format: 'YYYY-MM-DD' or 'YYYY-MM-DDTHH:MM:SS')"),
+      commitEndDate: z.string().optional().describe("Filter commits up to this date (format: 'YYYY-MM-DD' or 'YYYY-MM-DDTHH:MM:SS', e.g. '2025-06-19T23:59:59' for full day)"),
+      orderBy: z.enum(["ASC", "DESC"]).optional().describe("Sort commits by date: 'ASC' for oldest-first, 'DESC' for newest-first. Defaults to relevance if omitted."),
+      includeFacets: z.boolean().default(false).describe("Include facets in the search results"),
+      skip: z.coerce.number().default(0).describe("Number of results to skip"),
+      top: z.coerce.number().default(10).describe("Maximum number of results to return"),
     },
-    async ({ project, repository, fromCommit, toCommit, version, versionType, skip, top, includeLinks, includeWorkItems, author, user, fromDate, toDate, commitIds, historyMode }) => {
-      try {
-        const connection = await connectionProvider();
-        const gitApi = await connection.getGitApi();
+    async ({ searchText, project, repository, branch, author, commitStartDate, commitEndDate, orderBy, includeFacets, skip, top }) => {
+      const accessToken = await tokenProvider();
+      const url = `https://almsearch.dev.azure.com/${orgName}/_apis/search/commitSearchResults?api-version=${apiVersion}`;
 
-        // If specific commit IDs are provided, use getCommits with commit ID filtering
-        if (commitIds && commitIds.length > 0) {
-          const commits = [];
-          const batchSize = Math.min(top || 10, commitIds.length);
-          const startIndex = skip || 0;
-          const endIndex = Math.min(startIndex + batchSize, commitIds.length);
+      const requestBody: Record<string, unknown> = {
+        searchText,
+        includeFacets,
+        $skip: skip,
+        $top: top,
+      };
 
-          // Process commits in the requested range
-          const requestedCommitIds = commitIds.slice(startIndex, endIndex);
+      const filters: Record<string, string[]> = {};
+      if (project && project.length > 0) filters.projectName = project;
+      if (repository && repository.length > 0) filters.repositoryName = repository;
+      if (branch && branch.length > 0) filters.branchName = branch;
+      if (author && author.length > 0) filters.authorName = author;
+      if (commitStartDate) filters.commitStartDate = [commitStartDate];
+      if (commitEndDate) filters.commitEndDate = [commitEndDate];
 
-          // Use getCommits for each commit ID to maintain consistency
-          for (const commitId of requestedCommitIds) {
-            try {
-              const searchCriteria: GitQueryCommitsCriteria = {
-                includeLinks: includeLinks,
-                includeWorkItems: includeWorkItems,
-                fromCommitId: commitId,
-                toCommitId: commitId,
-              };
+      requestBody.filters = filters;
 
-              const commitResults = await gitApi.getCommits(repository, searchCriteria, project, 0, 1);
-
-              if (commitResults && commitResults.length > 0) {
-                commits.push(commitResults[0]);
-              }
-            } catch (error) {
-              // Log error but continue with other commits
-              console.warn(`Failed to retrieve commit ${commitId}: ${error instanceof Error ? error.message : String(error)}`);
-              // Add error information to result instead of failing completely
-              commits.push({
-                commitId: commitId,
-                error: `Failed to retrieve: ${error instanceof Error ? error.message : String(error)}`,
-              });
-            }
-          }
-
-          return {
-            content: [{ type: "text", text: JSON.stringify(commits, null, 2) }],
-          };
-        }
-
-        const searchCriteria: GitQueryCommitsCriteria = {
-          fromCommitId: fromCommit,
-          toCommitId: toCommit,
-          includeLinks: includeLinks,
-          includeWorkItems: includeWorkItems,
-        };
-
-        // Add author filter
-        if (author) {
-          searchCriteria.author = author;
-        }
-
-        // Add committer filter
-        if (user) {
-          searchCriteria.user = user;
-        }
-
-        // Add date range filters (ADO API expects ISO string format)
-        if (fromDate) {
-          searchCriteria.fromDate = fromDate;
-        }
-        if (toDate) {
-          searchCriteria.toDate = toDate;
-        }
-
-        // Add history mode if specified
-        if (historyMode) {
-          searchCriteria.historyMode = GitHistoryMode[historyMode as keyof typeof GitHistoryMode];
-        }
-
-        if (version) {
-          const itemVersion: GitVersionDescriptor = {
-            version: version,
-            versionType: GitVersionType[versionType as keyof typeof GitVersionType],
-          };
-          searchCriteria.itemVersion = itemVersion;
-        }
-
-        const commits = await gitApi.getCommits(repository, searchCriteria, project, skip, top);
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(commits, null, 2) }],
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error searching commits: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-          isError: true,
-        };
+      if (orderBy) {
+        requestBody.$orderBy = [{ field: "commitDate", sortOrder: orderBy }];
       }
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${accessToken}`,
+          "User-Agent": userAgentProvider(),
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Azure DevOps Commit Search API error: ${response.status} ${response.statusText}`);
+      }
+
+      const result = await response.text();
+      return {
+        content: [{ type: "text", text: result }],
+      };
     }
   );
 

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -7,10 +7,8 @@ import {
   GitRef,
   GitForkRef,
   PullRequestStatus,
-  GitQueryCommitsCriteria,
   GitVersionType,
   GitVersionDescriptor,
-  GitHistoryMode,
   GitPullRequestQuery,
   GitPullRequestQueryInput,
   GitPullRequestQueryType,
@@ -1737,8 +1735,6 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       }
     }
   );
-
-  const gitVersionTypeStrings = Object.values(GitVersionType).filter((value): value is string => typeof value === "string");
 
   server.tool(
     REPO_TOOLS.search_commits,

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -1740,7 +1740,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
   server.tool(
     REPO_TOOLS.search_commits,
-    "Search for commits in a repository with comprehensive filtering capabilities. Supports searching by description/comment text, time range, author, committer, specific commit IDs, and more. This is the unified tool for all commit search operations.",
+    "Search for commits in a repository with comprehensive filtering capabilities. Supports searching by description/comment text, time range, author, committer, specific commit IDs, and more. NOTE: searchText, authorEmail, committer, and committerEmail are client-side filters — they run against the commits already fetched from the API (limited by 'skip' and 'top'), not against the full repository history. Use API-level filters (fromDate, toDate, author, version) to narrow results before these filters apply.",
     {
       project: z.string().describe("Project name or ID"),
       repository: z.string().describe("Repository name or ID"),
@@ -1758,11 +1758,11 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       includeLinks: z.boolean().optional().default(false).describe("Include commit links"),
       includeWorkItems: z.boolean().optional().default(false).describe("Include associated work items"),
       // Enhanced search parameters
-      searchText: z.string().optional().describe("Search text to filter commits by description/comment. Supports partial matching."),
+      searchText: z.string().optional().describe("Search text to filter commits by description/comment. Supports partial matching. Client-side only: filters within the commits already fetched."),
       author: z.string().optional().describe("Filter commits by author email or display name"),
-      authorEmail: z.string().optional().describe("Filter commits by exact author email address"),
-      committer: z.string().optional().describe("Filter commits by committer email or display name"),
-      committerEmail: z.string().optional().describe("Filter commits by exact committer email address"),
+      authorEmail: z.string().optional().describe("Filter commits by exact author email address. Client-side only: filters within the commits already fetched."),
+      committer: z.string().optional().describe("Filter commits by committer email or display name. Client-side only: filters within the commits already fetched."),
+      committerEmail: z.string().optional().describe("Filter commits by exact committer email address. Client-side only: filters within the commits already fetched."),
       fromDate: z.string().optional().describe("Filter commits from this date (ISO 8601 format, e.g., '2024-01-01T00:00:00Z')"),
       toDate: z.string().optional().describe("Filter commits to this date (ISO 8601 format, e.g., '2024-12-31T23:59:59Z')"),
       commitIds: z.array(z.string()).optional().describe("Array of specific commit IDs to retrieve. When provided, other filters are ignored except top/skip."),

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -1748,10 +1748,10 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       project: z
         .union([z.string().transform((value) => [value]), z.array(z.string())])
         .optional()
-        .describe("Filter by projects"),
-      repository: z.array(z.string()).optional().describe("Filter by repositories"),
-      branch: z.array(z.string()).optional().describe("Filter by branches"),
-      author: z.array(z.string()).optional().describe("Filter by commit authors. Only full display names are supported."),
+        .describe("The names of the projects to search within. If omitted, searches across all projects in the organization."),
+      repository: z.array(z.string()).optional().describe("The names of the repositories to search within. If omitted, searches across all repositories in the specified projects."),
+      branch: z.array(z.string()).optional().describe("The names of the repository branches to search within. If omitted, searches across all branches in the specified repositories."),
+      author: z.array(z.string()).optional().describe("The names of the commit authors to search for. Only full display names are supported."),
       commitStartDate: z.string().optional().describe("Filter commits from this date (format: 'YYYY-MM-DD' or 'YYYY-MM-DDTHH:MM:SS')"),
       commitEndDate: z.string().optional().describe("Filter commits up to this date (format: 'YYYY-MM-DD' or 'YYYY-MM-DDTHH:MM:SS', e.g. '2025-06-19T23:59:59' for full day)"),
       orderBy: z.enum(["ASC", "DESC"]).optional().describe("Sort commits by date: 'ASC' for oldest-first, 'DESC' for newest-first. Defaults to relevance if omitted."),

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -5992,19 +5992,19 @@ describe("repos tools", () => {
       results: [
         {
           commitId: "abc123",
-          commitTitle: "Fix authentication bug",
-          commitDescription: "Fixed null pointer in auth module",
-          authorName: "dpaquette",
-          repositoryName: "MyRepo",
-          projectName: "MyProject",
+          commitTitle: "test commit title one",
+          commitDescription: "test commit description one",
+          authorName: "test-author-1",
+          repositoryName: "test-repo",
+          projectName: "test-project",
         },
         {
           commitId: "def456",
-          commitTitle: "Add feature flag support",
-          commitDescription: "Added feature flag infrastructure",
-          authorName: "krid",
-          repositoryName: "MyRepo",
-          projectName: "MyProject",
+          commitTitle: "test commit title two",
+          commitDescription: "test commit description two",
+          authorName: "test-author-2",
+          repositoryName: "test-repo",
+          projectName: "test-project",
         },
       ],
     };
@@ -6054,20 +6054,20 @@ describe("repos tools", () => {
       const handler = getHandler();
 
       // Zod transform converts string → string[] before handler is called; pass post-transform value
-      await handler({ searchText: "auth", project: ["MyProject"], skip: 0, top: 10, includeFacets: false });
+      await handler({ searchText: "test search", project: ["test-project"], skip: 0, top: 10, includeFacets: false });
 
       const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.filters.projectName).toEqual(["MyProject"]);
+      expect(body.filters.projectName).toEqual(["test-project"]);
     });
 
     it("should send projectName filter when project is provided as array", async () => {
       const mockFetch = setupFetchMock(true, mockSearchResponse);
       const handler = getHandler();
 
-      await handler({ searchText: "auth", project: ["Project1", "Project2"], skip: 0, top: 10, includeFacets: false });
+      await handler({ searchText: "test search", project: ["test-project-1", "test-project-2"], skip: 0, top: 10, includeFacets: false });
 
       const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.filters.projectName).toEqual(["Project1", "Project2"]);
+      expect(body.filters.projectName).toEqual(["test-project-1", "test-project-2"]);
     });
 
     it("should send repositoryName filter for multiple repos", async () => {
@@ -6075,16 +6075,16 @@ describe("repos tools", () => {
       const handler = getHandler();
 
       await handler({
-        searchText: "refactor",
-        project: ["AzureDevOps"],
-        repository: ["AzureDevOps", "azure-devops-remote-mcp"],
+        searchText: "test search",
+        project: ["test-project"],
+        repository: ["test-repo-1", "test-repo-2"],
         skip: 0,
         top: 10,
         includeFacets: false,
       });
 
       const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.filters.repositoryName).toEqual(["AzureDevOps", "azure-devops-remote-mcp"]);
+      expect(body.filters.repositoryName).toEqual(["test-repo-1", "test-repo-2"]);
     });
 
     it("should send authorName filter for multiple authors", async () => {
@@ -6092,15 +6092,15 @@ describe("repos tools", () => {
       const handler = getHandler();
 
       await handler({
-        searchText: "update",
-        author: ["dpaquette", "krid"],
+        searchText: "test search",
+        author: ["test-author-1", "test-author-2"],
         skip: 0,
         top: 10,
         includeFacets: false,
       });
 
       const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.filters.authorName).toEqual(["dpaquette", "krid"]);
+      expect(body.filters.authorName).toEqual(["test-author-1", "test-author-2"]);
     });
 
     it("should send branchName filter", async () => {
@@ -6193,11 +6193,11 @@ describe("repos tools", () => {
       const handler = getHandler();
 
       await handler({
-        searchText: "api",
-        project: ["AzureDevOps"],
-        repository: ["AzureDevOps", "azure-devops-remote-mcp"],
-        branch: ["main"],
-        author: ["dpaquette", "krid"],
+        searchText: "test search",
+        project: ["test-project"],
+        repository: ["test-repo-1", "test-repo-2"],
+        branch: ["test-branch-1"],
+        author: ["test-author-1", "test-author-2"],
         commitStartDate: "2024-01-01",
         commitEndDate: "2025-12-31T23:59:59",
         orderBy: "DESC",
@@ -6207,11 +6207,11 @@ describe("repos tools", () => {
       });
 
       const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-      expect(body.searchText).toBe("api");
-      expect(body.filters.projectName).toEqual(["AzureDevOps"]);
-      expect(body.filters.repositoryName).toEqual(["AzureDevOps", "azure-devops-remote-mcp"]);
-      expect(body.filters.branchName).toEqual(["main"]);
-      expect(body.filters.authorName).toEqual(["dpaquette", "krid"]);
+      expect(body.searchText).toBe("test search");
+      expect(body.filters.projectName).toEqual(["test-project"]);
+      expect(body.filters.repositoryName).toEqual(["test-repo-1", "test-repo-2"]);
+      expect(body.filters.branchName).toEqual(["test-branch-1"]);
+      expect(body.filters.authorName).toEqual(["test-author-1", "test-author-2"]);
       expect(body.filters.commitStartDate).toEqual(["2024-01-01"]);
       expect(body.filters.commitEndDate).toEqual(["2025-12-31T23:59:59"]);
       expect(body.$orderBy).toEqual([{ field: "commitDate", sortOrder: "DESC" }]);
@@ -7916,8 +7916,8 @@ describe("repos tools", () => {
         global.fetch = mockFetch;
 
         await handler({
-          searchText: "authentication",
-          author: ["john@example.com"],
+          searchText: "test search",
+          author: ["test-author@example.com"],
           commitStartDate: "2023-01-01",
           commitEndDate: "2023-12-31T23:59:59",
           skip: 0,
@@ -7926,7 +7926,7 @@ describe("repos tools", () => {
         });
 
         const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
-        expect(body.filters.authorName).toEqual(["john@example.com"]);
+        expect(body.filters.authorName).toEqual(["test-author@example.com"]);
         expect(body.filters.commitStartDate).toEqual(["2023-01-01"]);
         expect(body.filters.commitEndDate).toEqual(["2023-12-31T23:59:59"]);
       });

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -13,6 +13,9 @@ jest.mock("../../../src/tools/auth", () => ({
   getUserIdFromEmail: jest.fn(),
 }));
 
+// Mock index.js to avoid yargs CLI parsing at import time
+jest.mock("../../../src/index", () => ({ orgName: "test-org" }));
+
 const mockGetCurrentUserDetails = getCurrentUserDetails as jest.MockedFunction<typeof getCurrentUserDetails>;
 const mockGetUserIdFromEmail = getUserIdFromEmail as jest.MockedFunction<typeof getUserIdFromEmail>;
 
@@ -5984,68 +5987,244 @@ describe("repos tools", () => {
   });
 
   describe("repo_search_commits", () => {
-    it("should search commits successfully", async () => {
-      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+    const mockSearchResponse = {
+      count: 2,
+      results: [
+        {
+          commitId: "abc123",
+          commitTitle: "Fix authentication bug",
+          commitDescription: "Fixed null pointer in auth module",
+          authorName: "dpaquette",
+          repositoryName: "MyRepo",
+          projectName: "MyProject",
+        },
+        {
+          commitId: "def456",
+          commitTitle: "Add feature flag support",
+          commitDescription: "Added feature flag infrastructure",
+          authorName: "krid",
+          repositoryName: "MyRepo",
+          projectName: "MyProject",
+        },
+      ],
+    };
 
+    function setupFetchMock(ok: boolean, body: unknown, status = 200, statusText = "OK") {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok,
+        status,
+        statusText,
+        text: () => Promise.resolve(JSON.stringify(body)),
+      });
+      global.fetch = mockFetch;
+      return mockFetch;
+    }
+
+    function getHandler() {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
       const [, , , handler] = call;
+      return handler;
+    }
 
-      const mockCommits = [
-        { commitId: "abc123", comment: "Initial commit" },
-        { commitId: "def456", comment: "Add feature" },
-      ];
-      mockGitApi.getCommits.mockResolvedValue(mockCommits);
-
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-        version: "main",
-        versionType: "Branch",
-        skip: 0,
-        top: 10,
-      };
-
-      const result = await handler(params);
-
-      expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-        "test-repo",
-        {
-          fromCommitId: undefined,
-          toCommitId: undefined,
-          includeLinks: undefined,
-          includeWorkItems: undefined,
-          itemVersion: {
-            version: "main",
-            versionType: GitVersionType.Branch,
-          },
-        },
-        "test-project",
-        0,
-        10
-      );
-
-      expect(result.content[0].text).toBe(JSON.stringify(mockCommits, null, 2));
+    beforeEach(() => {
+      tokenProvider.mockResolvedValue("fake-token");
     });
 
-    it("should handle commit search errors", async () => {
-      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+    it("should search commits with searchText only and always send filters: {}", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
-      if (!call) throw new Error("repo_search_commits tool not registered");
-      const [, , , handler] = call;
+      const result = await handler({ searchText: "fix bug", skip: 0, top: 10, includeFacets: false });
 
-      mockGitApi.getCommits.mockRejectedValue(new Error("API Error"));
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("commitSearchResults"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ Authorization: "Bearer fake-token" }),
+          body: expect.stringContaining('"filters":{}'),
+        })
+      );
+      expect(result.content[0].text).toBe(JSON.stringify(mockSearchResponse));
+    });
 
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-      };
+    it("should send projectName filter when project is provided as string", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
 
-      const result = await handler(params);
+      // Zod transform converts string → string[] before handler is called; pass post-transform value
+      await handler({ searchText: "auth", project: ["MyProject"], skip: 0, top: 10, includeFacets: false });
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Error searching commits: API Error");
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.projectName).toEqual(["MyProject"]);
+    });
+
+    it("should send projectName filter when project is provided as array", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "auth", project: ["Project1", "Project2"], skip: 0, top: 10, includeFacets: false });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.projectName).toEqual(["Project1", "Project2"]);
+    });
+
+    it("should send repositoryName filter for multiple repos", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({
+        searchText: "refactor",
+        project: ["AzureDevOps"],
+        repository: ["AzureDevOps", "azure-devops-remote-mcp"],
+        skip: 0,
+        top: 10,
+        includeFacets: false,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.repositoryName).toEqual(["AzureDevOps", "azure-devops-remote-mcp"]);
+    });
+
+    it("should send authorName filter for multiple authors", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({
+        searchText: "update",
+        author: ["dpaquette", "krid"],
+        skip: 0,
+        top: 10,
+        includeFacets: false,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.authorName).toEqual(["dpaquette", "krid"]);
+    });
+
+    it("should send branchName filter", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({
+        searchText: "security",
+        branch: ["main", "develop"],
+        skip: 0,
+        top: 10,
+        includeFacets: false,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.branchName).toEqual(["main", "develop"]);
+    });
+
+    it("should send commitStartDate and commitEndDate filters", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({
+        searchText: "merge",
+        commitStartDate: "2025-01-01",
+        commitEndDate: "2025-06-30T23:59:59",
+        skip: 0,
+        top: 10,
+        includeFacets: false,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.commitStartDate).toEqual(["2025-01-01"]);
+      expect(body.filters.commitEndDate).toEqual(["2025-06-30T23:59:59"]);
+    });
+
+    it("should send $orderBy with commitDate DESC when orderBy is DESC", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "fix", orderBy: "DESC", skip: 0, top: 10, includeFacets: false });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.$orderBy).toEqual([{ field: "commitDate", sortOrder: "DESC" }]);
+    });
+
+    it("should send $orderBy with commitDate ASC when orderBy is ASC", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "init", orderBy: "ASC", skip: 0, top: 10, includeFacets: false });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.$orderBy).toEqual([{ field: "commitDate", sortOrder: "ASC" }]);
+    });
+
+    it("should not send $orderBy when orderBy is omitted", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "fix", skip: 0, top: 10, includeFacets: false });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.$orderBy).toBeUndefined();
+    });
+
+    it("should send includeFacets: true when requested", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "api", includeFacets: true, skip: 0, top: 25 });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.includeFacets).toBe(true);
+    });
+
+    it("should send $skip and $top for pagination", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({ searchText: "test", skip: 10, top: 5, includeFacets: false });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.$skip).toBe(10);
+      expect(body.$top).toBe(5);
+    });
+
+    it("should send all filters combined (kitchen sink)", async () => {
+      const mockFetch = setupFetchMock(true, mockSearchResponse);
+      const handler = getHandler();
+
+      await handler({
+        searchText: "api",
+        project: ["AzureDevOps"],
+        repository: ["AzureDevOps", "azure-devops-remote-mcp"],
+        branch: ["main"],
+        author: ["dpaquette", "krid"],
+        commitStartDate: "2024-01-01",
+        commitEndDate: "2025-12-31T23:59:59",
+        orderBy: "DESC",
+        includeFacets: true,
+        skip: 0,
+        top: 25,
+      });
+
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.searchText).toBe("api");
+      expect(body.filters.projectName).toEqual(["AzureDevOps"]);
+      expect(body.filters.repositoryName).toEqual(["AzureDevOps", "azure-devops-remote-mcp"]);
+      expect(body.filters.branchName).toEqual(["main"]);
+      expect(body.filters.authorName).toEqual(["dpaquette", "krid"]);
+      expect(body.filters.commitStartDate).toEqual(["2024-01-01"]);
+      expect(body.filters.commitEndDate).toEqual(["2025-12-31T23:59:59"]);
+      expect(body.$orderBy).toEqual([{ field: "commitDate", sortOrder: "DESC" }]);
+      expect(body.includeFacets).toBe(true);
+      expect(body.$skip).toBe(0);
+      expect(body.$top).toBe(25);
+    });
+
+    it("should throw an error when the API returns a non-OK response", async () => {
+      setupFetchMock(false, { message: "Bad Request" }, 400, "Bad Request");
+      const handler = getHandler();
+
+      await expect(handler({ searchText: "fix", skip: 0, top: 10, includeFacets: false })).rejects.toThrow("Azure DevOps Commit Search API error: 400 Bad Request");
     });
   });
 
@@ -6410,17 +6589,10 @@ describe("repos tools", () => {
       if (!call) throw new Error("repo_search_commits tool not registered");
       const [, , , handler] = call;
 
-      mockGitApi.getCommits.mockRejectedValue(new Error("API Error"));
+      tokenProvider.mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 500, statusText: "Internal Server Error", text: jest.fn() });
 
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-      };
-
-      const result = await handler(params);
-
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Error searching commits: API Error");
+      await expect(handler({ searchText: "fix", skip: 0, top: 10, includeFacets: false })).rejects.toThrow("Azure DevOps Commit Search API error: 500 Internal Server Error");
     });
 
     it("should handle thread creation error", async () => {
@@ -7102,86 +7274,44 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(mockThread, null, 2));
     });
 
-    it("should handle search_commits with version parameter", async () => {
+    it("should handle search_commits with branch filter", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
       const [, , , handler] = call;
 
-      const mockCommits = [{ commitId: "abc123", comment: "Test commit" }];
-      mockGitApi.getCommits.mockResolvedValue(mockCommits);
+      tokenProvider.mockResolvedValue("fake-token");
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ count: 1, results: [{ commitId: "abc123" }] })),
+      });
+      global.fetch = mockFetch;
 
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-        version: "main", // This should trigger the version branch
-        versionType: "Branch",
-        skip: 0, // Provide explicit values
-        top: 10,
-        includeLinks: false,
-        includeWorkItems: false,
-      };
+      await handler({ searchText: "test commit", branch: ["main"], skip: 0, top: 10, includeFacets: false });
 
-      const result = await handler(params);
-
-      expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-        "test-repo",
-        {
-          fromCommitId: undefined,
-          toCommitId: undefined,
-          includeLinks: false,
-          includeWorkItems: false,
-          itemVersion: {
-            version: "main",
-            versionType: GitVersionType.Branch,
-          },
-        },
-        "test-project",
-        0,
-        10
-      );
-
-      expect(result.content[0].text).toBe(JSON.stringify(mockCommits, null, 2));
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.branchName).toEqual(["main"]);
     });
 
-    it("should handle search_commits without version parameter", async () => {
+    it("should handle search_commits without branch filter", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
       const [, , , handler] = call;
 
-      const mockCommits = [{ commitId: "abc123", comment: "Test commit" }];
-      mockGitApi.getCommits.mockResolvedValue(mockCommits);
+      tokenProvider.mockResolvedValue("fake-token");
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ count: 1, results: [{ commitId: "abc123" }] })),
+      });
+      global.fetch = mockFetch;
 
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-        skip: 0, // Provide explicit values
-        top: 10,
-        includeLinks: false,
-        includeWorkItems: false,
-        // version is undefined - should test the branch where itemVersion is not set
-      };
+      await handler({ searchText: "test commit", skip: 0, top: 10, includeFacets: false });
 
-      const result = await handler(params);
-
-      expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-        "test-repo",
-        {
-          fromCommitId: undefined,
-          toCommitId: undefined,
-          includeLinks: false,
-          includeWorkItems: false,
-          // itemVersion should not be set when version is undefined
-        },
-        "test-project",
-        0,
-        10
-      );
-
-      expect(result.content[0].text).toBe(JSON.stringify(mockCommits, null, 2));
+      const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+      expect(body.filters.branchName).toBeUndefined();
     });
 
     it("should handle rightFileEndLine without rightFileStartLine", async () => {
@@ -7717,26 +7847,17 @@ describe("repos tools", () => {
       });
     });
 
-    it("should handle non-Error exceptions in search_commits", async () => {
+    it("should handle network errors in search_commits", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
       if (!call) throw new Error("repo_search_commits tool not registered");
       const [, , , handler] = call;
 
-      mockGitApi.getCommits.mockRejectedValue("String error"); // Non-Error exception
+      tokenProvider.mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network failure"));
 
-      const params = {
-        project: "test-project",
-        repository: "test-repo",
-        top: 10,
-        skip: 0,
-      };
-
-      const result = await handler(params);
-
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain("Error searching commits: String error");
+      await expect(handler({ searchText: "fix", skip: 0, top: 10, includeFacets: false })).rejects.toThrow("Network failure");
     });
 
     it("should handle valid rightFileEndOffset with rightFileEndLine in create_pull_request_thread", async () => {
@@ -7780,96 +7901,60 @@ describe("repos tools", () => {
 
   describe("enhanced commit search functions", () => {
     describe("repo_search_commits enhanced functionality", () => {
-      it("should search commits with enhanced filters", async () => {
+      it("should search commits with author and date filters via Search API", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
         if (!call) throw new Error("repo_search_commits tool not registered");
         const [, , , handler] = call;
 
-        const mockCommits = [
-          {
-            commitId: "abc123",
-            comment: "Fix bug in authentication",
-            author: { name: "John Doe", email: "john@example.com" },
-            committer: { name: "John Doe", email: "john@example.com" },
-            push: { date: "2023-01-01T00:00:00Z" },
-          },
-        ];
-        mockGitApi.getCommits.mockResolvedValue(mockCommits);
+        tokenProvider.mockResolvedValue("fake-token");
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ count: 1, results: [{ commitId: "abc123", commitTitle: "Fix bug in authentication" }] })),
+        });
+        global.fetch = mockFetch;
 
-        const params = {
-          project: "test-project",
-          repository: "test-repo",
+        await handler({
           searchText: "authentication",
-          author: "John Doe",
-          fromDate: "2023-01-01T00:00:00Z",
-          toDate: "2023-12-31T23:59:59Z",
+          author: ["john@example.com"],
+          commitStartDate: "2023-01-01",
+          commitEndDate: "2023-12-31T23:59:59",
+          skip: 0,
           top: 10,
-        };
+          includeFacets: false,
+        });
 
-        const result = await handler(params);
-
-        expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-          "test-repo",
-          expect.objectContaining({
-            author: "John Doe",
-            fromDate: "2023-01-01T00:00:00Z",
-            toDate: "2023-12-31T23:59:59Z",
-          }),
-          "test-project",
-          undefined,
-          10
-        );
-
-        expect(result.content[0].text).toBe(JSON.stringify(mockCommits, null, 2));
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+        expect(body.filters.authorName).toEqual(["john@example.com"]);
+        expect(body.filters.commitStartDate).toEqual(["2023-01-01"]);
+        expect(body.filters.commitEndDate).toEqual(["2023-12-31T23:59:59"]);
       });
 
-      it("should retrieve specific commits by IDs", async () => {
+      it("should search commits across multiple repos", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
         if (!call) throw new Error("repo_search_commits tool not registered");
         const [, , , handler] = call;
 
-        const mockCommit1 = { commitId: "abc123", comment: "First commit" };
-        const mockCommit2 = { commitId: "def456", comment: "Second commit" };
+        tokenProvider.mockResolvedValue("fake-token");
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          text: () => Promise.resolve(JSON.stringify({ count: 2, results: [{ commitId: "abc123" }, { commitId: "def456" }] })),
+        });
+        global.fetch = mockFetch;
 
-        mockGitApi.getCommits.mockResolvedValueOnce([mockCommit1]).mockResolvedValueOnce([mockCommit2]);
-
-        const params = {
-          project: "test-project",
-          repository: "test-repo",
-          commitIds: ["abc123", "def456"],
+        await handler({
+          searchText: "refactor",
+          repository: ["RepoA", "RepoB"],
+          skip: 0,
           top: 10,
-        };
+          includeFacets: false,
+        });
 
-        const result = await handler(params);
-
-        expect(mockGitApi.getCommits).toHaveBeenCalledTimes(2);
-        expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-          "test-repo",
-          expect.objectContaining({
-            fromCommitId: "abc123",
-            toCommitId: "abc123",
-          }),
-          "test-project",
-          0,
-          1
-        );
-        expect(mockGitApi.getCommits).toHaveBeenCalledWith(
-          "test-repo",
-          expect.objectContaining({
-            fromCommitId: "def456",
-            toCommitId: "def456",
-          }),
-          "test-project",
-          0,
-          1
-        );
-
-        const expectedCommits = [mockCommit1, mockCommit2];
-        expect(result.content[0].text).toBe(JSON.stringify(expectedCommits, null, 2));
+        const body = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+        expect(body.filters.repositoryName).toEqual(["RepoA", "RepoB"]);
       });
     });
   });
@@ -8378,29 +8463,15 @@ describe("repos tools", () => {
     });
 
     describe("repo_search_commits error handling", () => {
-      it("should handle commit search errors", async () => {
+      it("should handle commit search errors (non-ok HTTP response)", async () => {
         configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
         const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.search_commits);
         const [, , , handler] = call;
 
-        mockGitApi.getCommits.mockRejectedValue(new Error("Repository access denied"));
+        tokenProvider.mockResolvedValue("fake-token");
+        global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden", text: jest.fn() });
 
-        const params = {
-          project: "test-project",
-          repository: "test-repo",
-        };
-
-        const result = await handler(params);
-
-        expect(result).toEqual({
-          content: [
-            {
-              type: "text",
-              text: "Error searching commits: Repository access denied",
-            },
-          ],
-          isError: true,
-        });
+        await expect(handler({ searchText: "fix", skip: 0, top: 10, includeFacets: false })).rejects.toThrow("Azure DevOps Commit Search API error: 403 Forbidden");
       });
     });
 


### PR DESCRIPTION
Migrates the `repo_search_commits` tool from the Git REST API
(`GET _apis/git/repositories/{repo}/commits`) to the Azure DevOps
Search API (`POST almsearch.dev.azure.com/_apis/search/commitSearchResults`).

## GitHub issue number

Closes #1327

## **Associated Risks**

None

## ✅ **PR Checklist**

- [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [X] Title of the pull request is clear and informative.
- [X] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [X] 📄 Documentation added, updated, or N/A
- [X] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Tested the updated unit tests.

1. Test Suites: 18 passed, 18 total
2. Tests:       987 passed, 987 total

Manually tested the tool.

<img width="1296" height="771" alt="image" src="https://github.com/user-attachments/assets/7dacebaa-3476-4f0e-9e73-5ca227f4e315" />

<img width="1270" height="759" alt="image" src="https://github.com/user-attachments/assets/10241137-866f-4d75-9c18-1babebbbbca8" />
