### PR TITLE
Add `wit_upload_attachment` and `wit_add_attachment_to_work_item` tools

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -84,6 +84,8 @@
 | Work Items        | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                               | Execute a query and get results                                   |
 | Work Items        | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                   | Execute a WIQL query and return matching work items               |
 | Work Items        | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                             | Download a work item attachment; save locally or return as base64 |
+| Work Items        | [mcp_ado_wit_upload_attachment](#mcp_ado_wit_upload_attachment)                                           | Upload a local file to Azure DevOps as an attachment              |
+| Work Items        | [mcp_ado_wit_add_attachment_to_work_item](#mcp_ado_wit_add_attachment_to_work_item)                       | Link an uploaded attachment URL to a work item                    |
 | Work              | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                             | List all iterations in a project                                  |
 | Work              | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                         | Create new iterations in a project                                |
 | Work              | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                   | List iterations assigned to a team                                |
@@ -692,6 +694,24 @@ Download a work item attachment by its ID. If `savePath` is provided, saves the 
 
 - **Required**: `attachmentId`
 - **Optional**: `project`, `fileName`, `savePath`
+
+### mcp_ado_wit_upload_attachment
+
+Upload a local file to Azure DevOps as an attachment. Returns an attachment reference (ID and URL) that can be passed directly to `mcp_ado_wit_add_attachment_to_work_item`.
+
+The two-step design mirrors the ADO REST API model: upload once, attach to any number of work items without re-uploading.
+
+- **Required**: `filePath`
+- **Optional**: `project`, `fileName`, `comment`, `allowedPaths`, `maxFileSizeBytes`, `allowedMimeTypes`
+
+**Security note**: Use `allowedPaths` to restrict which directories the agent may read from. When provided, `filePath` must resolve to one of those prefixes. Recommended for automated or agent workflows to prevent exfiltration of sensitive files (e.g. `.env`, SSH keys). Supports MIME type allowlists via `allowedMimeTypes` (e.g. `["image/*", "text/plain"]`).
+
+### mcp_ado_wit_add_attachment_to_work_item
+
+Link an already-uploaded attachment URL to an existing work item. Use the `url` returned by `mcp_ado_wit_upload_attachment`, or any valid Azure DevOps attachment URL.
+
+- **Required**: `workItemId`, `attachmentUrl`, `fileName`
+- **Optional**: `project`, `comment`
 
 ## Work
 

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -35,6 +35,8 @@ const WORKITEM_TOOLS = {
   work_item_unlink: "wit_work_item_unlink",
   add_artifact_link: "wit_add_artifact_link",
   get_work_item_attachment: "wit_get_work_item_attachment",
+  upload_attachment: "wit_upload_attachment",
+  add_attachment_to_work_item: "wit_add_attachment_to_work_item",
   query_by_wiql: "wit_query_by_wiql",
 };
 
@@ -1569,6 +1571,191 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           content: [{ type: "text", text: `Error retrieving work item attachment: ${errorMessage}` }],
           isError: true,
         };
+      }
+    }
+  );
+
+  server.tool(
+    WORKITEM_TOOLS.upload_attachment,
+    `Upload a local file to Azure DevOps as an attachment. Returns an attachment reference (ID and URL) that can be passed to ${WORKITEM_TOOLS.add_attachment_to_work_item}.
+
+SECURITY: Use allowedPaths to restrict which directories the agent may read from. Example: allowedPaths: ["/tmp/test-artifacts"] limits uploads to that folder only. If a project is not specified, you will be prompted to select one.`,
+    {
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
+      filePath: z.string().describe("Absolute local path to the file to upload."),
+      fileName: z.string().optional().describe("Display name for the attachment. Defaults to the file's basename."),
+      comment: z.string().optional().describe("Optional description stored with the attachment."),
+      allowedPaths: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Security allowlist. If provided, filePath must start with one of these directory prefixes. " +
+            "Recommended when using this tool in automated or agent workflows to prevent exfiltration of sensitive files."
+        ),
+      maxFileSizeBytes: z.number().int().positive().max(104_857_600).optional().default(10_485_760).describe("Maximum allowed file size in bytes. Default 10 MB, hard ceiling 100 MB."),
+      allowedMimeTypes: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional MIME type allowlist (e.g. ['image/png', 'text/plain']). Supports wildcards (e.g. 'image/*'). " +
+            "When provided, the upload is rejected if the file extension does not map to an allowed type."
+        ),
+    },
+    async ({ project, filePath, fileName, comment, allowedPaths, maxFileSizeBytes, allowedMimeTypes }) => {
+      try {
+        const resolvedPath = path.resolve(filePath);
+
+        if (filePath.includes("..")) {
+          throw new Error(`Security: filePath must not contain '..' sequences. Received: ${filePath}`);
+        }
+
+        if (allowedPaths && allowedPaths.length > 0) {
+          const permitted = allowedPaths.some((allowed) => resolvedPath.startsWith(path.resolve(allowed)));
+          if (!permitted) {
+            throw new Error(`Security: filePath '${resolvedPath}' is not within any allowedPaths. Allowed prefixes: ${allowedPaths.join(", ")}`);
+          }
+        }
+
+        if (!fs.existsSync(resolvedPath)) {
+          throw new Error(`File not found: ${resolvedPath}`);
+        }
+
+        const stat = fs.statSync(resolvedPath);
+        if (!stat.isFile()) {
+          throw new Error(`Path is not a file: ${resolvedPath}`);
+        }
+
+        const effectiveMax = maxFileSizeBytes ?? 10_485_760;
+        if (stat.size > effectiveMax) {
+          throw new Error(`File size ${stat.size} bytes exceeds limit of ${effectiveMax} bytes. Use maxFileSizeBytes to increase the limit (max 100 MB).`);
+        }
+
+        if (allowedMimeTypes && allowedMimeTypes.length > 0) {
+          const ext = path.extname(resolvedPath).toLowerCase();
+          const UPLOAD_MIME_MAP: Record<string, string> = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+            ".bmp": "image/bmp",
+            ".svg": "image/svg+xml",
+            ".pdf": "application/pdf",
+            ".txt": "text/plain",
+            ".log": "text/plain",
+            ".json": "application/json",
+            ".xml": "application/xml",
+            ".csv": "text/csv",
+            ".zip": "application/zip",
+            ".mp4": "video/mp4",
+            ".mov": "video/quicktime",
+            ".avi": "video/avi",
+          };
+          const detectedMime = UPLOAD_MIME_MAP[ext] ?? "application/octet-stream";
+          const allowed = allowedMimeTypes.some((m) => detectedMime === m || (m.endsWith("/*") && detectedMime.startsWith(m.slice(0, -1))));
+          if (!allowed) {
+            throw new Error(`File type '${detectedMime}' (extension '${ext}') is not in allowedMimeTypes: ${allowedMimeTypes.join(", ")}`);
+          }
+        }
+
+        const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to upload the attachment to.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
+        const workItemApi = await connection.getWorkItemTrackingApi();
+        const effectiveFileName = fileName ?? path.basename(resolvedPath);
+        const uploadStream = fs.createReadStream(resolvedPath);
+
+        const attachmentRef = await workItemApi.createAttachment({}, uploadStream, effectiveFileName, undefined, resolvedProject);
+
+        if (!attachmentRef?.url) {
+          throw new Error("Upload succeeded but no attachment URL was returned.");
+        }
+
+        const result = {
+          id: attachmentRef.id,
+          url: attachmentRef.url,
+          fileName: effectiveFileName,
+          comment: comment ?? null,
+          uploadedAt: new Date().toISOString(),
+          fileSizeBytes: stat.size,
+        };
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`wit_upload_attachment failed: ${message}`);
+      }
+    }
+  );
+
+  server.tool(
+    WORKITEM_TOOLS.add_attachment_to_work_item,
+    `Link an already-uploaded attachment URL to an existing work item. Use the URL returned by ${WORKITEM_TOOLS.upload_attachment}, or any valid Azure DevOps attachment URL.
+
+This is intentionally a separate step from uploading so the same file can be attached to multiple work items without re-uploading, and so each operation remains focused. If a project is not specified, you will be prompted to select one.`,
+    {
+      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
+      workItemId: z.number().int().positive().describe("ID of the work item to attach the file to."),
+      attachmentUrl: z.string().url().describe("Attachment URL — use the 'url' field returned by wit_upload_attachment, or any valid Azure DevOps attachment URL."),
+      fileName: z.string().describe("Display name for the attachment as it will appear on the work item."),
+      comment: z.string().optional().describe("Optional comment shown in work item history alongside the attachment."),
+    },
+    async ({ project, workItemId, attachmentUrl, fileName, comment }) => {
+      try {
+        const connection = await connectionProvider();
+
+        let resolvedProject = project;
+        if (!resolvedProject) {
+          const result = await elicitProject(server, connection, "Select the Azure DevOps project to add the attachment to.");
+          if ("response" in result) return result.response;
+          resolvedProject = result.resolved;
+        }
+
+        const workItemApi = await connection.getWorkItemTrackingApi();
+
+        const patchDocument = [
+          {
+            op: "add",
+            path: "/relations/-",
+            value: {
+              rel: "AttachedFile",
+              url: attachmentUrl,
+              attributes: {
+                comment: comment ?? "",
+                name: fileName,
+              },
+            },
+          },
+        ];
+
+        const updatedWorkItem = await workItemApi.updateWorkItem({} as never, patchDocument, workItemId, resolvedProject, false, false, false, undefined);
+
+        const result = {
+          workItemId: updatedWorkItem.id,
+          attachedFileName: fileName,
+          attachmentUrl,
+          relations: updatedWorkItem.relations?.map((r) => ({
+            rel: r.rel,
+            url: r.url,
+            name: r.attributes?.["name"],
+            comment: r.attributes?.["comment"],
+          })),
+        };
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`wit_add_attachment_to_work_item failed: ${message}`);
       }
     }
   );

