### PR TITLE
Add commentType to createComment and createThread methods

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -1495,7 +1495,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
-        const comment = await gitApi.createComment({ content }, repositoryId, pullRequestId, threadId, project);
+        const comment = await gitApi.createComment({ content, commentType: 1 }, repositoryId, pullRequestId, threadId, project);
 
         // Check if the comment was successfully created
         if (!comment) {
@@ -1657,7 +1657,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         }
 
         const thread = await gitApi.createThread(
-          { comments: [{ content: content }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
+          { comments: [{ content: content, commentType: 1 }], threadContext: threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
           repositoryId,
           pullRequestId,
           project

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -5431,7 +5431,7 @@ describe("repos tools", () => {
 
       const result = await handler(params);
 
-      expect(mockGitApi.createComment).toHaveBeenCalledWith({ content: "Reply content" }, "repo123", 456, 789, undefined);
+      expect(mockGitApi.createComment).toHaveBeenCalledWith({ content: "Reply content", commentType: 1 }, "repo123", 456, 789, undefined);
       expect(result.content[0].text).toBe("Comment successfully added to thread 789.");
     });
 
@@ -5502,7 +5502,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "New thread content" }],
+          comments: [{ content: "New thread content", commentType: 1 }],
           threadContext: { filePath: undefined },
           status: undefined, // Default status would be handled by CommentThreadStatus enum lookup
         },
@@ -5539,7 +5539,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "Thread with position" }],
+          comments: [{ content: "Thread with position", commentType: 1 }],
           threadContext: {
             filePath: "/src/test.ts",
             rightFileStart: { line: 10, offset: 5 },
@@ -5576,7 +5576,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "Thread with normalized path" }],
+          comments: [{ content: "Thread with normalized path", commentType: 1 }],
           threadContext: {
             filePath: "/src/file-without-slash.ts", // Should have leading slash added
           },
@@ -5611,7 +5611,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "Thread with existing slash" }],
+          comments: [{ content: "Thread with existing slash", commentType: 1 }],
           threadContext: {
             filePath: "/src/file-with-slash.ts", // Should remain unchanged
           },
@@ -7045,7 +7045,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "Test comment" }],
+          comments: [{ content: "Test comment", commentType: 1 }],
           threadContext: {
             filePath: "/test/file.js",
             rightFileStart: { line: 5, offset: 10 },
@@ -7086,7 +7086,7 @@ describe("repos tools", () => {
 
       expect(mockGitApi.createThread).toHaveBeenCalledWith(
         {
-          comments: [{ content: "Test comment" }],
+          comments: [{ content: "Test comment", commentType: 1 }],
           threadContext: {
             filePath: "/test/file.js",
             rightFileStart: { line: 5 },


### PR DESCRIPTION
This pull request updates the way comments are created in pull request threads by explicitly setting the `commentType` field to `1` when creating comments and threads. This ensures that comments are consistently recognized as standard comments by the API. Related tests have also been updated to verify the new behavior.

**API integration updates:**

* Added `commentType: 1` to the payload when creating comments with `gitApi.createComment` in `src/tools/repositories.ts`, ensuring the comment type is explicitly set.
* Added `commentType: 1` to each comment in the payload when creating threads with `gitApi.createThread` in `src/tools/repositories.ts`.

**Test updates:**

* Updated all relevant tests in `test/src/tools/repositories.test.ts` to expect `commentType: 1` in the payloads for both `createComment` and `createThread` calls, ensuring tests accurately reflect the new API usage. [[1]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL5434-R5434) [[2]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL5505-R5505) [[3]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL5542-R5542) [[4]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL5579-R5579) [[5]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL5614-R5614) [[6]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL7048-R7048) [[7]](diffhunk://#diff-ab08119c40bb674907f4cd70e8c549daaf3bcd559398b0f2eddb463bf8eb160aL7089-R7089)

## GitHub issue number
#1368

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

updated automated tests, all are passing