### PR TITLE
feat: add Markdown formatting support for step content in test plans

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -467,14 +467,14 @@ Gets a list of test cases in the test plan.
 
 ### mcp_ado_testplan_create_test_case
 
-Creates a new test case work item.
+Creates a new test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
 
 - **Required**: `project`, `title`
 - **Optional**: `areaPath`, `iterationPath`, `priority`, `steps`, `testsWorkItemId`
 
 ### mcp_ado_testplan_update_test_case_steps
 
-Update an existing test case work item.
+Update the steps of an existing test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
 
 - **Required**: `id`, `steps`
 - **Optional**: None

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -584,6 +584,23 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
 }
 
 /*
+ * Format step content by converting Markdown markers to HTML and wrapping in the ADO rich text
+ * envelope. The entire HTML string is then XML-escaped for storage in the parameterizedString
+ * element, which is the format Azure DevOps expects for rendered step content.
+ */
+function formatStepContent(text: string): string {
+  // Convert Markdown markers to HTML tags (** before * to avoid conflicts)
+  const htmlContent = text
+    .replace(/\*\*(.+?)\*\*/g, "<B>$1</B>")
+    .replace(/\*(.+?)\*/g, "<I>$1</I>")
+    .replace(/`(.+?)`/g, "<CODE>$1</CODE>")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<A href="$2">$1</A>');
+
+  // Wrap in ADO rich text envelope and XML-escape the entire HTML string
+  return escapeXml(`<DIV><P>${htmlContent}</P></DIV>`);
+}
+
+/*
  * Helper function to convert steps text to XML format required
  */
 function convertStepsToXml(steps: string): string {
@@ -603,8 +620,8 @@ function convertStepsToXml(steps: string): string {
 
       xmlSteps += `
                 <step id="${i + 1}" type="ActionStep">
-                    <parameterizedString isformatted="true">${escapeXml(stepText)}</parameterizedString>
-                    <parameterizedString isformatted="true">${escapeXml(expectedText)}</parameterizedString>
+                    <parameterizedString isformatted="true">${formatStepContent(stepText)}</parameterizedString>
+                    <parameterizedString isformatted="true">${formatStepContent(expectedText)}</parameterizedString>
                 </step>`;
     }
   }

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -589,15 +589,16 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
  * element, which is the format Azure DevOps expects for rendered step content.
  */
 function formatStepContent(text: string): string {
-  // Convert Markdown markers to HTML tags (** before * to avoid conflicts)
+  // Convert Markdown markers to HTML tags (** before * and __ before _ to avoid conflicts)
   const htmlContent = text
     .replace(/\*\*(.+?)\*\*/g, "<B>$1</B>")
     .replace(/\*(.+?)\*/g, "<I>$1</I>")
+    .replace(/__(.+?)__/g, "<U>$1</U>")
     .replace(/`(.+?)`/g, "<CODE>$1</CODE>")
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<A href="$2">$1</A>');
 
   // Wrap in ADO rich text envelope and XML-escape the entire HTML string
-  return escapeXml(`<DIV><P>${htmlContent}</P></DIV>`);
+  return escapeXml(`${htmlContent}`);
 }
 
 /*

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -2193,6 +2193,153 @@ describe("configureTestPlanTools", () => {
       expect(result.content[0].text).toContain("API Error");
     });
 
+    it("should store HTML tags as XML-escaped formatting in step content", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
+      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200001, rev: 2, fields: {} });
+
+      const params = {
+        id: 200001,
+        steps: "1. Click <b>Save</b> button|Button <i>highlights</i> and form submits",
+      };
+      const result = await handler(params);
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        {},
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;b&gt;Save&lt;/b&gt;"),
+          }),
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;i&gt;highlights&lt;/i&gt;"),
+          }),
+        ]),
+        200001
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should convert Markdown bold and italic to XML-escaped HTML", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
+      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200002, rev: 2, fields: {} });
+
+      const params = {
+        id: 200002,
+        steps: "1. Press **Submit**|Result shows *success* message",
+      };
+      const result = await handler(params);
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        {},
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;B&gt;Submit&lt;/B&gt;"),
+          }),
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;I&gt;success&lt;/I&gt;"),
+          }),
+        ]),
+        200002
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should convert Markdown inline code to XML-escaped HTML code tags", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
+      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200003, rev: 2, fields: {} });
+
+      const params = {
+        id: 200003,
+        steps: "1. Run `npm install`|Command exits with code `0`",
+      };
+      const result = await handler(params);
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        {},
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;CODE&gt;npm install&lt;/CODE&gt;"),
+          }),
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;CODE&gt;0&lt;/CODE&gt;"),
+          }),
+        ]),
+        200003
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should escape non-whitelisted HTML tags", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
+      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200004, rev: 2, fields: {} });
+
+      const params = {
+        id: 200004,
+        steps: "1. Inject <script>alert(1)</script>|Should be escaped",
+      };
+      const result = await handler(params);
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        {},
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;script&gt;alert(1)&lt;/script&gt;"),
+          }),
+        ]),
+        200004
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should convert Markdown links to XML-escaped anchor tags", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
+      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200005, rev: 2, fields: {} });
+
+      const params = {
+        id: 200005,
+        steps: "1. Open [Azure Portal](https://portal.azure.com)|Portal loads",
+      };
+      const result = await handler(params);
+
+      expect(mockWitApi.updateWorkItem).toHaveBeenCalledWith(
+        {},
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "/fields/Microsoft.VSTS.TCM.Steps",
+            value: expect.stringContaining("&lt;A href=&quot;https://portal.azure.com&quot;&gt;Azure Portal&lt;/A&gt;"),
+          }),
+        ]),
+        200005
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
     it("should handle mixed numbered and non-numbered steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");


### PR DESCRIPTION
This pull request enhances the formatting of test case steps in Azure DevOps by supporting Markdown-to-HTML conversion and ensuring proper XML-escaping for safe storage. It introduces a new helper function to handle the formatting and updates both the implementation and tests to verify correct behavior for various Markdown features and HTML escaping.

**Formatting and Conversion Enhancements:**

- Added `formatStepContent` function in `src/tools/test-plans.ts` to convert Markdown markers (bold, italic, inline code, and links) to corresponding HTML tags, wrap the result in the ADO rich text envelope, and XML-escape the final string for storage.
- Updated `convertStepsToXml` to use `formatStepContent` for both step and expected result content, ensuring all step content is consistently formatted and escaped.

**Testing Improvements:**

- Added comprehensive tests in `test/src/tools/test-plan.test.ts` to verify that:
  - HTML tags in step content are properly XML-escaped.
  - Markdown bold and italic are converted to XML-escaped HTML.
  - Markdown inline code is converted to XML-escaped `<CODE>` tags.
  - Non-whitelisted HTML tags (e.g., `<script>`) are escaped and not rendered.
  - Markdown links are converted to XML-escaped anchor tags.

## GitHub issue number
#1399 1398

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Updated tests and tested manually with success