--- a/test/mocks/work-items.ts
+++ b/test/mocks/work-items.ts
@@ -664,6 +664,22 @@ export const _mockWorkItemRevisions = [
   },
 ];
 
+export const _mockAttachmentReference = {
+  id: "abc-123-def-456",
+  url: "https://dev.azure.com/fabrikam/_apis/wit/attachments/abc-123-def-456",
+};
+
+export const _mockWorkItemWithAttachment = {
+  id: 99,
+  relations: [
+    {
+      rel: "AttachedFile",
+      url: "https://dev.azure.com/fabrikam/_apis/wit/attachments/abc-123-def-456",
+      attributes: { name: "screenshot.png", comment: "Bug evidence" },
+    },
+  ],
+};
+
 export const _mockWiqlQueryResults = {
   queryType: 1,
   queryResultType: 1,

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -49,6 +49,7 @@ interface WorkItemTrackingApiMock {
   queryById: jest.Mock;
   queryByWiql: jest.Mock;
   getAttachmentContent: jest.Mock;
+  createAttachment: jest.Mock;
 }
 
 interface MockConnection {
@@ -92,6 +93,7 @@ describe("configureWorkItemTools", () => {
       queryById: jest.fn(),
       queryByWiql: jest.fn(),
       getAttachmentContent: jest.fn(),
+      createAttachment: jest.fn(),
     };
 
     mockConnection = {
@@ -5003,6 +5005,177 @@ describe("configureWorkItemTools", () => {
       (mockWorkItemTrackingApi.getRevisions as jest.Mock).mockResolvedValue(revisionsWithNoFields);
       const result = await handler({ project: "P", workItemId: 1, top: 10 });
       expect(result.content[0].text).toBe(JSON.stringify(revisionsWithNoFields, null, 2));
+    });
+  });
+
+  describe("wit_upload_attachment tool", () => {
+    const SAFE_DIR = "/tmp/test-artifacts";
+    const SAFE_FILE = `${SAFE_DIR}/screenshot.png`;
+    const FAKE_ATTACHMENT_URL = "https://dev.azure.com/myorg/_apis/wit/attachments/abc-123";
+
+    beforeEach(() => {
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.statSync as jest.Mock).mockReturnValue({ isFile: () => true, size: 5_120 });
+      (fs.createReadStream as jest.Mock).mockReturnValue("STREAM" as never);
+      (mockWorkItemTrackingApi.createAttachment as jest.Mock).mockResolvedValue({ id: "abc-123", url: FAKE_ATTACHMENT_URL });
+    });
+
+    it("should upload a file and return the attachment reference", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_upload_attachment");
+      if (!call) throw new Error("wit_upload_attachment tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ project: "MyProject", filePath: SAFE_FILE });
+
+      expect(mockWorkItemTrackingApi.createAttachment).toHaveBeenCalledWith({}, "STREAM", "screenshot.png", undefined, "MyProject");
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.url).toBe(FAKE_ATTACHMENT_URL);
+      expect(parsed.id).toBe("abc-123");
+      expect(parsed.fileName).toBe("screenshot.png");
+    });
+
+    it("should use a custom fileName when provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await handler({ project: "MyProject", filePath: SAFE_FILE, fileName: "custom-name.png" });
+
+      expect(mockWorkItemTrackingApi.createAttachment).toHaveBeenCalledWith({}, "STREAM", "custom-name.png", undefined, "MyProject");
+    });
+
+    it("should reject paths containing '..'", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: "/tmp/../etc/passwd" })).rejects.toThrow("Security: filePath must not contain '..' sequences");
+    });
+
+    it("should reject paths outside allowedPaths", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: "/etc/passwd", allowedPaths: [SAFE_DIR] })).rejects.toThrow("Security: filePath");
+    });
+
+    it("should accept paths within allowedPaths", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: SAFE_FILE, allowedPaths: [SAFE_DIR] })).resolves.toBeDefined();
+    });
+
+    it("should reject files exceeding maxFileSizeBytes", async () => {
+      (fs.statSync as jest.Mock).mockReturnValue({ isFile: () => true, size: 20_000_000 });
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: SAFE_FILE, maxFileSizeBytes: 10_485_760 })).rejects.toThrow("exceeds limit");
+    });
+
+    it("should reject disallowed MIME types", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: `${SAFE_DIR}/video.mp4`, allowedMimeTypes: ["image/png", "image/jpeg"] })).rejects.toThrow("not in allowedMimeTypes");
+    });
+
+    it("should accept files matching an allowedMimeTypes wildcard", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: `${SAFE_DIR}/photo.jpg`, allowedMimeTypes: ["image/*"] })).resolves.toBeDefined();
+    });
+
+    it("should throw when file does not exist", async () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: SAFE_FILE })).rejects.toThrow("File not found");
+    });
+
+    it("should throw when createAttachment returns no URL", async () => {
+      (mockWorkItemTrackingApi.createAttachment as jest.Mock).mockResolvedValue({});
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_upload_attachment")!;
+
+      await expect(handler({ project: "MyProject", filePath: SAFE_FILE })).rejects.toThrow("no attachment URL was returned");
+    });
+  });
+
+  describe("wit_add_attachment_to_work_item tool", () => {
+    const ATTACHMENT_URL = "https://dev.azure.com/myorg/_apis/wit/attachments/abc-123";
+
+    beforeEach(() => {
+      (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockResolvedValue({
+        id: 99,
+        relations: [
+          {
+            rel: "AttachedFile",
+            url: ATTACHMENT_URL,
+            attributes: { name: "screenshot.png", comment: "Bug evidence" },
+          },
+        ],
+      });
+    });
+
+    it("should patch the work item with an AttachedFile relation", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_attachment_to_work_item");
+      if (!call) throw new Error("wit_add_attachment_to_work_item tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({
+        project: "MyProject",
+        workItemId: 99,
+        attachmentUrl: ATTACHMENT_URL,
+        fileName: "screenshot.png",
+        comment: "Bug evidence",
+      });
+
+      expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining([
+          expect.objectContaining({
+            op: "add",
+            path: "/relations/-",
+            value: expect.objectContaining({ rel: "AttachedFile", url: ATTACHMENT_URL }),
+          }),
+        ]),
+        99,
+        "MyProject",
+        false,
+        false,
+        false,
+        undefined
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.workItemId).toBe(99);
+      expect(parsed.attachedFileName).toBe("screenshot.png");
+      expect(parsed.relations).toHaveLength(1);
+      expect(parsed.relations[0].rel).toBe("AttachedFile");
+    });
+
+    it("should default comment to empty string when not provided", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_add_attachment_to_work_item")!;
+
+      await handler({ project: "MyProject", workItemId: 99, attachmentUrl: ATTACHMENT_URL, fileName: "log.txt" });
+
+      const patchDoc = (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mock.calls[0][1];
+      expect(patchDoc[0].value.attributes.comment).toBe("");
+    });
+
+    it("should propagate API errors with context", async () => {
+      (mockWorkItemTrackingApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("403 Forbidden"));
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const [, , , handler] = (server.tool as jest.Mock).mock.calls.find(([n]) => n === "wit_add_attachment_to_work_item")!;
+
+      await expect(handler({ project: "MyProject", workItemId: 99, attachmentUrl: ATTACHMENT_URL, fileName: "screenshot.png" })).rejects.toThrow(
+        "wit_add_attachment_to_work_item failed: 403 Forbidden"
+      );
     });
   });
 });


