### PR TITLE
Enhance Wiki link support with additional attributes and validation

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -69,6 +69,15 @@ function getLinkTypeFromName(name: string) {
   }
 }
 
+function getArtifactLinkAttributeName(linkType: string): string {
+  switch (linkType) {
+    case "Wiki":
+      return "Wiki Page";
+    default:
+      return linkType;
+  }
+}
+
 function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     WORKITEM_TOOLS.list_backlogs,
@@ -1297,6 +1306,20 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       commitId: z.string().optional().describe("The commit SHA hash. Required when linkType is 'Fixed in Commit'."),
       pullRequestId: z.coerce.number().min(1).optional().describe("The pull request ID. Required when linkType is 'Pull Request'."),
       buildId: z.coerce.number().min(1).optional().describe("The build ID. Required when linkType is 'Build', 'Found in build', or 'Integrated in build'."),
+      wikiId: z.string().optional().describe("The wiki ID (GUID). Required when linkType is 'Wiki'."),
+      pageId: z.coerce
+        .number()
+        .min(1)
+        .optional()
+        .describe(
+          "The numeric wiki page ID from the browser URL (e.g., '98' in '.../wikis/Contoso.wiki/98/What-is-Contoso'). When provided for 'Wiki' links, the full page path is resolved automatically via the API. Takes precedence over 'pagePath'."
+        ),
+      pagePath: z
+        .string()
+        .optional()
+        .describe(
+          "The full wiki page path from the wiki root (e.g., '/Home/What-is-Contoso'). Required when linkType is 'Wiki' and 'pageId' is not provided. Must be the complete path, not just the page name from the URL."
+        ),
 
       linkType: z
         .enum([
@@ -1319,7 +1342,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .describe("Type of artifact link, defaults to 'Branch'. This determines both the link type and how to build the VSTFS URI from individual components."),
       comment: z.string().optional().describe("Comment to include with the artifact link."),
     },
-    async ({ workItemId, project, artifactUri, projectId, repositoryId, branchName, commitId, pullRequestId, buildId, linkType, comment }) => {
+    async ({ workItemId, project, artifactUri, projectId, repositoryId, branchName, commitId, pullRequestId, buildId, wikiId, pageId, pagePath, linkType, comment }) => {
       try {
         const connection = await connectionProvider();
 
@@ -1382,6 +1405,50 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               finalArtifactUri = `vstfs:///Build/Build/${encodeURIComponent(buildId.toString())}`;
               break;
 
+            case "Wiki": {
+              if (!projectId || !wikiId) {
+                return {
+                  content: [{ type: "text", text: "For 'Wiki' links, 'projectId', 'wikiId', and 'pagePath' are required." }],
+                  isError: true,
+                };
+              }
+
+              let resolvedPagePath = pagePath;
+
+              if (pageId !== undefined) {
+                // Look up the actual page path by page ID to get the full path
+                const orgUrl = connection.serverUrl;
+                const accessToken = await tokenProvider();
+                const pageResponse = await fetch(`${orgUrl}/${encodeURIComponent(resolvedProject)}/_apis/wiki/wikis/${encodeURIComponent(wikiId)}/pages/${pageId}?api-version=7.1`, {
+                  headers: {
+                    "Authorization": `Bearer ${accessToken}`,
+                    "User-Agent": userAgentProvider(),
+                  },
+                });
+                if (!pageResponse.ok) {
+                  return {
+                    content: [{ type: "text", text: `Failed to look up wiki page ID ${pageId}: ${pageResponse.statusText}` }],
+                    isError: true,
+                  };
+                }
+                const pageData = await pageResponse.json();
+                resolvedPagePath = pageData.path as string;
+              }
+
+              if (!resolvedPagePath) {
+                return {
+                  content: [{ type: "text", text: "For 'Wiki' links, 'pageId' or 'pagePath' is required." }],
+                  isError: true,
+                };
+              }
+
+              // Strip leading slash, then encode each segment joined by %2F
+              const normalizedPath = resolvedPagePath.startsWith("/") ? resolvedPagePath.slice(1) : resolvedPagePath;
+              const encodedPath = normalizedPath.split("/").map(encodeURIComponent).join("%2F");
+              finalArtifactUri = `vstfs:///Wiki/WikiPage/${encodeURIComponent(projectId)}%2F${encodeURIComponent(wikiId)}%2F${encodedPath}`;
+              break;
+            }
+
             default:
               return {
                 content: [{ type: "text", text: `URI building from components is not supported for link type '${linkType}'. Please provide the full 'artifactUri' instead.` }],
@@ -1399,7 +1466,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               rel: "ArtifactLink",
               url: finalArtifactUri,
               attributes: {
-                name: linkType,
+                name: getArtifactLinkAttributeName(linkType),
                 ...(comment && { comment }),
               },
             },

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3758,6 +3758,116 @@ describe("configureWorkItemTools", () => {
         expect(result.content[0].text).toBe("For 'Build' links, 'buildId' is required.");
       });
 
+      it("should build Wiki URI from components and use 'Wiki Page' as attribute name", async () => {
+        configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+        if (!call) throw new Error("wit_add_artifact_link tool not registered");
+        const [, , , handler] = call;
+
+        const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
+        mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
+
+        const params = {
+          workItemId: 1234,
+          project: "TestProject",
+          linkType: "Wiki",
+          projectId: "project-guid",
+          wikiId: "wiki-guid",
+          pagePath: "/Home/What-is-Contoso",
+        };
+
+        const result = await handler(params);
+
+        expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
+          {},
+          [
+            {
+              op: "add",
+              path: "/relations/-",
+              value: {
+                rel: "ArtifactLink",
+                url: "vstfs:///Wiki/WikiPage/project-guid%2Fwiki-guid%2FHome%2FWhat-is-Contoso",
+                attributes: {
+                  name: "Wiki Page",
+                },
+              },
+            },
+          ],
+          1234,
+          "TestProject"
+        );
+
+        const response = JSON.parse(result.content[0].text);
+        expect(response.success).toBe(true);
+        expect(response.linkType).toBe("Wiki");
+      });
+
+      it("should build Wiki URI from components when pagePath has no leading slash", async () => {
+        configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+        if (!call) throw new Error("wit_add_artifact_link tool not registered");
+        const [, , , handler] = call;
+
+        const mockWorkItem = { id: 1234, fields: { "System.Title": "Test Item" } };
+        mockWorkItemTrackingApi.updateWorkItem.mockResolvedValue(mockWorkItem);
+
+        const params = {
+          workItemId: 1234,
+          project: "TestProject",
+          linkType: "Wiki",
+          projectId: "project-guid",
+          wikiId: "wiki-guid",
+          pagePath: "Home/What-is-Contoso",
+        };
+
+        const result = await handler(params);
+
+        expect(mockWorkItemTrackingApi.updateWorkItem).toHaveBeenCalledWith(
+          {},
+          [
+            {
+              op: "add",
+              path: "/relations/-",
+              value: {
+                rel: "ArtifactLink",
+                url: "vstfs:///Wiki/WikiPage/project-guid%2Fwiki-guid%2FHome%2FWhat-is-Contoso",
+                attributes: {
+                  name: "Wiki Page",
+                },
+              },
+            },
+          ],
+          1234,
+          "TestProject"
+        );
+
+        const response = JSON.parse(result.content[0].text);
+        expect(response.success).toBe(true);
+      });
+
+      it("should return error for Wiki link missing required parameters", async () => {
+        configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+        const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_add_artifact_link");
+        if (!call) throw new Error("wit_add_artifact_link tool not registered");
+        const [, , , handler] = call;
+
+        const params = {
+          workItemId: 1234,
+          project: "TestProject",
+          linkType: "Wiki",
+          projectId: "project-guid",
+          // Missing wikiId and pagePath
+        };
+
+        const result = await handler(params);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toBe("For 'Wiki' links, 'projectId', 'wikiId', and 'pagePath' are required.");
+      });
+
       it("should return error for unsupported link type in URI building", async () => {
         configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
 


### PR DESCRIPTION
This pull request adds support for linking Azure DevOps work items to Wiki pages via artifact links. It introduces new parameters for specifying Wiki page information, handles URI construction for Wiki links, and updates tests to cover these scenarios.

**Wiki link support:**

* Added new parameters (`wikiId`, `pageId`, `pagePath`) to the `wit_add_artifact_link` tool for specifying Wiki page information. The handler now resolves the full Wiki page path from either `pageId` (via API lookup) or `pagePath`, and constructs the correct `vstfs` URI for Wiki pages. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R1309-R1322) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R1408-R1451)
* Introduced the helper function `getArtifactLinkAttributeName` to ensure the attribute name for Wiki links is set to `"Wiki Page"` instead of just `"Wiki"`. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R72-R80) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L1402-R1469)

**Validation and error handling:**

* Added validation to require `projectId`, `wikiId`, and either `pagePath` or `pageId` for Wiki links, with clear error messages if any are missing.

**Testing:**

* Added and updated tests in `work-items.test.ts` to verify Wiki link creation, including correct URI encoding, attribute naming, and error handling for missing parameters.

## GitHub issue number
#1412

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manually tested and updated auto tests
