### PR TITLE
fix: update HTML tags to lowercase in formatStepContent function

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -591,11 +591,11 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
 function formatStepContent(text: string): string {
   // Convert Markdown markers to HTML tags (** before * and __ before _ to avoid conflicts)
   const htmlContent = text
-    .replace(/\*\*(.+?)\*\*/g, "<B>$1</B>")
-    .replace(/\*(.+?)\*/g, "<I>$1</I>")
-    .replace(/__(.+?)__/g, "<U>$1</U>")
-    .replace(/`(.+?)`/g, "<CODE>$1</CODE>")
-    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<A href="$2">$1</A>');
+    .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
+    .replace(/\*(.+?)\*/g, "<i>$1</i>")
+    .replace(/__(.+?)__/g, "<u>$1</u>")
+    .replace(/`(.+?)`/g, "<code>$1</code>")
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2">$1</a>');
 
   // Wrap in ADO rich text envelope and XML-escape the entire HTML string
   return escapeXml(`${htmlContent}`);

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -2243,11 +2243,11 @@ describe("configureTestPlanTools", () => {
         expect.arrayContaining([
           expect.objectContaining({
             path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: expect.stringContaining("&lt;B&gt;Submit&lt;/B&gt;"),
+            value: expect.stringContaining("&lt;b&gt;Submit&lt;/b&gt;"),
           }),
           expect.objectContaining({
             path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: expect.stringContaining("&lt;I&gt;success&lt;/I&gt;"),
+            value: expect.stringContaining("&lt;i&gt;success&lt;/i&gt;"),
           }),
         ]),
         200002
@@ -2274,11 +2274,11 @@ describe("configureTestPlanTools", () => {
         expect.arrayContaining([
           expect.objectContaining({
             path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: expect.stringContaining("&lt;CODE&gt;npm install&lt;/CODE&gt;"),
+            value: expect.stringContaining("&lt;code&gt;npm install&lt;/code&gt;"),
           }),
           expect.objectContaining({
             path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: expect.stringContaining("&lt;CODE&gt;0&lt;/CODE&gt;"),
+            value: expect.stringContaining("&lt;code&gt;0&lt;/code&gt;"),
           }),
         ]),
         200003
@@ -2332,7 +2332,7 @@ describe("configureTestPlanTools", () => {
         expect.arrayContaining([
           expect.objectContaining({
             path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: expect.stringContaining("&lt;A href=&quot;https://portal.azure.com&quot;&gt;Azure Portal&lt;/A&gt;"),
+            value: expect.stringContaining("&lt;a href=&quot;https://portal.azure.com&quot;&gt;Azure Portal&lt;/a&gt;"),
           }),
         ]),
         200005


### PR DESCRIPTION
This pull request updates the `formatStepContent` function in `src/tools/test-plans.ts` to improve the HTML output generated from Markdown content. The main change is to use standard lowercase HTML tags instead of uppercase tags for formatting, ensuring better compatibility and adherence to HTML standards.

Formatting improvements:

* Changed the Markdown-to-HTML conversion to use lowercase tags (`<b>`, `<i>`, `<u>`, `<code>`, `<a>`) instead of uppercase tags (`<B>`, `<I>`, `<U>`, `<CODE>`, `<A>`), which aligns with HTML best practices and improves rendering consistency.

## GitHub issue number
N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual testing