### PR DESCRIPTION
# Add `wit_upload_attachment` and `wit_add_attachment_to_work_item` tools

## Summary

This PR adds two new tools to the `work-items` domain that complete the attachment story alongside the existing `wit_get_work_item_attachment`:

| Tool | Purpose |
|------|---------|
| `wit_upload_attachment` | Upload a file from a local path and receive a URL back |
| `wit_add_attachment_to_work_item` | Attach an already-uploaded URL to a work item |

The two-step design is intentional — it mirrors the ADO REST API model, keeps each tool focused, and allows attaching the same uploaded file to multiple work items without re-uploading.

---

## Motivation

Issue #392 (duplicate of #299, #376, #344) has been open since mid-2025. The maintainers noted a **security concern** as the reason for deferral. This proposal directly addresses that concern — see the Security section below.

Real-world use cases that are currently blocked:
- Automated QA workflows (Playwright → screenshot → attach to bug)
- CI pipelines attaching build logs or test reports to work items
- Teams using Claude Code / agent workflows that need evidence attached to ADO tickets

---

## Security Design

**The risk the maintainers identified:** An LLM-controlled MCP tool that can read arbitrary local file paths and upload them to ADO could be exploited via prompt injection — malicious content in a work item could instruct the agent to exfiltrate sensitive local files (secrets, `.env`, SSH keys, etc.) by uploading them as attachments.

