### PR TITLE
Enforce org boundary on wiki page URL input

### DIFF
--- a/src/tools/wiki.ts
+++ b/src/tools/wiki.ts
@@ -5,7 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { z } from "zod";
 import { WikiPagesBatchRequest } from "azure-devops-node-api/interfaces/WikiInterfaces.js";
-import { apiVersion, extractAdoStreamError } from "../utils.js";
+import { apiVersion, extractAdoStreamError, getOrgFromUrl } from "../utils.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 
 const WIKI_TOOLS = {
@@ -220,6 +220,23 @@ function configureWikiTools(server: McpServer, tokenProvider: () => Promise<stri
 
           if ("error" in parsed) {
             return { content: [{ type: "text", text: `Error fetching wiki page content: ${parsed.error}` }], isError: true };
+          }
+
+          // Guard against cross-organization requests: a user-supplied URL must target the
+          // same organization the server is connected to. Otherwise the org segment in the
+          // URL would be silently ignored and content fetched from the configured org instead.
+          const configuredOrg = getOrgFromUrl(connection.serverUrl);
+          const urlOrg = getOrgFromUrl(url);
+          if (configuredOrg && urlOrg !== configuredOrg) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Error fetching wiki page content: The provided URL targets organization '${urlOrg ?? "unknown"}', which does not match the configured organization '${configuredOrg}'. Cross-organization requests are not allowed.`,
+                },
+              ],
+              isError: true,
+            };
           }
 
           resolvedProject = parsed.project;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,37 @@ export function extractAdoStreamError(content: string): string | null {
 }
 
 /**
+ * Extracts the Azure DevOps organization identifier from a URL.
+ *
+ * Only recognized Azure DevOps hosts are accepted; any other host returns null
+ * so that callers can treat unrecognized URLs as a boundary violation.
+ *
+ * Supports both modern and legacy organization URL forms:
+ *  - https://dev.azure.com/{org}/...            -> org is the first path segment
+ *  - https://{org}.visualstudio.com/...         -> org is the host subdomain
+ *
+ * @param url Any Azure DevOps URL (e.g. a wiki page link or a connection serverUrl).
+ * @returns The lowercased organization name, or null if it cannot be determined.
+ */
+export function getOrgFromUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    if (host === "visualstudio.com" || host.endsWith(".visualstudio.com")) {
+      const subdomain = host.split(".")[0];
+      return subdomain && subdomain !== "visualstudio" ? subdomain : null;
+    }
+    if (host === "dev.azure.com" || host.endsWith(".dev.azure.com")) {
+      const firstSegment = u.pathname.split("/").filter(Boolean)[0];
+      return firstSegment ? firstSegment.toLowerCase() : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Convert a Node.js ReadableStream to a string.
  * Shared utility for consistent stream handling across tools.
  */

--- a/test/src/tools/wiki.test.ts
+++ b/test/src/tools/wiki.test.ts
@@ -700,7 +700,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki?wikiVersion=GBmain&pagePath=%2FDocs%2FIntro";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki?wikiVersion=GBmain&pagePath=%2FDocs%2FIntro";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/Docs/Intro", undefined, undefined, true);
@@ -733,7 +733,7 @@ describe("configureWikiTools", () => {
         json: jest.fn().mockResolvedValue({ content: "# Page Title\nBody" }),
       });
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/123/Page-Title";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/123/Page-Title";
       const result = await handler({ url });
 
       // Current implementation may fallback to root path stream retrieval
@@ -766,7 +766,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/999/Some-Page";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/999/Some-Page";
       const result = await handler({ url });
 
       // Implementation currently falls back to root path if path not resolved prior to fallback
@@ -780,7 +780,7 @@ describe("configureWikiTools", () => {
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
       if (!call) throw new Error("wiki_get_page_content tool not registered");
       const [, , , handler] = call;
-      const result = await handler({ url: "https://dev.azure.com/org/project/_wiki/wikis/wiki1?pagePath=%2FHome", wikiIdentifier: "wiki1", project: "project" });
+      const result = await handler({ url: "https://dev.azure.com/testorg/project/_wiki/wikis/wiki1?pagePath=%2FHome", wikiIdentifier: "wiki1", project: "project" });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Provide either 'url' OR 'wikiIdentifier'");
     });
@@ -817,6 +817,59 @@ describe("configureWikiTools", () => {
       expect(result.content[0].text).toContain("Error fetching wiki page content: Invalid URL format");
     });
 
+    it("should reject a URL pointing to a different organization (dev.azure.com)", async () => {
+      configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
+      if (!call) throw new Error("wiki_get_page_content tool not registered");
+      const [, , , handler] = call;
+
+      const url = "https://dev.azure.com/otherorg/project/_wiki/wikis/myWiki?pagePath=%2FHome";
+      const result = await handler({ url });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("does not match the configured organization 'testorg'");
+      expect(result.content[0].text).toContain("Cross-organization requests are not allowed");
+      expect(mockWikiApi.getPageText).not.toHaveBeenCalled();
+    });
+
+    it("should reject a legacy visualstudio.com URL pointing to a different organization", async () => {
+      configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
+      if (!call) throw new Error("wiki_get_page_content tool not registered");
+      const [, , , handler] = call;
+
+      const url = "https://otherorg.visualstudio.com/project/_wiki/wikis/myWiki?pagePath=%2FHome";
+      const result = await handler({ url });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("organization 'otherorg'");
+      expect(mockWikiApi.getPageText).not.toHaveBeenCalled();
+    });
+
+    it("should allow a URL that matches the configured organization regardless of casing", async () => {
+      configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
+      if (!call) throw new Error("wiki_get_page_content tool not registered");
+      const [, , , handler] = call;
+
+      const mockStream = {
+        setEncoding: jest.fn(),
+        on: function (event: string, cb: (chunk?: unknown) => void) {
+          if (event === "data") setImmediate(() => cb("same org content"));
+          if (event === "end") setImmediate(() => cb());
+          return this;
+        },
+      };
+      mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
+
+      const url = "https://dev.azure.com/TestOrg/project/_wiki/wikis/myWiki?pagePath=%2FHome";
+      const result = await handler({ url });
+
+      expect(result.isError).toBeUndefined();
+      expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/Home", undefined, undefined, true);
+      expect(result.content[0].text).toContain("same org content");
+    });
+
     it("should handle URL with pageId that returns 404", async () => {
       configureWikiTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wiki_get_page_content");
@@ -832,7 +885,7 @@ describe("configureWikiTools", () => {
         status: 404,
       });
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/999/NonExistent-Page";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/999/NonExistent-Page";
       const result = await handler({ url });
 
       expect(result.isError).toBe(true);
@@ -868,7 +921,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/not-a-number/Some-Page";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/not-a-number/Some-Page";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/", undefined, undefined, true);
@@ -898,7 +951,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/123/Page-Title";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/123/Page-Title";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/", undefined, undefined, true);
@@ -921,7 +974,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki?pagePath=Home";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki?pagePath=Home";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/Home", undefined, undefined, true);
@@ -944,7 +997,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/", undefined, undefined, true);
@@ -1035,7 +1088,7 @@ describe("configureWikiTools", () => {
       };
       mockWikiApi.getPageText.mockResolvedValue(mockStream as unknown);
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/123/Page-Title";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/123/Page-Title";
       const result = await handler({ url });
 
       expect(mockWikiApi.getPageText).toHaveBeenCalledWith("project", "myWiki", "/", undefined, undefined, true);
@@ -1771,7 +1824,7 @@ describe("configureWikiTools", () => {
         json: jest.fn().mockResolvedValue({ content: pageContent }),
       });
 
-      const url = "https://dev.azure.com/org/project/_wiki/wikis/myWiki/123/Page-Title";
+      const url = "https://dev.azure.com/testorg/project/_wiki/wikis/myWiki/123/Page-Title";
       const result = await handler({ url });
 
       const responseText = result.content[0].text;

--- a/test/src/utils.test.ts
+++ b/test/src/utils.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AlertType, AlertValidityStatus, Confidence, Severity, State } from "azure-devops-node-api/interfaces/AlertInterfaces";
-import { createEnumMapping, encodeFormattedValue, extractAdoStreamError, getEnumKeys, mapStringArrayToEnum, mapStringToEnum, safeEnumConvert } from "../../src/utils";
+import { createEnumMapping, encodeFormattedValue, extractAdoStreamError, getEnumKeys, getOrgFromUrl, mapStringArrayToEnum, mapStringToEnum, safeEnumConvert } from "../../src/utils";
 
 describe("utils", () => {
   describe("createEnumMapping", () => {
@@ -521,5 +521,37 @@ describe("encodeFormattedValue", () => {
       expect(once).toBe("Already &lt;tag&gt; plus &lt;new&gt; and $cash");
       expect(twice).toBe(once);
     });
+  });
+});
+
+describe("getOrgFromUrl", () => {
+  it("extracts org from a dev.azure.com URL as the first path segment", () => {
+    expect(getOrgFromUrl("https://dev.azure.com/contoso")).toBe("contoso");
+    expect(getOrgFromUrl("https://dev.azure.com/contoso/project/_wiki/wikis/myWiki?pagePath=%2FHome")).toBe("contoso");
+  });
+
+  it("extracts org from a legacy visualstudio.com URL as the host subdomain", () => {
+    expect(getOrgFromUrl("https://contoso.visualstudio.com/project/_wiki/wikis/myWiki")).toBe("contoso");
+  });
+
+  it("lowercases the org for case-insensitive comparison", () => {
+    expect(getOrgFromUrl("https://dev.azure.com/Contoso/project")).toBe("contoso");
+    expect(getOrgFromUrl("https://Contoso.visualstudio.com/project")).toBe("contoso");
+  });
+
+  it("returns null for invalid URLs", () => {
+    expect(getOrgFromUrl("not-a-url")).toBeNull();
+    expect(getOrgFromUrl("")).toBeNull();
+  });
+
+  it("returns null for non-Azure DevOps hosts", () => {
+    expect(getOrgFromUrl("https://example.com/contoso/project/_wiki/wikis/myWiki")).toBeNull();
+    expect(getOrgFromUrl("https://dev.azure.com.evil.com/contoso/project")).toBeNull();
+    expect(getOrgFromUrl("https://notvisualstudio.com/contoso")).toBeNull();
+  });
+
+  it("returns null when no org segment is present", () => {
+    expect(getOrgFromUrl("https://dev.azure.com/")).toBeNull();
+    expect(getOrgFromUrl("https://dev.azure.com")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
The `wiki_get_page_content` tool accepts a full wiki page URL and previously used only the project/wiki path segments while **ignoring the organization** in the URL, silently issuing the request against the configured org. A URL pointing at a different organization would therefore return content from the configured org instead of erroring — a cross-organization boundary violation

## Changes
- Add `getOrgFromUrl` helper in `src/utils.ts` that extracts the org from recognized Azure DevOps hosts only:
  - `https://dev.azure.com/{org}/...` -> first path segment
  - `https://{org}.visualstudio.com/...` -> host subdomain
  - any other host returns `null` (treated as a boundary violation)
  - result is normalized to lowercase for case-insensitive comparison
- In `wiki_get_page_content`, reject any user-supplied URL whose org does not match the connected org (`connection.serverUrl`), returning an `isError` result without issuing the request.
- Tests: unit tests for `getOrgFromUrl` (incl. non-ADO hosts, casing) and cross-org rejection tests for the wiki tool; updated existing same-org fixtures.

## Scope / risk
The other wiki tools (`get_wiki`, `list_wikis`, `list_pages`, `get_page` metadata, `create_or_update_page`) build their URLs from `connection.serverUrl` and take only `wikiIdentifier`/`project`/`path` as input, so they cannot be redirected to another org and are unaffected.

## Validation
- `npm run build` ✅
- Full test suite: 974 passing (148 in the touched utils + wiki suites) ✅
- `npm run eslint` ✅