### PR TITLE
Fix: issue 1386 - inconsistent auth for certain tools in remote MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "azure-devops-extension-api": "^5.272.3",
         "azure-devops-extension-sdk": "^4.0.2",
         "azure-devops-node-api": "^15.1.2",
+        "undici": "^7.0.0",
         "winston": "^3.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.63",
@@ -8641,6 +8642,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "azure-devops-extension-api": "^5.272.3",
     "azure-devops-extension-sdk": "^4.0.2",
     "azure-devops-node-api": "^15.1.2",
+    "undici": "^7.0.0",
     "winston": "^3.18.3",
     "yargs": "^18.0.0",
     "zod": "^3.25.63",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { getBearerHandler, getPersonalAccessTokenHandler, WebApi } from "azure-devops-node-api";
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -80,6 +81,12 @@ function getAzureDevOpsClient(getAzureDevOpsToken: () => Promise<string>, userAg
 }
 
 async function main() {
+  const proxy = process.env.HTTPS_PROXY ?? process.env.https_proxy ?? process.env.HTTP_PROXY ?? process.env.http_proxy;
+  if (proxy) {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    logger.debug("Proxy environment detected: configured undici EnvHttpProxyAgent for all fetch() calls");
+  }
+
   logger.info("Starting Azure DevOps MCP Server", {
     organization: orgName,
     organizationUrl: orgUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { getBearerHandler, getPersonalAccessTokenHandler, WebApi } from "azure-devops-node-api";
-import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { createAuthenticator } from "./auth.js";
 import { logger } from "./logger.js";
 import { getOrgTenant } from "./org-tenants.js";
+import { configureProxyDispatcher } from "./proxy.js";
 //import { configurePrompts } from "./prompts.js";
 import { configureAllTools } from "./tools.js";
 import { UserAgentComposer } from "./useragent.js";
@@ -81,9 +81,7 @@ function getAzureDevOpsClient(getAzureDevOpsToken: () => Promise<string>, userAg
 }
 
 async function main() {
-  const proxy = process.env.HTTPS_PROXY ?? process.env.https_proxy ?? process.env.HTTP_PROXY ?? process.env.http_proxy;
-  if (proxy) {
-    setGlobalDispatcher(new EnvHttpProxyAgent());
+  if (configureProxyDispatcher()) {
     logger.debug("Proxy environment detected: configured undici EnvHttpProxyAgent for all fetch() calls");
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+
+/**
+ * Configure undici's global dispatcher with EnvHttpProxyAgent when an
+ * HTTP(S) proxy env var is set, so the built-in fetch() respects
+ * HTTPS_PROXY / HTTP_PROXY / NO_PROXY. Node 20's fetch ignores these by
+ * default — NODE_USE_ENV_PROXY=1 only landed in Node 22. Returns true if
+ * the dispatcher was installed, false if no proxy env var was set.
+ */
+export function configureProxyDispatcher(): boolean {
+  const proxy = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!proxy) {
+    return false;
+  }
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+  return true;
+}

--- a/test/src/proxy.test.ts
+++ b/test/src/proxy.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import { jest } from "@jest/globals";
+
+const mockSetGlobalDispatcher = jest.fn();
+const mockEnvHttpProxyAgent = jest.fn();
+
+jest.mock("undici", () => ({
+  setGlobalDispatcher: mockSetGlobalDispatcher,
+  EnvHttpProxyAgent: mockEnvHttpProxyAgent,
+}));
+
+import { configureProxyDispatcher } from "../../src/proxy";
+
+describe("configureProxyDispatcher", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    mockSetGlobalDispatcher.mockClear();
+    mockEnvHttpProxyAgent.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns false and does not install dispatcher when no proxy env var is set", () => {
+    expect(configureProxyDispatcher()).toBe(false);
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+    expect(mockEnvHttpProxyAgent).not.toHaveBeenCalled();
+  });
+
+  it("installs dispatcher when HTTPS_PROXY is set", () => {
+    process.env.HTTPS_PROXY = "http://proxy.corp:8080";
+
+    expect(configureProxyDispatcher()).toBe(true);
+    expect(mockEnvHttpProxyAgent).toHaveBeenCalledTimes(1);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs dispatcher when lowercase https_proxy is set", () => {
+    process.env.https_proxy = "http://proxy.corp:8080";
+
+    expect(configureProxyDispatcher()).toBe(true);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs dispatcher when HTTP_PROXY is set", () => {
+    process.env.HTTP_PROXY = "http://proxy.corp:8080";
+
+    expect(configureProxyDispatcher()).toBe(true);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("installs dispatcher when lowercase http_proxy is set", () => {
+    process.env.http_proxy = "http://proxy.corp:8080";
+
+    expect(configureProxyDispatcher()).toBe(true);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats an empty HTTPS_PROXY as unset and falls through to other vars", () => {
+    process.env.HTTPS_PROXY = "";
+    process.env.http_proxy = "http://proxy.corp:8080";
+
+    expect(configureProxyDispatcher()).toBe(true);
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when all proxy env vars are empty strings", () => {
+    process.env.HTTPS_PROXY = "";
+    process.env.https_proxy = "";
+    process.env.HTTP_PROXY = "";
+    process.env.http_proxy = "";
+
+    expect(configureProxyDispatcher()).toBe(false);
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
  Route fetch() requests through undici's `EnvHttpProxyAgent` when an HTTP(S)
  proxy env var is set, so that the four tools using raw `fetch()` for identity
  lookups (`core_get_identity_ids`, `repo_vote_pull_request`,
  `repo_update_pull_request`'s auto-complete path, and
  `repo_list_pull_requests_by_repo_or_project`'s user-filter paths) honor
  `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` on Node.js 20. Without this,
  those tools return HTTP 401 in environments where authentication is
  injected at the proxy layer (corporate proxies, cloud dev sandboxes,
  some CI/CD setups), while every other tool — which goes through
  `azure-devops-node-api`'s legacy `https` client — works correctly.

  The fix lives in a new `src/proxy.ts` and is invoked once at server
  startup from `main()`. It coexists with the existing PAT fetch interceptor.

  ## GitHub issue number

  Fixes #1386

  ## **Associated Risks**

  - **Adds `undici` as an explicit dependency.** Node.js 20+ already bundles
    undici internally to power `fetch()`, so there is no new transitive code
    on the wire — this just makes the import explicit at the project level.
  - **`setGlobalDispatcher` mutates global state.** It changes undici's
    internal dispatcher for the entire process. This is orthogonal to the
    PAT-mode `globalThis.fetch` interceptor (which operates one layer
    above) and the two compose cleanly, but anything else in the process
    that relies on undici's default no-proxy behavior would now route
    through the proxy. Nothing in this server does.
  - **Only triggers when a proxy env var is non-empty.** When `HTTPS_PROXY`,
    `https_proxy`, `HTTP_PROXY`, and `http_proxy` are all unset or empty,
    the dispatcher is not installed — behavior in non-proxy environments
    is unchanged.

  ## ✅ **PR Checklist**

  - [X] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
  - [X] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
  - [X] Title of the pull request is clear and informative.
  - [X] 👌 Code hygiene
  - [ ] 🔭 Telemetry added, updated, or N/A — **N/A** (no user-observable behavior change in non-proxy environments; no new code paths to instrument)
  - [ ] 📄 Documentation added, updated, or N/A — **N/A** (no public API change; proxy env vars are standard Node convention)
  - [X] 🛡️ Automated tests added, or N/A — 7 unit tests in `test/src/proxy.test.ts`, 100% coverage on `src/proxy.ts`

  ## 🧪 **How did you test it?**

  **Unit tests** (`npm test -- --testPathPatterns=proxy`):

  - No proxy env var set → dispatcher not installed
  - `HTTPS_PROXY` set → dispatcher installed
  - Lowercase `https_proxy` set → dispatcher installed
  - `HTTP_PROXY` set → dispatcher installed
  - Lowercase `http_proxy` set → dispatcher installed
  - `HTTPS_PROXY=""` falls through to `http_proxy` correctly
  - All proxy env vars empty → dispatcher not installed

  All 7 tests pass; 100% statement/branch/function/line coverage on
  `src/proxy.ts`. The existing 22 auth tests still pass — the change does
  not alter `src/tools/auth.ts` itself.

  **Manual verification** of the proxy code path was not performed in this
  PR because reproducing the proxy-injection setup requires a corporate
  proxy environment with auth substitution. The fix is the minimal undici
  configuration recommended by [Node.js's proxy docs for v20](https://nodejs.org/api/cli.html#node_use_env_proxy1).

  Two small marks I left unchecked because they're judgment calls for the maintainers:

  - Telemetry and Documentation — both N/A in my view, but the boxes are unchecked because the template treats them as affirmative actions. Maintainers may want you to tick them with the "N/A" justification I wrote inline.