**How this implementation mitigates it:**

1. **`allowedPaths` parameter** — The tool accepts an optional `allowedPaths` array. When provided, the `filePath` must resolve to one of those prefixes. This lets users lock the tool to a safe sandbox (e.g. `/tmp/playwright-artifacts/`).

2. **Path traversal prevention** — The implementation uses `path.resolve()` and rejects any path containing `..` sequences before the allowedPaths check.

3. **File size limit** — Configurable via `maxFileSizeBytes`, default 10 MB, hard ceiling 100 MB. Prevents accidental MP4 uploads from saturating API quotas.

4. **MIME type allowlist** — An optional `allowedMimeTypes` array. When provided, the file's detected content type must match. Defaults to open (no restriction) but makes it easy for security-conscious users to restrict to `image/*` or `text/*`.

5. **No base64 path** — Unlike some proposals, this implementation does **not** accept raw base64 content. File path only, which requires prior filesystem access and reduces the LLM's ability to exfiltrate data it received in-context.

These mitigations follow the same "Spotlighting" philosophy already in the repo (see PR #1062).

---

## API Design

### `wit_upload_attachment`

```typescript
{
  project: string;          // Project name or ID
  filePath: string;         // Absolute local path to the file
  fileName?: string;        // Override display name (defaults to basename)
  comment?: string;         // Optional description stored with the attachment
  allowedPaths?: string[];  // If set, filePath must start with one of these
  maxFileSizeBytes?: number; // Default 10_485_760 (10 MB)
  allowedMimeTypes?: string[]; // e.g. ["image/png", "image/jpeg", "text/plain"]
}
```

Returns: `{ id: string; url: string; fileName: string; uploadedAt: string }`

### `wit_add_attachment_to_work_item`

```typescript
{
  project: string;     // Project name or ID
  workItemId: number;  // Target work item
  attachmentUrl: string; // URL from wit_upload_attachment (or any valid ADO attachment URL)
  fileName: string;    // Display name for the attachment relation
  comment?: string;    // Optional comment shown in work item history
}
```

Returns: the updated work item relations array.

---

## Implementation Notes

- Uses `WorkItemTrackingApi.createAttachment()` (already in the SDK the repo depends on) for upload
- Uses `WorkItemTrackingApi.updateWorkItem()` with an `add` JSON Patch operation on `/relations/-` and relation type `AttachedFile` for the link step — same pattern as existing link tools
- No new dependencies required
- Fits cleanly into `configureWorkItemTools()` alongside the existing 21 tools

---

## What I'm NOT doing

- No base64 content input (security risk, see above)
- No "upload and attach in one step" mega-tool (violates the project's stated design philosophy: *"concise, simple, focused tools"*)
- No streaming for large files in this initial PR (can follow on)

---

## Files changed

- `src/tools/work-items.ts` — two new tool registrations
- `docs/TOOLSET.md` — documentation entries for both tools
- `test/src/tools/work-items.test.ts` — unit tests covering happy path, path traversal rejection, file-too-large rejection, and allowedPaths enforcement
- `test/mocks/work-items.ts` — mock data for attachment responses

---

## Checklist

- [ ] Follows existing tool patterns (`McpServer.tool()`, `z.object()` schema, `JSON.stringify(result, null, 2)` response)
- [ ] Error handling consistent with existing tools
- [ ] Security mitigations documented above implemented and tested
- [ ] TOOLSET.md updated
- [ ] No new `npm` dependencies

---
