### PR TITLE
Refactor code structure for better readability and maintainability

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -1,309 +1,357 @@
 # Toolset
 
+This page lists all available tools provided by the local Azure DevOps MCP server. Use it as a reference to understand what each tool does, what parameters it requires, and how tools are organized by functional area.
+
 ## Overview
 
-| Functional Area   | Tool                                                                                                      | Description                                                       |
-| ----------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Advanced Security | [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)                                                   | Retrieve Advanced Security alerts for a repository                |
-| Advanced Security | [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details)                                     | Get detailed information about a specific security alert          |
-| Core              | [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)                                                 | List all projects in the organization                             |
-| Core              | [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams)                                       | List teams within a project                                       |
-| Core              | [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)                                           | Retrieve identity IDs by search filter                            |
-| Pipelines         | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                                   | Create a new pipeline with YAML configuration                     |
-| Pipelines         | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                             | Retrieve a list of builds with optional filters                   |
-| Pipelines         | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                                 | Get the status of a specific build                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                       | Retrieve complete logs for a build                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                           | Get a specific build log by log ID                                |
-| Pipelines         | [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                               | Get changes (commits) associated with a build                     |
-| Pipelines         | [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                       | List build/pipeline definitions in a project                      |
-| Pipelines         | [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions)     | Get revision history of a build definition                        |
-| Pipelines         | [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                         | Start a new pipeline run with optional parameters                 |
-| Pipelines         | [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                                   | Get details of a specific pipeline run                            |
-| Pipelines         | [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                               | List recent runs for a pipeline                                   |
-| Pipelines         | [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                             | Update a build stage (cancel, retry, or run)                      |
-| Repositories      | [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                 | List all repositories in a project                                |
-| Repositories      | [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                               | Get repository details by name or ID                              |
-| Repositories      | [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                 | List all branches in a repository                                 |
-| Repositories      | [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                           | List branches created by current user                             |
-| Repositories      | [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                       | Get details of a specific branch                                  |
-| Repositories      | [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                 | Create a new branch from a source branch                          |
-| Repositories      | [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                               | Search for commits with comprehensive filters                     |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project) | List pull requests with optional filters                          |
-| Repositories      | [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                 | Find pull requests containing specific commits                    |
-| Repositories      | [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                               | Get details of a specific pull request                            |
-| Repositories      | [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                           | Get file changes (diff) for a pull request                        |
-| Repositories      | [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                     | Create a new pull request                                         |
-| Repositories      | [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                     | Update pull request properties and settings                       |
-| Repositories      | [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                 | Add or remove reviewers from a pull request                       |
-| Repositories      | [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                         | Cast a vote on a pull request                                     |
-| Repositories      | [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                         | List comment threads on a pull request                            |
-| Repositories      | [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)         | List comments in a specific thread                                |
-| Repositories      | [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request                     |
-| Repositories      | [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread                    |
-| Repositories      | [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                                   |
-| Repositories      | [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory                             |
-| Repositories      | [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version                            |
-| Search            | [mcp_ado_search_code](#mcp_ado_search_code)                                                               | Search for code across repositories                               |
-| Search            | [mcp_ado_search_wiki](#mcp_ado_search_wiki)                                                               | Search wiki pages by keywords                                     |
-| Search            | [mcp_ado_search_workitem](#mcp_ado_search_workitem)                                                       | Search work items by text and filters                             |
-| Test Plans        | [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                     | List test plans in a project                                      |
-| Test Plans        | [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                                   | Create a new test plan                                            |
-| Test Plans        | [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                                   | List test suites in a test plan                                   |
-| Test Plans        | [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                                 | Create a test suite within a test plan                            |
-| Test Plans        | [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                     | Add test cases to a test suite                                    |
-| Test Plans        | [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                     | List test cases in a test suite                                   |
-| Test Plans        | [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                                   | Create a new test case work item                                  |
-| Test Plans        | [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                       | Update steps of an existing test case                             |
-| Test Plans        | [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id)     | Get test results for a specific build                             |
-| Wiki              | [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                                                       | List wikis in organization or project                             |
-| Wiki              | [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                                                           | Get details of a specific wiki                                    |
-| Wiki              | [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                                                       | List pages in a wiki                                              |
-| Wiki              | [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                                                           | Get wiki page metadata (without content)                          |
-| Wiki              | [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)                                           | Retrieve wiki page content                                        |
-| Wiki              | [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page)                                 | Create or update a wiki page                                      |
-| Work Items        | [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                                   | Get a work item by ID                                             |
-| Work Items        | [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)                       | Retrieve multiple work items by IDs                               |
-| Work Items        | [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                                             | Create a new work item                                            |
-| Work Items        | [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                                             | Update fields of a work item                                      |
-| Work Items        | [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)                               | Update multiple work items in batch                               |
-| Work Items        | [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                                     | Create child work items under a parent                            |
-| Work Items        | [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                                               | Link work items together                                          |
-| Work Items        | [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                                             | Remove links from a work item                                     |
-| Work Items        | [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                                           | Link artifacts (commits, builds, PRs) to work items               |
-| Work Items        | [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request)                 | Link a work item to a pull request                                |
-| Work Items        | [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)                               | List comments on a work item                                      |
-| Work Items        | [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                                   | Add a comment to a work item                                      |
-| Work Items        | [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)                             | Update an existing comment on a work item                         |
-| Work Items        | [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)                             | Get revision history of a work item                               |
-| Work Items        | [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                                         | Get details of a work item type                                   |
-| Work Items        | [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                                   | List work items relevant to current user                          |
-| Work Items        | [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)                     | Get work items in a specific iteration                            |
-| Work Items        | [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                                   | List backlogs for a team                                          |
-| Work Items        | [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)                               | Get work items in a backlog                                       |
-| Work Items        | [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                                           | Get a work item query by ID or path                               |
-| Work Items        | [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)                               | Execute a query and get results                                   |
-| Work Items        | [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                                   | Execute a WIQL query and return matching work items               |
-| Work Items        | [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)                             | Download a work item attachment; save locally or return as base64 |
-| Work              | [mcp_ado_work_list_iterations](#mcp_ado_work_list_iterations)                                             | List all iterations in a project                                  |
-| Work              | [mcp_ado_work_create_iterations](#mcp_ado_work_create_iterations)                                         | Create new iterations in a project                                |
-| Work              | [mcp_ado_work_list_team_iterations](#mcp_ado_work_list_team_iterations)                                   | List iterations assigned to a team                                |
-| Work              | [mcp_ado_work_assign_iterations](#mcp_ado_work_assign_iterations)                                         | Assign iterations to a team                                       |
-| Work              | [mcp_ado_work_get_iteration_capacities](#mcp_ado_work_get_iteration_capacities)                           | Get capacity for all teams in an iteration                        |
-| Work              | [mcp_ado_work_get_team_capacity](#mcp_ado_work_get_team_capacity)                                         | Get capacity for a specific team in iteration                     |
-| Work              | [mcp_ado_work_update_team_capacity](#mcp_ado_work_update_team_capacity)                                   | Update team member capacity for iteration                         |
-| Work              | [mcp_ado_work_get_team_settings](#mcp_ado_work_get_team_settings)                                         | Get team settings including default iteration and area            |
+### Advanced Security
 
-## Advanced Security
+| Tool                                                                  | Description                                              |
+| --------------------------------------------------------------------- | -------------------------------------------------------- |
+| [mcp_ado_advsec_get_alerts](#mcp_ado_advsec_get_alerts)               | Retrieve Advanced Security alerts for a repository       |
+| [mcp_ado_advsec_get_alert_details](#mcp_ado_advsec_get_alert_details) | Get detailed information about a specific security alert |
 
-### mcp_ado_advsec_get_alerts
+### Core
+
+| Tool                                                                | Description                            |
+| ------------------------------------------------------------------- | -------------------------------------- |
+| [mcp_ado_core_list_projects](#mcp_ado_core_list_projects)           | List all projects in the organization  |
+| [mcp_ado_core_list_project_teams](#mcp_ado_core_list_project_teams) | List teams within a project            |
+| [mcp_ado_core_get_identity_ids](#mcp_ado_core_get_identity_ids)     | Retrieve identity IDs by search filter |
+
+### Pipelines
+
+| Tool                                                                                                  | Description                                       |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                               | Create a new pipeline with YAML configuration     |
+| [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                         | Retrieve a list of builds with optional filters   |
+| [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                             | Get the status of a specific build                |
+| [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                   | Retrieve complete logs for a build                |
+| [mcp_ado_pipelines_get_build_log_by_id](#mcp_ado_pipelines_get_build_log_by_id)                       | Get a specific build log by log ID                |
+| [mcp_ado_pipelines_get_build_changes](#mcp_ado_pipelines_get_build_changes)                           | Get changes (commits) associated with a build     |
+| [mcp_ado_pipelines_get_build_definitions](#mcp_ado_pipelines_get_build_definitions)                   | List build/pipeline definitions in a project      |
+| [mcp_ado_pipelines_get_build_definition_revisions](#mcp_ado_pipelines_get_build_definition_revisions) | Get revision history of a build definition        |
+| [mcp_ado_pipelines_run_pipeline](#mcp_ado_pipelines_run_pipeline)                                     | Start a new pipeline run with optional parameters |
+| [mcp_ado_pipelines_get_run](#mcp_ado_pipelines_get_run)                                               | Get details of a specific pipeline run            |
+| [mcp_ado_pipelines_list_runs](#mcp_ado_pipelines_list_runs)                                           | List recent runs for a pipeline                   |
+| [mcp_ado_pipelines_update_build_stage](#mcp_ado_pipelines_update_build_stage)                         | Update a build stage (cancel, retry, or run)      |
+
+### Repositories
+
+| Tool                                                                                                      | Description                                    |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| [mcp_ado_repo_list_repos_by_project](#mcp_ado_repo_list_repos_by_project)                                 | List all repositories in a project             |
+| [mcp_ado_repo_get_repo_by_name_or_id](#mcp_ado_repo_get_repo_by_name_or_id)                               | Get repository details by name or ID           |
+| [mcp_ado_repo_list_branches_by_repo](#mcp_ado_repo_list_branches_by_repo)                                 | List all branches in a repository              |
+| [mcp_ado_repo_list_my_branches_by_repo](#mcp_ado_repo_list_my_branches_by_repo)                           | List branches created by current user          |
+| [mcp_ado_repo_get_branch_by_name](#mcp_ado_repo_get_branch_by_name)                                       | Get details of a specific branch               |
+| [mcp_ado_repo_create_branch](#mcp_ado_repo_create_branch)                                                 | Create a new branch from a source branch       |
+| [mcp_ado_repo_search_commits](#mcp_ado_repo_search_commits)                                               | Search for commits with comprehensive filters  |
+| [mcp_ado_repo_list_pull_requests_by_repo_or_project](#mcp_ado_repo_list_pull_requests_by_repo_or_project) | List pull requests with optional filters       |
+| [mcp_ado_repo_list_pull_requests_by_commits](#mcp_ado_repo_list_pull_requests_by_commits)                 | Find pull requests containing specific commits |
+| [mcp_ado_repo_get_pull_request_by_id](#mcp_ado_repo_get_pull_request_by_id)                               | Get details of a specific pull request         |
+| [mcp_ado_repo_get_pull_request_changes](#mcp_ado_repo_get_pull_request_changes)                           | Get file changes (diff) for a pull request     |
+| [mcp_ado_repo_create_pull_request](#mcp_ado_repo_create_pull_request)                                     | Create a new pull request                      |
+| [mcp_ado_repo_update_pull_request](#mcp_ado_repo_update_pull_request)                                     | Update pull request properties and settings    |
+| [mcp_ado_repo_update_pull_request_reviewers](#mcp_ado_repo_update_pull_request_reviewers)                 | Add or remove reviewers from a pull request    |
+| [mcp_ado_repo_vote_pull_request](#mcp_ado_repo_vote_pull_request)                                         | Cast a vote on a pull request                  |
+| [mcp_ado_repo_list_pull_request_threads](#mcp_ado_repo_list_pull_request_threads)                         | List comment threads on a pull request         |
+| [mcp_ado_repo_list_pull_request_thread_comments](#mcp_ado_repo_list_pull_request_thread_comments)         | List comments in a specific thread             |
+| [mcp_ado_repo_create_pull_request_thread](#mcp_ado_repo_create_pull_request_thread)                       | Create a new comment thread on a pull request  |
+| [mcp_ado_repo_update_pull_request_thread](#mcp_ado_repo_update_pull_request_thread)                       | Update an existing pull request comment thread |
+| [mcp_ado_repo_reply_to_comment](#mcp_ado_repo_reply_to_comment)                                           | Reply to a pull request comment                |
+| [mcp_ado_repo_list_directory](#mcp_ado_repo_list_directory)                                               | List files and folders in a directory          |
+| [mcp_ado_repo_get_file_content](#mcp_ado_repo_get_file_content)                                           | Get file content at a specific version         |
+
+### Search
+
+| Tool                                                | Description                           |
+| --------------------------------------------------- | ------------------------------------- |
+| [mcp_ado_search_code](#mcp_ado_search_code)         | Search for code across repositories   |
+| [mcp_ado_search_wiki](#mcp_ado_search_wiki)         | Search wiki pages by keywords         |
+| [mcp_ado_search_workitem](#mcp_ado_search_workitem) | Search work items by text and filters |
+
+### Test Plans
+
+| Tool                                                                                                  | Description                            |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                 | List test plans in a project           |
+| [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                               | Create a new test plan                 |
+| [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                               | List test suites in a test plan        |
+| [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                             | Create a test suite within a test plan |
+| [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                 | Add test cases to a test suite         |
+| [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                 | List test cases in a test suite        |
+| [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                               | Create a new test case work item       |
+| [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                   | Update steps of an existing test case  |
+| [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id) | Get test results for a specific build  |
+
+### Wiki
+
+| Tool                                                                      | Description                              |
+| ------------------------------------------------------------------------- | ---------------------------------------- |
+| [mcp_ado_wiki_list_wikis](#mcp_ado_wiki_list_wikis)                       | List wikis in organization or project    |
+| [mcp_ado_wiki_get_wiki](#mcp_ado_wiki_get_wiki)                           | Get details of a specific wiki           |
+| [mcp_ado_wiki_list_pages](#mcp_ado_wiki_list_pages)                       | List pages in a wiki                     |
+| [mcp_ado_wiki_get_page](#mcp_ado_wiki_get_page)                           | Get wiki page metadata (without content) |
+| [mcp_ado_wiki_get_page_content](#mcp_ado_wiki_get_page_content)           | Retrieve wiki page content               |
+| [mcp_ado_wiki_create_or_update_page](#mcp_ado_wiki_create_or_update_page) | Create or update a wiki page             |
+
+### Work Items
+
+| Tool                                                                                      | Description                                                       |
+| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [mcp_ado_wit_get_work_item](#mcp_ado_wit_get_work_item)                                   | Get a work item by ID                                             |
+| [mcp_ado_wit_get_work_items_batch_by_ids](#mcp_ado_wit_get_work_items_batch_by_ids)       | Retrieve multiple work items by IDs                               |
+| [mcp_ado_wit_create_work_item](#mcp_ado_wit_create_work_item)                             | Create a new work item                                            |
+| [mcp_ado_wit_update_work_item](#mcp_ado_wit_update_work_item)                             | Update fields of a work item                                      |
+| [mcp_ado_wit_update_work_items_batch](#mcp_ado_wit_update_work_items_batch)               | Update multiple work items in batch                               |
+| [mcp_ado_wit_add_child_work_items](#mcp_ado_wit_add_child_work_items)                     | Create child work items under a parent                            |
+| [mcp_ado_wit_work_items_link](#mcp_ado_wit_work_items_link)                               | Link work items together                                          |
+| [mcp_ado_wit_work_item_unlink](#mcp_ado_wit_work_item_unlink)                             | Remove links from a work item                                     |
+| [mcp_ado_wit_add_artifact_link](#mcp_ado_wit_add_artifact_link)                           | Link artifacts (commits, builds, PRs) to work items               |
+| [mcp_ado_wit_link_work_item_to_pull_request](#mcp_ado_wit_link_work_item_to_pull_request) | Link a work item to a pull request                                |
+| [mcp_ado_wit_list_work_item_comments](#mcp_ado_wit_list_work_item_comments)               | List comments on a work item                                      |
+| [mcp_ado_wit_add_work_item_comment](#mcp_ado_wit_add_work_item_comment)                   | Add a comment to a work item                                      |
+| [mcp_ado_wit_update_work_item_comment](#mcp_ado_wit_update_work_item_comment)             | Update an existing comment on a work item                         |
+| [mcp_ado_wit_list_work_item_revisions](#mcp_ado_wit_list_work_item_revisions)             | Get revision history of a work item                               |
+| [mcp_ado_wit_get_work_item_type](#mcp_ado_wit_get_work_item_type)                         | Get details of a work item type                                   |
+| [mcp_ado_wit_my_work_items](#mcp_ado_wit_my_work_items)                                   | List work items relevant to current user                          |
+| [mcp_ado_wit_get_work_items_for_iteration](#mcp_ado_wit_get_work_items_for_iteration)     | Get work items in a specific iteration                            |
+| [mcp_ado_wit_list_backlogs](#mcp_ado_wit_list_backlogs)                                   | List backlogs for a team                                          |
+| [mcp_ado_wit_list_backlog_work_items](#mcp_ado_wit_list_backlog_work_items)               | Get work items in a backlog                                       |
+| [mcp_ado_wit_get_query](#mcp_ado_wit_get_query)                                           | Get a work item query by ID or path                               |
+| [mcp_ado_wit_get_query_results_by_id](#mcp_ado_wit_get_query_results_by_id)               | Execute a query and get results                                   |
+| [mcp_ado_wit_query_by_wiql](#mcp_ado_wit_query_by_wiql)                                   | Execute a WIQL query and return matching work items               |
+| [mcp_ado_wit_get_work_item_attachment](#mcp_ado_wit_get_work_item_attachment)             | Download a work item attachment; save locally or return as base64 |
+
+### Work
+
+> **Note:** The work tools are being aligned with the [Azure DevOps remote MCP server](https://learn.microsoft.com/en-us/azure/devops/mcp-server/remote-mcp-server?view=azure-devops#work) tool structure.
+
+| Tool                          | Action                     | Description                                                                             |
+| ----------------------------- | -------------------------- | --------------------------------------------------------------------------------------- |
+| [work](#work)                 | `list_iterations`          | List all iterations in a project                                                        |
+| [work](#work)                 | `list_team_iterations`     | List iterations assigned to a team                                                      |
+| [work](#work)                 | `get_team_settings`        | Get team settings including default iteration, backlog iteration, and default area path |
+| [work](#work)                 | `get_team_capacity`        | Get team capacity for an iteration                                                      |
+| [work](#work)                 | `get_iteration_capacities` | Get an iteration's capacity for all teams in the iteration and project                  |
+| [work_iteration_write](#work) | `create`                   | Create iterations                                                                       |
+| [work_iteration_write](#work) | `assign`                   | Assign iterations to a team                                                             |
+| [work_capacity_write](#work)  | `update`                   | Update the team capacity of a team member for a specific iteration                      |
+
+## Details
+
+### Advanced Security
+
+#### mcp_ado_advsec_get_alerts
 
 Retrieve Advanced Security alerts for a repository.
 
 - **Required**: `project`, `repository`, `confidenceLevels`
 - **Optional**: `alertType`, `continuationToken`, `onlyDefaultBranch`, `orderBy`, `ref`, `ruleId`, `ruleName`, `severities`, `states`, `toolName`, `top`, `validity`
 
-### mcp_ado_advsec_get_alert_details
+#### mcp_ado_advsec_get_alert_details
 
 Get detailed information about a specific Advanced Security alert.
 
 - **Required**: `project`, `repository`, `alertId`
 - **Optional**: `ref`
 
-## Core
+### Core
 
-### mcp_ado_core_list_projects
+#### mcp_ado_core_list_projects
 
 Retrieve a list of projects in your Azure DevOps organization.
 
 - **Required**: None
 - **Optional**: `continuationToken`, `projectNameFilter`, `skip`, `stateFilter`, `top`
 
-### mcp_ado_core_list_project_teams
+#### mcp_ado_core_list_project_teams
 
 Retrieve a list of teams for the specified Azure DevOps project.
 
 - **Required**: `project`
 - **Optional**: `mine`, `skip`, `top`
 
-### mcp_ado_core_get_identity_ids
+#### mcp_ado_core_get_identity_ids
 
 Retrieve Azure DevOps identity IDs for a provided search filter.
 
 - **Required**: `searchFilter`
 - **Optional**: None
 
-## Pipelines
+### Pipelines
 
-### mcp_ado_pipelines_create_pipeline
+#### mcp_ado_pipelines_create_pipeline
 
 Creates a pipeline definition with YAML configuration for a given project.
 
 - **Required**: `project`, `name`, `yamlPath`, `repositoryType`, `repositoryName`
 - **Optional**: `folder`, `repositoryConnectionId`, `repositoryId`
 
-### mcp_ado_pipelines_get_builds
+#### mcp_ado_pipelines_get_builds
 
 Retrieves a list of builds for a given project.
 
 - **Required**: `project`
 - **Optional**: `branchName`, `buildIds`, `buildNumber`, `continuationToken`, `definitions`, `deletedFilter`, `maxBuildsPerDefinition`, `maxTime`, `minTime`, `properties`, `queryOrder`, `queues`, `reasonFilter`, `repositoryId`, `repositoryType`, `requestedFor`, `resultFilter`, `statusFilter`, `tagFilters`, `top`
 
-### mcp_ado_pipelines_get_build_status
+#### mcp_ado_pipelines_get_build_status
 
 Fetches the status of a specific build.
 
 - **Required**: `project`, `buildId`
 - **Optional**: None
 
-### mcp_ado_pipelines_get_build_log
+#### mcp_ado_pipelines_get_build_log
 
 Retrieves the logs for a specific build.
 
 - **Required**: `project`, `buildId`
 - **Optional**: None
 
-### mcp_ado_pipelines_get_build_log_by_id
+#### mcp_ado_pipelines_get_build_log_by_id
 
 Get a specific build log by log ID.
 
 - **Required**: `project`, `buildId`, `logId`
 - **Optional**: `endLine`, `startLine`
 
-### mcp_ado_pipelines_get_build_changes
+#### mcp_ado_pipelines_get_build_changes
 
 Get the changes associated with a specific build.
 
 - **Required**: `project`, `buildId`
 - **Optional**: `continuationToken`, `includeSourceChange`, `top`
 
-### mcp_ado_pipelines_get_build_definitions
+#### mcp_ado_pipelines_get_build_definitions
 
 Retrieves a list of build definitions for a given project.
 
 - **Required**: `project`
 - **Optional**: `builtAfter`, `continuationToken`, `definitionIds`, `includeAllProperties`, `includeLatestBuilds`, `minMetricsTime`, `name`, `notBuiltAfter`, `path`, `processType`, `queryOrder`, `repositoryId`, `repositoryType`, `taskIdFilter`, `top`, `yamlFilename`
 
-### mcp_ado_pipelines_get_build_definition_revisions
+#### mcp_ado_pipelines_get_build_definition_revisions
 
 Retrieves a list of revisions for a specific build definition.
 
 - **Required**: `project`, `definitionId`
 - **Optional**: None
 
-### mcp_ado_pipelines_run_pipeline
+#### mcp_ado_pipelines_run_pipeline
 
 Starts a new run of a pipeline.
 
 - **Required**: `project`, `pipelineId`
 - **Optional**: `pipelineVersion`, `previewRun`, `resources`, `stagesToSkip`, `templateParameters`, `variables`, `yamlOverride`
 
-### mcp_ado_pipelines_get_run
+#### mcp_ado_pipelines_get_run
 
 Gets a run for a particular pipeline.
 
 - **Required**: `project`, `pipelineId`, `runId`
 - **Optional**: None
 
-### mcp_ado_pipelines_list_runs
+#### mcp_ado_pipelines_list_runs
 
 Gets top 10000 runs for a particular pipeline.
 
 - **Required**: `project`, `pipelineId`
 - **Optional**: None
 
-### mcp_ado_pipelines_update_build_stage
+#### mcp_ado_pipelines_update_build_stage
 
 Updates the stage of a specific build.
 
 - **Required**: `project`, `buildId`, `stageName`, `status`
 - **Optional**: `forceRetryAllJobs`
 
-### mcp_ado_pipelines_list_artifacts
+#### mcp_ado_pipelines_list_artifacts
 
 Lists artifacts for a given build.
 
 - **Required**: `project`, `buildId`
 
-### mcp_ado_pipelines_download_artifact
+#### mcp_ado_pipelines_download_artifact
 
 Downloads a pipeline artifact.
 
 - **Required**: `project`, `buildId`, `artifactName`
 - **Optional**: `destinationPath` (relative local path; absolute paths and path traversal are not allowed)
 
-## Repositories
+### Repositories
 
-### mcp_ado_repo_list_repos_by_project
+#### mcp_ado_repo_list_repos_by_project
 
 Retrieve a list of repositories for a given project.
 
 - **Required**: `project`
 - **Optional**: `repoNameFilter`, `skip`, `top`
 
-### mcp_ado_repo_get_repo_by_name_or_id
+#### mcp_ado_repo_get_repo_by_name_or_id
 
 Get the repository by project and repository name or ID.
 
 - **Required**: `project`, `repositoryNameOrId`
 - **Optional**: None
 
-### mcp_ado_repo_list_branches_by_repo
+#### mcp_ado_repo_list_branches_by_repo
 
 Retrieve a list of branches for a given repository.
 
 - **Required**: `repositoryId`
 - **Optional**: `filterContains`, `top`
 
-### mcp_ado_repo_list_my_branches_by_repo
+#### mcp_ado_repo_list_my_branches_by_repo
 
 Retrieve a list of my branches for a given repository Id.
 
 - **Required**: `repositoryId`
 - **Optional**: `filterContains`, `top`
 
-### mcp_ado_repo_get_branch_by_name
+#### mcp_ado_repo_get_branch_by_name
 
 Get a branch by its name.
 
 - **Required**: `repositoryId`, `branchName`
 - **Optional**: None
 
-### mcp_ado_repo_create_branch
+#### mcp_ado_repo_create_branch
 
 Create a new branch in the repository.
 
 - **Required**: `repositoryId`, `branchName`
 - **Optional**: `sourceBranchName`, `sourceCommitId`
 
-### mcp_ado_repo_search_commits
+#### mcp_ado_repo_search_commits
 
 Search for commits across projects and repositories with comprehensive filtering capabilities.
 
 - **Required**: `searchText`
 - **Optional**: `project`, `repository`, `branch`, `author`, `commitStartDate`, `commitEndDate`, `orderBy`, `includeFacets`, `skip`, `top`
 
-### mcp_ado_repo_list_pull_requests_by_repo_or_project
+#### mcp_ado_repo_list_pull_requests_by_repo_or_project
 
 Retrieve a list of pull requests for a given repository.
 
 - **Required**: None (either `repositoryId` or `project` must be provided)
 - **Optional**: `created_by_me`, `created_by_user`, `i_am_reviewer`, `project`, `repositoryId`, `skip`, `sourceRefName`, `status`, `targetRefName`, `top`, `user_is_reviewer`
 
-### mcp_ado_repo_list_pull_requests_by_commits
+#### mcp_ado_repo_list_pull_requests_by_commits
 
 Lists pull requests by commit IDs to find which pull requests contain specific commits.
 
 - **Required**: `project`, `repository`, `commits`
 - **Optional**: `queryType`
 
-### mcp_ado_repo_get_pull_request_by_id
+#### mcp_ado_repo_get_pull_request_by_id
 
 Get a pull request by its ID.
 
 - **Required**: `repositoryId`, `pullRequestId`
 - **Optional**: `project`, `includeWorkItemRefs`, `includeLabels`, `includeChangedFiles`
 
-### mcp_ado_repo_get_pull_request_changes
+#### mcp_ado_repo_get_pull_request_changes
 
 Get the file changes (diff) for a pull request iteration with actual code diff content. Returns the code changes including line-by-line diffs made in the pull request.
 
@@ -321,432 +369,391 @@ Get the file changes (diff) for a pull request iteration with actual code diff c
 - The diff content includes `lineDiffBlocks` showing line numbers and change types
 - By default, each `lineDiffBlock` includes `originalLines` (from base) and `modifiedLines` (from target) arrays with actual code content
 
-### mcp_ado_repo_create_pull_request
+#### mcp_ado_repo_create_pull_request
 
 Create a new pull request.
 
 - **Required**: `repositoryId`, `sourceRefName`, `targetRefName`, `title`
 - **Optional**: `description`, `forkSourceRepositoryId`, `isDraft`, `labels`, `workItems`
 
-### mcp_ado_repo_update_pull_request
+#### mcp_ado_repo_update_pull_request
 
 Update a Pull Request by ID with specified fields.
 
 - **Required**: `repositoryId`, `pullRequestId`
 - **Optional**: `autoComplete`, `bypassReason`, `deleteSourceBranch`, `description`, `isDraft`, `mergeStrategy`, `status`, `targetRefName`, `title`, `transitionWorkItems`
 
-### mcp_ado_repo_update_pull_request_reviewers
+#### mcp_ado_repo_update_pull_request_reviewers
 
 Add or remove reviewers for an existing pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `reviewerIds`, `action`
 - **Optional**: None
 
-### mcp_ado_repo_vote_pull_request
+#### mcp_ado_repo_vote_pull_request
 
 Cast a vote on a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `vote`
 - **Optional**: None
 
-### mcp_ado_repo_list_pull_request_threads
+#### mcp_ado_repo_list_pull_request_threads
 
 Retrieve a list of comment threads for a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`
 - **Optional**: `baseIteration`, `fullResponse`, `iteration`, `project`, `skip`, `top`
 
-### mcp_ado_repo_list_pull_request_thread_comments
+#### mcp_ado_repo_list_pull_request_thread_comments
 
 Retrieve a list of comments in a pull request thread.
 
 - **Required**: `repositoryId`, `pullRequestId`, `threadId`
 - **Optional**: `fullResponse`, `project`, `skip`, `top`
 
-### mcp_ado_repo_create_pull_request_thread
+#### mcp_ado_repo_create_pull_request_thread
 
 Creates a new comment thread on a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `content`
 - **Optional**: `filePath`, `project`, `rightFileEndLine`, `rightFileEndOffset`, `rightFileStartLine`, `rightFileStartOffset`, `status`
 
-### mcp_ado_repo_update_pull_request_thread
+#### mcp_ado_repo_update_pull_request_thread
 
 Updates an existing comment thread on a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `threadId`
 - **Optional**: `project`, `status`
 
-### mcp_ado_repo_reply_to_comment
+#### mcp_ado_repo_reply_to_comment
 
 Replies to a specific comment on a pull request.
 
 - **Required**: `repositoryId`, `pullRequestId`, `threadId`, `content`
 - **Optional**: `fullResponse`, `project`
 
-### mcp_ado_repo_list_directory
+#### mcp_ado_repo_list_directory
 
 List files and folders in a directory within a repository.
 
 - **Required**: `repositoryId`
 - **Optional**: `path`, `project`, `version`, `versionType`, `recursive`, `recursionDepth`
 
-### mcp_ado_repo_get_file_content
+#### mcp_ado_repo_get_file_content
 
 Get the content of a file from a Git repository at a specific version (branch, tag, or commit SHA).
 
 - **Required**: `repositoryId`, `path`
 - **Optional**: `project`, `version`, `versionType`
 
-## Search
+### Search
 
-### mcp_ado_search_code
+#### mcp_ado_search_code
 
 Search Azure DevOps Repositories for a given search text.
 
 - **Required**: `searchText`
 - **Optional**: `branch`, `includeFacets`, `path`, `project`, `repository`, `skip`, `top`
 
-### mcp_ado_search_wiki
+#### mcp_ado_search_wiki
 
 Search Azure DevOps Wiki for a given search text.
 
 - **Required**: `searchText`
 - **Optional**: `includeFacets`, `project`, `skip`, `top`, `wiki`
 
-### mcp_ado_search_workitem
+#### mcp_ado_search_workitem
 
 Get Azure DevOps Work Item search results for a given search text.
 
 - **Required**: `searchText`
 - **Optional**: `areaPath`, `assignedTo`, `includeFacets`, `project`, `skip`, `state`, `top`, `workItemType`
 
-## Test Plans
+### Test Plans
 
-### mcp_ado_testplan_list_test_plans
+#### mcp_ado_testplan_list_test_plans
 
 Retrieve a paginated list of test plans from an Azure DevOps project.
 
 - **Required**: `project`
 - **Optional**: `continuationToken`, `filterActivePlans`, `includePlanDetails`
 
-### mcp_ado_testplan_create_test_plan
+#### mcp_ado_testplan_create_test_plan
 
 Creates a new test plan in the project.
 
 - **Required**: `project`, `name`, `iteration`
 - **Optional**: `areaPath`, `description`, `endDate`, `startDate`
 
-### mcp_ado_testplan_list_test_suites
+#### mcp_ado_testplan_list_test_suites
 
 Retrieve a paginated list of test suites from an Azure DevOps project and Test Plan Id. Returns test suites in a properly nested hierarchical structure.
 
 - **Required**: `project`, `planId`
 - **Optional**: `continuationToken`
 
-### mcp_ado_testplan_create_test_suite
+#### mcp_ado_testplan_create_test_suite
 
 Creates a new test suite in a test plan.
 
 - **Required**: `project`, `planId`, `parentSuiteId`, `name`
 - **Optional**: None
 
-### mcp_ado_testplan_add_test_cases_to_suite
+#### mcp_ado_testplan_add_test_cases_to_suite
 
 Adds existing test cases to a test suite.
 
 - **Required**: `project`, `planId`, `suiteId`, `testCaseIds`
 - **Optional**: None
 
-### mcp_ado_testplan_list_test_cases
+#### mcp_ado_testplan_list_test_cases
 
 Gets a list of test cases in the test plan.
 
 - **Required**: `project`, `planid`, `suiteid`
 - **Optional**: `continuationToken`
 
-### mcp_ado_testplan_create_test_case
+#### mcp_ado_testplan_create_test_case
 
 Creates a new test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
 
 - **Required**: `project`, `title`
 - **Optional**: `areaPath`, `iterationPath`, `priority`, `steps`, `testsWorkItemId`
 
-### mcp_ado_testplan_update_test_case_steps
+#### mcp_ado_testplan_update_test_case_steps
 
 Update the steps of an existing test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
 
 - **Required**: `id`, `steps`
 - **Optional**: None
 
-### mcp_ado_testplan_show_test_results_from_build_id
+#### mcp_ado_testplan_show_test_results_from_build_id
 
 Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes.
 
 - **Required**: `project`, `buildid`
 - **Optional**: `outcomes`
 
-## Wiki
+### Wiki
 
-### mcp_ado_wiki_list_wikis
+#### mcp_ado_wiki_list_wikis
 
 Retrieve a list of wikis for an organization or project.
 
 - **Required**: None
 - **Optional**: `project`
 
-### mcp_ado_wiki_get_wiki
+#### mcp_ado_wiki_get_wiki
 
 Get the wiki by wikiIdentifier.
 
 - **Required**: `wikiIdentifier`
 - **Optional**: `project`
 
-### mcp_ado_wiki_list_pages
+#### mcp_ado_wiki_list_pages
 
 Retrieve a list of wiki pages for a specific wiki and project.
 
 - **Required**: `wikiIdentifier`, `project`
 - **Optional**: `continuationToken`, `pageViewsForDays`, `top`
 
-### mcp_ado_wiki_get_page
+#### mcp_ado_wiki_get_page
 
 Retrieve wiki page metadata by path. This tool does not return page content.
 
 - **Required**: `wikiIdentifier`, `project`, `path`
 - **Optional**: `recursionLevel`
 
-### mcp_ado_wiki_get_page_content
+#### mcp_ado_wiki_get_page_content
 
 Retrieve wiki page content.
 
 - **Required**: None (either `url` OR `wikiIdentifier` and `project`)
 - **Optional**: `path`, `project`, `url`, `wikiIdentifier`
 
-### mcp_ado_wiki_create_or_update_page
+#### mcp_ado_wiki_create_or_update_page
 
 Create or update a wiki page with content.
 
 - **Required**: `wikiIdentifier`, `path`, `content`
 - **Optional**: `branch`, `etag`, `project`
 
-## Work Items
+### Work Items
 
-### mcp_ado_wit_get_work_item
+#### mcp_ado_wit_get_work_item
 
 Get a single work item by ID.
 
 - **Required**: `id`, `project`
 - **Optional**: `asOf`, `expand`, `fields`
 
-### mcp_ado_wit_get_work_items_batch_by_ids
+#### mcp_ado_wit_get_work_items_batch_by_ids
 
 Retrieve list of work items by IDs in batch.
 
 - **Required**: `project`, `ids`
 - **Optional**: `fields`
 
-### mcp_ado_wit_create_work_item
+#### mcp_ado_wit_create_work_item
 
 Create a new work item in a specified project and work item type.
 
 - **Required**: `project`, `workItemType`, `fields`
 - **Optional**: None
 
-### mcp_ado_wit_update_work_item
+#### mcp_ado_wit_update_work_item
 
 Update a work item by ID with specified fields.
 
 - **Required**: `id`, `updates`
 - **Optional**: None
 
-### mcp_ado_wit_update_work_items_batch
+#### mcp_ado_wit_update_work_items_batch
 
 Update work items in batch.
 
 - **Required**: `updates`
 - **Optional**: None
 
-### mcp_ado_wit_add_child_work_items
+#### mcp_ado_wit_add_child_work_items
 
 Create one or many child work items from a parent by work item type and parent id.
 
 - **Required**: `parentId`, `project`, `workItemType`, `items`
 - **Optional**: None
 
-### mcp_ado_wit_work_items_link
+#### mcp_ado_wit_work_items_link
 
 Link work items together in batch.
 
 - **Required**: `project`, `updates`
 - **Optional**: None
 
-### mcp_ado_wit_work_item_unlink
+#### mcp_ado_wit_work_item_unlink
 
 Remove one or many links from a single work item.
 
 - **Required**: `project`, `id`
 - **Optional**: `type`, `url`
 
-### mcp_ado_wit_add_artifact_link
+#### mcp_ado_wit_add_artifact_link
 
 Add artifact links (repository, branch, commit, builds) to work items.
 
 - **Required**: `workItemId`, `project`
 - **Optional**: `artifactUri`, `branchName`, `buildId`, `comment`, `commitId`, `linkType`, `projectId`, `pullRequestId`, `repositoryId`
 
-### mcp_ado_wit_link_work_item_to_pull_request
+#### mcp_ado_wit_link_work_item_to_pull_request
 
 Link a single work item to an existing pull request.
 
 - **Required**: `projectId`, `repositoryId`, `pullRequestId`, `workItemId`
 - **Optional**: `pullRequestProjectId`
 
-### mcp_ado_wit_list_work_item_comments
+#### mcp_ado_wit_list_work_item_comments
 
 Retrieve list of comments for a work item by ID.
 
 - **Required**: `project`, `workItemId`
 - **Optional**: `top`
 
-### mcp_ado_wit_add_work_item_comment
+#### mcp_ado_wit_add_work_item_comment
 
 Add comment to a work item by ID.
 
 - **Required**: `project`, `workItemId`, `comment`
 - **Optional**: `format`
 
-### mcp_ado_wit_update_work_item_comment
+#### mcp_ado_wit_update_work_item_comment
 
 Update an existing comment on a work item by ID.
 
 - **Required**: `project`, `workItemId`, `commentId`, `text`
 - **Optional**: `format`
 
-### mcp_ado_wit_list_work_item_revisions
+#### mcp_ado_wit_list_work_item_revisions
 
 Retrieve list of revisions for a work item by ID.
 
 - **Required**: `project`, `workItemId`
 - **Optional**: `expand`, `skip`, `top`
 
-### mcp_ado_wit_get_work_item_type
+#### mcp_ado_wit_get_work_item_type
 
 Get a specific work item type.
 
 - **Required**: `project`, `workItemType`
 - **Optional**: None
 
-### mcp_ado_wit_my_work_items
+#### mcp_ado_wit_my_work_items
 
 Retrieve a list of work items relevant to the authenticated user.
 
 - **Required**: `project`
 - **Optional**: `includeCompleted`, `top`, `type`
 
-### mcp_ado_wit_get_work_items_for_iteration
+#### mcp_ado_wit_get_work_items_for_iteration
 
 Retrieve a list of work items for a specified iteration.
 
 - **Required**: `project`, `iterationId`
 - **Optional**: `team`
 
-### mcp_ado_wit_list_backlogs
+#### mcp_ado_wit_list_backlogs
 
 Receive a list of backlogs for a given project and team.
 
 - **Required**: `project`, `team`
 - **Optional**: None
 
-### mcp_ado_wit_list_backlog_work_items
+#### mcp_ado_wit_list_backlog_work_items
 
 Retrieve a list of backlogs for a given project, team, and backlog category.
 
 - **Required**: `project`, `team`, `backlogId`
 - **Optional**: None
 
-### mcp_ado_wit_get_query
+#### mcp_ado_wit_get_query
 
 Get a query by its ID or path.
 
 - **Required**: `project`, `query`
 - **Optional**: `depth`, `expand`, `includeDeleted`, `useIsoDateFormat`
 
-### mcp_ado_wit_get_query_results_by_id
+#### mcp_ado_wit_get_query_results_by_id
 
 Retrieve the results of a work item query given the query ID.
 
 - **Required**: `id`
 - **Optional**: `project`, `responseType`, `team`, `timePrecision`, `top`
 
-### mcp_ado_wit_query_by_wiql
+#### mcp_ado_wit_query_by_wiql
 
 Execute a WIQL (Work Item Query Language) query and return the matching work items. If a project is not specified, you will be prompted to select one.
 
 - **Required**: `wiql`
 - **Optional**: `project`, `team`, `timePrecision`, `top`
 
-### mcp_ado_wit_get_work_item_attachment
+#### mcp_ado_wit_get_work_item_attachment
 
 Download a work item attachment by its ID. If `savePath` is provided, saves the file to that local directory and returns the file path. Otherwise returns the content as a base64-encoded resource. Useful for viewing images (e.g. screenshots) or other files attached to work items such as bugs.
 
 - **Required**: `attachmentId`
 - **Optional**: `project`, `fileName`, `savePath`
 
-## Work
+### Work
 
-### mcp_ado_work_list_iterations
+> **Note:** The work tools are being aligned with the [Azure DevOps remote MCP server](https://learn.microsoft.com/en-us/azure/devops/mcp-server/remote-mcp-server?view=azure-devops#work) tool structure.
 
-List all iterations in a specified Azure DevOps project.
+The work tools are consolidated into grouped dispatchers using an `action` parameter.
 
-- **Required**: `project`
-- **Optional**: `depth`, `excludedIds`
-
-### mcp_ado_work_create_iterations
-
-Create new iterations in a specified Azure DevOps project.
-
-- **Required**: `project`, `iterations`
-- **Optional**: None
-
-### mcp_ado_work_list_team_iterations
-
-Retrieve a list of iterations for a specific team in a project.
-
-- **Required**: `project`, `team`
-- **Optional**: `timeframe`
-
-### mcp_ado_work_assign_iterations
-
-Assign existing iterations to a specific team in a project.
-
-- **Required**: `project`, `team`, `iterations`
-- **Optional**: None
-
-### mcp_ado_work_get_iteration_capacities
-
-Get an iteration's capacity for all teams in iteration and project.
-
-- **Required**: `project`, `iterationId`
-- **Optional**: None
-
-### mcp_ado_work_get_team_capacity
-
-Get the team capacity of a specific team and iteration in a project.
-
-- **Required**: `project`, `team`, `iterationId`
-- **Optional**: None
-
-### mcp_ado_work_update_team_capacity
-
-Update the team capacity of a team member for a specific iteration in a project.
-
-- **Required**: `project`, `team`, `teamMemberId`, `iterationId`, `activities`
-- **Optional**: `daysOff`
-
-### mcp_ado_work_get_team_settings
-
-Get team settings including default iteration, backlog iteration, and default area path for a team.
-
-- **Required**: `project`
-- **Optional**: `team`
+| Tool                   | Action                     | Description                                                                             | Read-only |
+| ---------------------- | -------------------------- | --------------------------------------------------------------------------------------- | :-------: |
+| `work`                 | `list_iterations`          | List all iterations in a project                                                        |    ✅     |
+| `work`                 | `list_team_iterations`     | List iterations assigned to a team                                                      |    ✅     |
+| `work`                 | `get_team_settings`        | Get team settings including default iteration, backlog iteration, and default area path |    ✅     |
+| `work`                 | `get_team_capacity`        | Get team capacity for an iteration                                                      |    ✅     |
+| `work`                 | `get_iteration_capacities` | Get an iteration's capacity for all teams in the iteration and project                  |    ✅     |
+| `work_iteration_write` | `create`                   | Create iterations                                                                       |    ❌     |
+| `work_iteration_write` | `assign`                   | Assign iterations to a team                                                             |    ❌     |
+| `work_capacity_write`  | `update`                   | Update the team capacity of a team member for a specific iteration                      |    ❌     |

--- a/src/tools/work.ts
+++ b/src/tools/work.ts
@@ -77,7 +77,7 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
           const workItemTrackingApi = await connection.getWorkItemTrackingApi();
           const effectiveDepth = depth ?? 1;
 
-          let results = await workItemTrackingApi.getClassificationNodes(resolvedProject, [], effectiveDepth);
+          const results = await workItemTrackingApi.getClassificationNodes(resolvedProject, [], effectiveDepth);
 
           if (!results) {
             return { content: [{ type: "text", text: "No iterations were found" }], isError: true };
@@ -163,10 +163,18 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
             resolvedProject = result.resolved;
           }
 
-          const workApi = await connection.getWorkApi();
-          const teamContext = { project: resolvedProject, team: team! };
+          if (!team) {
+            return { content: [{ type: "text", text: "Team is required for get_team_capacity" }], isError: true };
+          }
 
-          const rawResults = await workApi.getCapacitiesWithIdentityRefAndTotals(teamContext, iterationId!);
+          if (!iterationId) {
+            return { content: [{ type: "text", text: "iterationId is required for get_team_capacity" }], isError: true };
+          }
+
+          const workApi = await connection.getWorkApi();
+          const teamContext = { project: resolvedProject, team };
+
+          const rawResults = await workApi.getCapacitiesWithIdentityRefAndTotals(teamContext, iterationId);
 
           if (!rawResults || rawResults.teamMembers?.length === 0) {
             return { content: [{ type: "text", text: "No team capacity assigned to the team" }], isError: true };
@@ -202,8 +210,12 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
             resolvedProject = result.resolved;
           }
 
+          if (!iterationId) {
+            return { content: [{ type: "text", text: "iterationId is required for get_iteration_capacities" }], isError: true };
+          }
+
           const workApi = await connection.getWorkApi();
-          const rawResults = await workApi.getTotalIterationCapacities(resolvedProject, iterationId!);
+          const rawResults = await workApi.getTotalIterationCapacities(resolvedProject, iterationId);
 
           if (!rawResults || !rawResults.teams || rawResults.teams.length === 0) {
             return { content: [{ type: "text", text: "No iteration capacity assigned to the teams" }], isError: true };
@@ -291,8 +303,12 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
         }
 
         if (action === "assign") {
+          if (!team) {
+            return { content: [{ type: "text", text: "Team is required for assign" }], isError: true };
+          }
+
           const workApi = await connection.getWorkApi();
-          const teamContext = { project, team: team! };
+          const teamContext = { project, team };
           const results = [];
 
           for (const { identifier, path } of iterations) {

--- a/src/tools/work.ts
+++ b/src/tools/work.ts
@@ -8,192 +8,226 @@ import { TreeStructureGroup, TreeNodeStructureType, WorkItemClassificationNode }
 import { elicitProject, elicitTeam } from "../shared/elicitations.js";
 
 const WORK_TOOLS = {
-  list_team_iterations: "work_list_team_iterations",
-  list_iterations: "work_list_iterations",
-  create_iterations: "work_create_iterations",
-  assign_iterations: "work_assign_iterations",
-  get_team_capacity: "work_get_team_capacity",
-  update_team_capacity: "work_update_team_capacity",
-  get_iteration_capacities: "work_get_iteration_capacities",
-  get_team_settings: "work_get_team_settings",
+  work: "work",
+  work_iteration_write: "work_iteration_write",
+  work_capacity_write: "work_capacity_write",
 };
 
 function configureWorkTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
-    WORK_TOOLS.list_team_iterations,
-    "Retrieve a list of iterations for a specific team in a project. If a project or team is not specified, you will be prompted to select one.",
+    WORK_TOOLS.work,
+    "Retrieve work-related data for a project or team. Use the action parameter to specify the operation.",
     {
+      action: z
+        .enum(["list_iterations", "list_team_iterations", "get_team_settings", "get_team_capacity", "get_iteration_capacities"])
+        .describe(
+          "The action to perform. Options: list_iterations (list all iterations in a project), list_team_iterations (list iterations assigned to a team), get_team_settings (get team settings including default iteration and area path), get_team_capacity (get team capacity for an iteration), get_iteration_capacities (get capacity for all teams in an iteration)."
+        ),
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Reuse from prior context if already known. If not provided, a team selection prompt will be shown."),
-      timeframe: z.enum(["current"]).optional().describe("The timeframe for which to retrieve iterations. Currently, only 'current' is supported."),
+      team: z
+        .string()
+        .optional()
+        .describe("The name or ID of the Azure DevOps team. Required for list_team_iterations, get_team_settings, and get_team_capacity. Reuse from prior context if already known."),
+      iterationId: z.string().optional().describe("The Iteration ID. Required for get_team_capacity and get_iteration_capacities."),
+      timeframe: z.enum(["current"]).optional().describe("The timeframe for list_team_iterations. Only 'current' is supported."),
+      depth: z.coerce.number().default(2).describe("Depth of children to fetch. Used for list_iterations. Defaults to 2."),
+      excludedIds: z.array(z.coerce.number().min(1)).optional().describe("An optional array of iteration IDs, and their children, to exclude from results. Used for list_iterations."),
     },
-    async ({ project, team, timeframe }) => {
+    async ({ action, project, team, iterationId, timeframe, depth, excludedIds }) => {
       try {
         const connection = await connectionProvider();
-
         let resolvedProject = project;
-        if (!resolvedProject) {
-          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list team iterations for.");
-          if ("response" in result) return result.response;
-          resolvedProject = result.resolved;
-        }
 
-        let resolvedTeam = team;
-        if (!resolvedTeam) {
-          const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to list iterations for.");
-          if ("response" in result) return result.response;
-          resolvedTeam = result.resolved;
-        }
-
-        const workApi = await connection.getWorkApi();
-        const iterations = await workApi.getTeamIterations({ project: resolvedProject, team: resolvedTeam }, timeframe);
-
-        if (!iterations) {
-          return { content: [{ type: "text", text: "No iterations found" }], isError: true };
-        }
-
-        return {
-          content: [
-            { type: "text", text: `Project: ${resolvedProject}, Team: ${resolvedTeam}` },
-            { type: "text", text: JSON.stringify(iterations, null, 2) },
-          ],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        return {
-          content: [{ type: "text", text: `Error fetching team iterations: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    WORK_TOOLS.create_iterations,
-    "Create new iterations in a specified Azure DevOps project.",
-    {
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
-      iterations: z
-        .array(
-          z.object({
-            iterationName: z.string().describe("The name of the iteration to create."),
-            startDate: z.string().optional().describe("The start date of the iteration in ISO format (e.g., '2023-01-01T00:00:00Z'). Optional."),
-            finishDate: z.string().optional().describe("The finish date of the iteration in ISO format (e.g., '2023-01-31T23:59:59Z'). Optional."),
-          })
-        )
-        .describe("An array of iterations to create. Each iteration must have a name and can optionally have start and finish dates in ISO format."),
-    },
-    async ({ project, iterations }) => {
-      try {
-        const connection = await connectionProvider();
-        const workItemTrackingApi = await connection.getWorkItemTrackingApi();
-        const results = [];
-
-        for (const { iterationName, startDate, finishDate } of iterations) {
-          // Step 1: Create the iteration
-          const iteration = await workItemTrackingApi.createOrUpdateClassificationNode(
-            {
-              name: iterationName,
-              attributes: {
-                startDate: startDate ? new Date(startDate) : undefined,
-                finishDate: finishDate ? new Date(finishDate) : undefined,
-              },
-            },
-            project,
-            TreeStructureGroup.Iterations
-          );
-
-          if (iteration) {
-            results.push(iteration);
+        if (action === "list_team_iterations") {
+          if (!resolvedProject) {
+            const result = await elicitProject(server, connection, "Select the Azure DevOps project to list team iterations for.");
+            if ("response" in result) return result.response;
+            resolvedProject = result.resolved;
           }
+
+          let resolvedTeam = team;
+          if (!resolvedTeam) {
+            const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to list iterations for.");
+            if ("response" in result) return result.response;
+            resolvedTeam = result.resolved;
+          }
+
+          const workApi = await connection.getWorkApi();
+          const iterations = await workApi.getTeamIterations({ project: resolvedProject, team: resolvedTeam }, timeframe);
+
+          if (!iterations) {
+            return { content: [{ type: "text", text: "No iterations found" }], isError: true };
+          }
+
+          return {
+            content: [
+              { type: "text", text: `Project: ${resolvedProject}, Team: ${resolvedTeam}` },
+              { type: "text", text: JSON.stringify(iterations, null, 2) },
+            ],
+          };
         }
 
-        if (results.length === 0) {
-          return { content: [{ type: "text", text: "No iterations were created" }], isError: true };
+        if (action === "list_iterations") {
+          if (!resolvedProject) {
+            const result = await elicitProject(server, connection, "Select the Azure DevOps project to list iterations for.");
+            if ("response" in result) return result.response;
+            resolvedProject = result.resolved;
+          }
+
+          const workItemTrackingApi = await connection.getWorkItemTrackingApi();
+          const effectiveDepth = depth ?? 1;
+
+          let results = await workItemTrackingApi.getClassificationNodes(resolvedProject, [], effectiveDepth);
+
+          if (!results) {
+            return { content: [{ type: "text", text: "No iterations were found" }], isError: true };
+          }
+
+          let filteredResults = results.filter((node) => node.structureType === TreeNodeStructureType.Iteration);
+
+          if (excludedIds && excludedIds.length > 0) {
+            const filterOutIds = (nodes: WorkItemClassificationNode[]): WorkItemClassificationNode[] => {
+              return nodes
+                .filter((node) => !node.id || !excludedIds.includes(node.id))
+                .map((node) => {
+                  if (node.children && node.children.length > 0) {
+                    return {
+                      ...node,
+                      children: filterOutIds(node.children),
+                    };
+                  }
+                  return node;
+                });
+            };
+
+            filteredResults = filterOutIds(filteredResults);
+          }
+
+          if (filteredResults.length === 0) {
+            return { content: [{ type: "text", text: "No iterations were found" }], isError: true };
+          }
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(filteredResults, null, 2) }],
+          };
         }
 
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        if (action === "get_team_settings") {
+          if (!resolvedProject) {
+            const result = await elicitProject(server, connection, "Select the Azure DevOps project to get team settings for.");
+            if ("response" in result) return result.response;
+            resolvedProject = result.resolved;
+          }
 
-        return {
-          content: [{ type: "text", text: `Error creating iterations: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
+          let resolvedTeam = team;
+          if (!resolvedTeam) {
+            const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to get settings for.");
+            if ("response" in result) return result.response;
+            resolvedTeam = result.resolved;
+          }
 
-  server.tool(
-    WORK_TOOLS.list_iterations,
-    "List all iterations in a specified Azure DevOps project. If a project is not specified, you will be prompted to select one.",
-    {
-      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      depth: z.coerce.number().default(2).describe("Depth of children to fetch."),
-      excludedIds: z.array(z.coerce.number().min(1)).optional().describe("An optional array of iteration IDs, and their children, that should not be returned."),
-    },
-    async ({ project, depth, excludedIds: ids }) => {
-      try {
-        const connection = await connectionProvider();
+          const workApi = await connection.getWorkApi();
+          const teamContext = { project: resolvedProject, team: resolvedTeam };
+          const teamSettings = await workApi.getTeamSettings(teamContext);
 
-        let resolvedProject = project;
-        if (!resolvedProject) {
-          const result = await elicitProject(server, connection, "Select the Azure DevOps project to list iterations for.");
-          if ("response" in result) return result.response;
-          resolvedProject = result.resolved;
-        }
+          if (!teamSettings) {
+            return { content: [{ type: "text", text: "No team settings found" }], isError: true };
+          }
 
-        const workItemTrackingApi = await connection.getWorkItemTrackingApi();
-        let results = [];
+          const teamFieldValues = await workApi.getTeamFieldValues(teamContext);
 
-        if (depth === undefined) {
-          depth = 1;
-        }
-
-        results = await workItemTrackingApi.getClassificationNodes(resolvedProject, [], depth);
-
-        // Handle null or undefined results
-        if (!results) {
-          return { content: [{ type: "text", text: "No iterations were found" }], isError: true };
-        }
-
-        // Filter out items with structureType=0 (Area nodes), only keep structureType=1 (Iteration nodes)
-        let filteredResults = results.filter((node) => node.structureType === TreeNodeStructureType.Iteration);
-
-        // If specific IDs are provided, filter them out recursively (exclude matching nodes and their children)
-        if (ids && ids.length > 0) {
-          const filterOutIds = (nodes: WorkItemClassificationNode[]): WorkItemClassificationNode[] => {
-            return nodes
-              .filter((node) => !node.id || !ids.includes(node.id))
-              .map((node) => {
-                if (node.children && node.children.length > 0) {
-                  return {
-                    ...node,
-                    children: filterOutIds(node.children),
-                  };
-                }
-                return node;
-              });
+          const settingsResult = {
+            backlogIteration: teamSettings.backlogIteration,
+            defaultIteration: teamSettings.defaultIteration,
+            defaultIterationMacro: teamSettings.defaultIterationMacro,
+            backlogVisibilities: teamSettings.backlogVisibilities,
+            bugsBehavior: teamSettings.bugsBehavior,
+            workingDays: teamSettings.workingDays,
+            defaultAreaPath: teamFieldValues?.defaultValue,
+            areaPathField: teamFieldValues?.field,
+            areaPaths: teamFieldValues?.values,
           };
 
-          filteredResults = filterOutIds(filteredResults);
+          return {
+            content: [
+              { type: "text", text: `Project: ${resolvedProject}, Team: ${resolvedTeam}` },
+              { type: "text", text: JSON.stringify(settingsResult, null, 2) },
+            ],
+          };
         }
 
-        if (filteredResults.length === 0) {
-          return { content: [{ type: "text", text: "No iterations were found" }], isError: true };
+        if (action === "get_team_capacity") {
+          if (!resolvedProject) {
+            const result = await elicitProject(server, connection, "Select the Azure DevOps project to get team capacity for.");
+            if ("response" in result) return result.response;
+            resolvedProject = result.resolved;
+          }
+
+          const workApi = await connection.getWorkApi();
+          const teamContext = { project: resolvedProject, team: team! };
+
+          const rawResults = await workApi.getCapacitiesWithIdentityRefAndTotals(teamContext, iterationId!);
+
+          if (!rawResults || rawResults.teamMembers?.length === 0) {
+            return { content: [{ type: "text", text: "No team capacity assigned to the team" }], isError: true };
+          }
+
+          const simplifiedResults = {
+            ...rawResults,
+            teamMembers: (rawResults.teamMembers || []).map((member) => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const { url, ...rest } = member;
+              return {
+                ...rest,
+                teamMember: member.teamMember
+                  ? {
+                      displayName: member.teamMember.displayName,
+                      id: member.teamMember.id,
+                      uniqueName: member.teamMember.uniqueName,
+                    }
+                  : undefined,
+              };
+            }),
+          };
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(simplifiedResults, null, 2) }],
+          };
         }
 
-        return {
-          content: [{ type: "text", text: JSON.stringify(filteredResults, null, 2) }],
-        };
+        if (action === "get_iteration_capacities") {
+          if (!resolvedProject) {
+            const result = await elicitProject(server, connection, "Select the Azure DevOps project to get iteration capacities for.");
+            if ("response" in result) return result.response;
+            resolvedProject = result.resolved;
+          }
+
+          const workApi = await connection.getWorkApi();
+          const rawResults = await workApi.getTotalIterationCapacities(resolvedProject, iterationId!);
+
+          if (!rawResults || !rawResults.teams || rawResults.teams.length === 0) {
+            return { content: [{ type: "text", text: "No iteration capacity assigned to the teams" }], isError: true };
+          }
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(rawResults, null, 2) }],
+          };
+        }
+
+        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 
+        const actionErrorMessages: Record<string, string> = {
+          list_team_iterations: `Error fetching team iterations: ${errorMessage}`,
+          list_iterations: `Error fetching iterations: ${errorMessage}`,
+          get_team_settings: `Error fetching team settings: ${errorMessage}`,
+          get_team_capacity: `Error getting team capacity: ${errorMessage}`,
+          get_iteration_capacities: `Error getting iteration capacities: ${errorMessage}`,
+        };
+
         return {
-          content: [{ type: "text", text: `Error fetching iterations: ${errorMessage}` }],
+          content: [{ type: "text", text: actionErrorMessages[action] ?? `Error: ${errorMessage}` }],
           isError: true,
         };
       }
@@ -201,47 +235,96 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
   );
 
   server.tool(
-    WORK_TOOLS.assign_iterations,
-    "Assign existing iterations to a specific team in a project.",
+    WORK_TOOLS.work_iteration_write,
+    "Create or assign iterations in an Azure DevOps project. Use the action parameter to specify the operation.",
     {
+      action: z.enum(["create", "assign"]).describe("The action to perform. 'create' creates new iterations in the project; 'assign' assigns existing iterations to a team."),
       project: z.string().describe("The name or ID of the Azure DevOps project."),
-      team: z.string().describe("The name or ID of the Azure DevOps team."),
+      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Required for assign."),
       iterations: z
         .array(
           z.object({
-            identifier: z.string().describe("The identifier of the iteration to assign."),
-            path: z.string().describe("The path of the iteration to assign, e.g., 'Project/Iteration'."),
+            iterationName: z.string().optional().describe("The name of the iteration to create. Used for create."),
+            startDate: z.string().optional().describe("The start date of the iteration in ISO format (e.g., '2023-01-01T00:00:00Z'). Used for create."),
+            finishDate: z.string().optional().describe("The finish date of the iteration in ISO format (e.g., '2023-01-31T23:59:59Z'). Used for create."),
+            identifier: z.string().optional().describe("The identifier of the iteration to assign. Used for assign."),
+            path: z.string().optional().describe("The path of the iteration to assign, e.g., 'Project/Iteration'. Used for assign."),
           })
         )
-        .describe("An array of iterations to assign. Each iteration must have an identifier and a path."),
+        .describe("An array of iterations to process. For create: provide iterationName and optional dates. For assign: provide identifier and path."),
     },
-    async ({ project, team, iterations }) => {
+    async ({ action, project, team, iterations }) => {
       try {
         const connection = await connectionProvider();
-        const workApi = await connection.getWorkApi();
-        const teamContext = { project, team };
-        const results = [];
 
-        for (const { identifier, path } of iterations) {
-          const assignment = await workApi.postTeamIteration({ path: path, id: identifier }, teamContext);
+        if (action === "create") {
+          const workItemTrackingApi = await connection.getWorkItemTrackingApi();
+          const results = [];
 
-          if (assignment) {
-            results.push(assignment);
+          for (const { iterationName, startDate, finishDate } of iterations) {
+            if (!iterationName) continue;
+
+            const iteration = await workItemTrackingApi.createOrUpdateClassificationNode(
+              {
+                name: iterationName,
+                attributes: {
+                  startDate: startDate ? new Date(startDate) : undefined,
+                  finishDate: finishDate ? new Date(finishDate) : undefined,
+                },
+              },
+              project,
+              TreeStructureGroup.Iterations
+            );
+
+            if (iteration) {
+              results.push(iteration);
+            }
           }
+
+          if (results.length === 0) {
+            return { content: [{ type: "text", text: "No iterations were created" }], isError: true };
+          }
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          };
         }
 
-        if (results.length === 0) {
-          return { content: [{ type: "text", text: "No iterations were assigned to the team" }], isError: true };
+        if (action === "assign") {
+          const workApi = await connection.getWorkApi();
+          const teamContext = { project, team: team! };
+          const results = [];
+
+          for (const { identifier, path } of iterations) {
+            if (!identifier || !path) continue;
+
+            const assignment = await workApi.postTeamIteration({ path: path, id: identifier }, teamContext);
+
+            if (assignment) {
+              results.push(assignment);
+            }
+          }
+
+          if (results.length === 0) {
+            return { content: [{ type: "text", text: "No iterations were assigned to the team" }], isError: true };
+          }
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          };
         }
 
-        return {
-          content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-        };
+        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 
+        const actionErrorMessages: Record<string, string> = {
+          create: `Error creating iterations: ${errorMessage}`,
+          assign: `Error assigning iterations: ${errorMessage}`,
+        };
+
         return {
-          content: [{ type: "text", text: `Error assigning iterations: ${errorMessage}` }],
+          content: [{ type: "text", text: actionErrorMessages[action] ?? `Error: ${errorMessage}` }],
           isError: true,
         };
       }
@@ -249,70 +332,10 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
   );
 
   server.tool(
-    WORK_TOOLS.get_team_capacity,
-    "Get the team capacity of a specific team and iteration in a project. If a project is not specified, you will be prompted to select one.",
-    {
-      project: z.string().optional().describe("The name or Id of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      team: z.string().describe("The name or Id of the Azure DevOps team. Reuse from prior context if already known."),
-      iterationId: z.string().describe("The Iteration Id to get capacity for."),
-    },
-    async ({ project, team, iterationId }) => {
-      try {
-        const connection = await connectionProvider();
-
-        let resolvedProject = project;
-        if (!resolvedProject) {
-          const result = await elicitProject(server, connection, "Select the Azure DevOps project to get team capacity for.");
-          if ("response" in result) return result.response;
-          resolvedProject = result.resolved;
-        }
-
-        const workApi = await connection.getWorkApi();
-        const teamContext = { project: resolvedProject, team };
-
-        const rawResults = await workApi.getCapacitiesWithIdentityRefAndTotals(teamContext, iterationId);
-
-        if (!rawResults || rawResults.teamMembers?.length === 0) {
-          return { content: [{ type: "text", text: "No team capacity assigned to the team" }], isError: true };
-        }
-
-        // Remove unwanted fields from teamMember and url
-        const simplifiedResults = {
-          ...rawResults,
-          teamMembers: (rawResults.teamMembers || []).map((member) => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { url, ...rest } = member;
-            return {
-              ...rest,
-              teamMember: member.teamMember
-                ? {
-                    displayName: member.teamMember.displayName,
-                    id: member.teamMember.id,
-                    uniqueName: member.teamMember.uniqueName,
-                  }
-                : undefined,
-            };
-          }),
-        };
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(simplifiedResults, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        return {
-          content: [{ type: "text", text: `Error getting team capacity: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    WORK_TOOLS.update_team_capacity,
+    WORK_TOOLS.work_capacity_write,
     "Update the team capacity of a team member for a specific iteration in a project.",
     {
+      action: z.literal("update").describe("The action to perform. Only 'update' is supported."),
       project: z.string().describe("The name or Id of the Azure DevOps project."),
       team: z.string().describe("The name or Id of the Azure DevOps team."),
       teamMemberId: z.string().describe("The team member Id for the specific team member."),
@@ -347,7 +370,6 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
           daysOff?: { start: Date; end: Date }[];
         }
 
-        // Prepare the capacity update object
         const capacityPatch: CapacityPatch = {
           activities: activities.map((a) => ({
             name: a.name,
@@ -359,14 +381,12 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
           })),
         };
 
-        // Update the team member's capacity
         const updatedCapacity = await workApi.updateCapacityWithIdentityRef(capacityPatch, teamContext, iterationId, teamMemberId);
 
         if (!updatedCapacity) {
           return { content: [{ type: "text", text: "Failed to update team member capacity" }], isError: true };
         }
 
-        // Simplify output
         const simplifiedResult = {
           teamMember: updatedCapacity.teamMember
             ? {
@@ -384,113 +404,9 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
         };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+
         return {
           content: [{ type: "text", text: `Error updating team capacity: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    WORK_TOOLS.get_iteration_capacities,
-    "Get an iteration's capacity for all teams in iteration and project. If a project is not specified, you will be prompted to select one.",
-    {
-      project: z.string().optional().describe("The name or Id of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      iterationId: z.string().describe("The Iteration Id to get capacity for."),
-    },
-    async ({ project, iterationId }) => {
-      try {
-        const connection = await connectionProvider();
-
-        let resolvedProject = project;
-        if (!resolvedProject) {
-          const result = await elicitProject(server, connection, "Select the Azure DevOps project to get iteration capacities for.");
-          if ("response" in result) return result.response;
-          resolvedProject = result.resolved;
-        }
-
-        const workApi = await connection.getWorkApi();
-
-        const rawResults = await workApi.getTotalIterationCapacities(resolvedProject, iterationId);
-
-        if (!rawResults || !rawResults.teams || rawResults.teams.length === 0) {
-          return { content: [{ type: "text", text: "No iteration capacity assigned to the teams" }], isError: true };
-        }
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(rawResults, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        return {
-          content: [{ type: "text", text: `Error getting iteration capacities: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    WORK_TOOLS.get_team_settings,
-    "Get team settings including default iteration, backlog iteration, and default area path for a team. If a project or team is not specified, you will be prompted to select one.",
-    {
-      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
-      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Reuse from prior context if already known. If not provided, a team selection prompt will be shown."),
-    },
-    async ({ project, team }) => {
-      try {
-        const connection = await connectionProvider();
-
-        let resolvedProject = project;
-        if (!resolvedProject) {
-          const result = await elicitProject(server, connection, "Select the Azure DevOps project to get team settings for.");
-          if ("response" in result) return result.response;
-          resolvedProject = result.resolved;
-        }
-
-        let resolvedTeam = team;
-        if (!resolvedTeam) {
-          const result = await elicitTeam(server, connection, resolvedProject, "Select the Azure DevOps team to get settings for.");
-          if ("response" in result) return result.response;
-          resolvedTeam = result.resolved;
-        }
-
-        const workApi = await connection.getWorkApi();
-        const teamContext = { project: resolvedProject, team: resolvedTeam };
-
-        const teamSettings = await workApi.getTeamSettings(teamContext);
-
-        if (!teamSettings) {
-          return { content: [{ type: "text", text: "No team settings found" }], isError: true };
-        }
-
-        const teamFieldValues = await workApi.getTeamFieldValues(teamContext);
-
-        const result = {
-          backlogIteration: teamSettings.backlogIteration,
-          defaultIteration: teamSettings.defaultIteration,
-          defaultIterationMacro: teamSettings.defaultIterationMacro,
-          backlogVisibilities: teamSettings.backlogVisibilities,
-          bugsBehavior: teamSettings.bugsBehavior,
-          workingDays: teamSettings.workingDays,
-          defaultAreaPath: teamFieldValues?.defaultValue,
-          areaPathField: teamFieldValues?.field,
-          areaPaths: teamFieldValues?.values,
-        };
-
-        return {
-          content: [
-            { type: "text", text: `Project: ${resolvedProject}, Team: ${resolvedTeam}` },
-            { type: "text", text: JSON.stringify(result, null, 2) },
-          ],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        return {
-          content: [{ type: "text", text: `Error fetching team settings: ${errorMessage}` }],
           isError: true,
         };
       }

--- a/test/src/tools/work.test.ts
+++ b/test/src/tools/work.test.ts
@@ -83,8 +83,8 @@ describe("configureWorkTools", () => {
     it("should call getTeamIterations API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockResolvedValue([
@@ -100,6 +100,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_team_iterations" as const,
         project: "fabrikam",
         team: "Fabrikam Team",
         timeframe: undefined,
@@ -132,14 +133,15 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to retrieve iterations");
       (mockWorkApi.getTeamIterations as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "list_team_iterations" as const,
         project: "fabrikam",
         team: "Fabrikam Team",
         timeframe: undefined,
@@ -155,13 +157,14 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "list_team_iterations" as const,
         project: "fabrikam",
         team: "Fabrikam Team",
         timeframe: undefined,
@@ -177,13 +180,14 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "list_team_iterations" as const,
         project: "fabrikam",
         team: "Fabrikam Team",
         timeframe: undefined,
@@ -199,8 +203,8 @@ describe("configureWorkTools", () => {
     it("should elicit project and team when not provided and user accepts", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -211,7 +215,7 @@ describe("configureWorkTools", () => {
 
       (mockWorkApi.getTeamIterations as jest.Mock).mockResolvedValue([{ id: "iter-1", name: "Sprint 1" }]);
 
-      const result = await handler({ project: undefined, team: undefined, timeframe: undefined });
+      const result = await handler({ action: "list_team_iterations" as const, project: undefined, team: undefined, timeframe: undefined });
 
       expect(elicitMock).toHaveBeenCalledTimes(2);
       expect(mockWorkApi.getTeamIterations).toHaveBeenCalledWith({ project: "ProjectAlpha", team: "Team One" }, undefined);
@@ -222,8 +226,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when project elicitation is declined", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -231,7 +235,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, team: undefined, timeframe: undefined });
+      const result = await handler({ action: "list_team_iterations" as const, project: undefined, team: undefined, timeframe: undefined });
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getTeamIterations).not.toHaveBeenCalled();
@@ -240,8 +244,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when team elicitation is declined", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -250,7 +254,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "accept", content: { project: "ProjectAlpha" } }).mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, team: undefined, timeframe: undefined });
+      const result = await handler({ action: "list_team_iterations" as const, project: undefined, team: undefined, timeframe: undefined });
 
       expect(result.content[0].text).toBe("Team selection cancelled.");
       expect(mockWorkApi.getTeamIterations).not.toHaveBeenCalled();
@@ -259,8 +263,8 @@ describe("configureWorkTools", () => {
     it("should return error when no teams are available for elicitation", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_team_iterations");
-      if (!call) throw new Error("work_list_team_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -269,7 +273,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "accept", content: { project: "ProjectAlpha" } });
 
-      const result = await handler({ project: undefined, team: undefined, timeframe: undefined });
+      const result = await handler({ action: "list_team_iterations" as const, project: undefined, team: undefined, timeframe: undefined });
 
       expect(elicitMock).toHaveBeenCalledTimes(1);
       expect(mockWorkApi.getTeamIterations).not.toHaveBeenCalled();
@@ -282,8 +286,8 @@ describe("configureWorkTools", () => {
     it("should call getClassificationNodes API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -337,6 +341,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
       };
@@ -391,8 +396,8 @@ describe("configureWorkTools", () => {
     it("should use default depth of 1 when depth parameter is not provided", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -409,6 +414,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
       };
 
@@ -435,8 +441,8 @@ describe("configureWorkTools", () => {
     it("should filter out non-iteration nodes and return only iteration nodes", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -463,6 +469,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -491,8 +498,8 @@ describe("configureWorkTools", () => {
     it("should handle case when no iteration nodes are found", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -509,6 +516,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -523,13 +531,14 @@ describe("configureWorkTools", () => {
     it("should handle empty API response", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -544,13 +553,14 @@ describe("configureWorkTools", () => {
     it("should handle null API response", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -565,8 +575,8 @@ describe("configureWorkTools", () => {
     it("should handle iteration node with undefined children", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -583,6 +593,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -609,14 +620,15 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to retrieve iterations");
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -631,13 +643,14 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 1,
       };
@@ -652,8 +665,8 @@ describe("configureWorkTools", () => {
     it("should properly map child iterations with all expected properties", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -684,6 +697,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
       };
@@ -711,8 +725,8 @@ describe("configureWorkTools", () => {
     it("should filter out iterations by excludedIds parameter", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -756,6 +770,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
         excludedIds: [126394],
@@ -798,8 +813,8 @@ describe("configureWorkTools", () => {
     it("should recursively filter out iterations and their children by excludedIds", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -875,6 +890,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 3,
         excludedIds: [126394], // Exclude "Archived" folder
@@ -910,8 +926,8 @@ describe("configureWorkTools", () => {
     it("should handle multiple excludedIds filtering", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -956,6 +972,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
         excludedIds: [126393, 126395], // Exclude Sprint 1 and Sprint 3
@@ -977,8 +994,8 @@ describe("configureWorkTools", () => {
     it("should handle empty excludedIds array without filtering", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -1005,6 +1022,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
         excludedIds: [],
@@ -1023,8 +1041,8 @@ describe("configureWorkTools", () => {
     it("should handle excludedIds filtering with nodes that have no id property", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.getClassificationNodes as jest.Mock).mockResolvedValue([
@@ -1060,6 +1078,7 @@ describe("configureWorkTools", () => {
       ]);
 
       const params = {
+        action: "list_iterations" as const,
         project: "Fabrikam",
         depth: 2,
         excludedIds: [126394],
@@ -1081,8 +1100,8 @@ describe("configureWorkTools", () => {
     it("should elicit project when not provided and user accepts", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -1100,7 +1119,7 @@ describe("configureWorkTools", () => {
         },
       ]);
 
-      const result = await handler({ project: undefined, depth: 2 });
+      const result = await handler({ action: "list_iterations" as const, project: undefined, depth: 2 });
 
       expect(elicitMock).toHaveBeenCalledTimes(1);
       expect(mockWorkItemTrackingApi.getClassificationNodes).toHaveBeenCalledWith("ProjectAlpha", [], 2);
@@ -1110,8 +1129,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when project elicitation is declined", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_list_iterations");
-      if (!call) throw new Error("work_list_iterations tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -1119,7 +1138,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, depth: 2 });
+      const result = await handler({ action: "list_iterations" as const, project: undefined, depth: 2 });
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkItemTrackingApi.getClassificationNodes).not.toHaveBeenCalled();
@@ -1130,9 +1149,9 @@ describe("configureWorkTools", () => {
     it("should call postTeamIteration API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_assign_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockResolvedValue({
@@ -1147,6 +1166,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "assign" as const,
         project: "Fabrikam",
         team: "Fabrikam Team",
         iterations: [
@@ -1193,15 +1213,16 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_assign_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to assign iteration");
       (mockWorkApi.postTeamIteration as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "assign" as const,
         project: "Fabrikam",
         team: "Fabrikam Team",
         iterations: [
@@ -1222,14 +1243,15 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_assign_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "assign" as const,
         project: "Fabrikam",
         team: "Fabrikam Team",
         iterations: [
@@ -1250,14 +1272,15 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_assign_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_assign_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.postTeamIteration as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "assign" as const,
         project: "Fabrikam",
         team: "Fabrikam Team",
         iterations: [
@@ -1280,9 +1303,9 @@ describe("configureWorkTools", () => {
     it("should call createOrUpdateClassificationNode API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_create_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue({
@@ -1304,6 +1327,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "Fabrikam",
         iterations: [
           {
@@ -1358,15 +1382,16 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_create_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to create iteration");
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "create" as const,
         project: "Fabrikam",
         iterations: [
           {
@@ -1387,14 +1412,15 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_create_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "create" as const,
         project: "Fabrikam",
         iterations: [
           {
@@ -1415,14 +1441,15 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_create_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "create" as const,
         project: "Fabrikam",
         iterations: [
           {
@@ -1443,9 +1470,9 @@ describe("configureWorkTools", () => {
     it("should handle iterations without start and finish dates", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_create_iterations");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
 
-      if (!call) throw new Error("work_create_iterations tool not registered");
+      if (!call) throw new Error("work_iteration_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkItemTrackingApi.createOrUpdateClassificationNode as jest.Mock).mockResolvedValue({
@@ -1458,6 +1485,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "Fabrikam",
         iterations: [
           {
@@ -1503,8 +1531,8 @@ describe("configureWorkTools", () => {
     it("should call getCapacitiesWithIdentityRefAndTotals API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
@@ -1566,6 +1594,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1621,8 +1650,8 @@ describe("configureWorkTools", () => {
     it("should handle team with no capacity assigned", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
@@ -1632,6 +1661,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1648,13 +1678,14 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1670,8 +1701,8 @@ describe("configureWorkTools", () => {
     it("should handle undefined teamMembers array correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
@@ -1681,6 +1712,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1703,8 +1735,8 @@ describe("configureWorkTools", () => {
     it("should handle team member with undefined teamMember property", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
@@ -1726,6 +1758,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1758,14 +1791,15 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to retrieve team capacity");
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1781,13 +1815,14 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "SampleProject",
         team: "SampleProject Team",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
@@ -1803,8 +1838,8 @@ describe("configureWorkTools", () => {
     it("should properly simplify team member data by removing unwanted fields", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getCapacitiesWithIdentityRefAndTotals as jest.Mock).mockResolvedValue({
@@ -1844,6 +1879,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_capacity" as const,
         project: "TestProject",
         team: "TestTeam",
         iterationId: "test-iteration-id",
@@ -1894,8 +1930,8 @@ describe("configureWorkTools", () => {
     it("should elicit project when not provided and user accepts", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -1913,7 +1949,7 @@ describe("configureWorkTools", () => {
         ],
       });
 
-      const result = await handler({ project: undefined, team: "Team A", iterationId: "iter-1" });
+      const result = await handler({ action: "get_team_capacity" as const, project: undefined, team: "Team A", iterationId: "iter-1" });
 
       expect(elicitMock).toHaveBeenCalledTimes(1);
       expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).toHaveBeenCalled();
@@ -1923,8 +1959,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when project elicitation is declined", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_capacity");
-      if (!call) throw new Error("work_get_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -1932,7 +1968,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, team: "Team A", iterationId: "iter-1" });
+      const result = await handler({ action: "get_team_capacity" as const, project: undefined, team: "Team A", iterationId: "iter-1" });
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).not.toHaveBeenCalled();
@@ -1943,8 +1979,8 @@ describe("configureWorkTools", () => {
     it("should call updateCapacityWithIdentityRef API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
@@ -1976,6 +2012,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-123",
@@ -2042,8 +2079,8 @@ describe("configureWorkTools", () => {
     it("should handle updating capacity without daysOff", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
@@ -2062,6 +2099,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-456",
@@ -2112,8 +2150,8 @@ describe("configureWorkTools", () => {
     it("should handle updating capacity with multiple activities", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
@@ -2140,6 +2178,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-789",
@@ -2214,8 +2253,8 @@ describe("configureWorkTools", () => {
     it("should handle updating capacity with unassigned activity (empty name)", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
@@ -2239,6 +2278,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-000",
@@ -2305,13 +2345,14 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-123",
@@ -2334,8 +2375,8 @@ describe("configureWorkTools", () => {
     it("should handle undefined teamMember in API result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockResolvedValue({
@@ -2350,6 +2391,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-123",
@@ -2381,14 +2423,15 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to update capacity");
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-123",
@@ -2411,13 +2454,14 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_update_team_capacity");
-      if (!call) throw new Error("work_update_team_capacity tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_capacity_write");
+      if (!call) throw new Error("work_capacity_write tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.updateCapacityWithIdentityRef as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "update" as const,
         project: "TestProject",
         team: "TestTeam",
         teamMemberId: "test-user-id-123",
@@ -2442,8 +2486,8 @@ describe("configureWorkTools", () => {
     it("should call getTotalIterationCapacities API with the correct parameters and return the expected result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
@@ -2476,6 +2520,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2519,8 +2564,8 @@ describe("configureWorkTools", () => {
     it("should handle iteration with no teams assigned", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
@@ -2530,6 +2575,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2545,13 +2591,14 @@ describe("configureWorkTools", () => {
     it("should handle null API results correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2566,8 +2613,8 @@ describe("configureWorkTools", () => {
     it("should handle undefined teams array correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
@@ -2577,6 +2624,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2591,8 +2639,8 @@ describe("configureWorkTools", () => {
     it("should handle single team with capacity", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
@@ -2614,6 +2662,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SingleTeamProject",
         iterationId: "single-team-iteration-id",
       };
@@ -2646,14 +2695,15 @@ describe("configureWorkTools", () => {
     it("should handle API errors correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to retrieve iteration capacities");
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2668,13 +2718,14 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockRejectedValue("string error");
 
       const params = {
+        action: "get_iteration_capacities" as const,
         project: "SampleProject",
         iterationId: "299567e9-f6e6-4a9b-89c8-7a9722e949d7",
       };
@@ -2689,8 +2740,8 @@ describe("configureWorkTools", () => {
     it("should elicit project when not provided and user accepts", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -2702,7 +2753,7 @@ describe("configureWorkTools", () => {
         teams: [{ team: { id: "team-1", name: "Team One" } }],
       });
 
-      const result = await handler({ project: undefined, iterationId: "iter-1" });
+      const result = await handler({ action: "get_iteration_capacities" as const, project: undefined, iterationId: "iter-1" });
 
       expect(elicitMock).toHaveBeenCalledTimes(1);
       expect(mockWorkApi.getTotalIterationCapacities).toHaveBeenCalledWith("ProjectAlpha", "iter-1");
@@ -2712,8 +2763,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when project elicitation is declined", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_iteration_capacities");
-      if (!call) throw new Error("work_get_iteration_capacities tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -2721,7 +2772,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, iterationId: "iter-1" });
+      const result = await handler({ action: "get_iteration_capacities" as const, project: undefined, iterationId: "iter-1" });
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getTotalIterationCapacities).not.toHaveBeenCalled();
@@ -2732,8 +2783,8 @@ describe("configureWorkTools", () => {
     it("should call getTeamSettings and getTeamFieldValues APIs and return combined result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockResolvedValue({
@@ -2774,6 +2825,7 @@ describe("configureWorkTools", () => {
       });
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -2825,8 +2877,8 @@ describe("configureWorkTools", () => {
     it("should use default team when team is not provided", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockResolvedValue({
@@ -2851,6 +2903,7 @@ describe("configureWorkTools", () => {
       elicitMock.mockResolvedValueOnce({ action: "accept", content: { team: "Fabrikam Team" } });
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: undefined,
       };
@@ -2874,13 +2927,14 @@ describe("configureWorkTools", () => {
     it("should handle null team settings result", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -2895,8 +2949,8 @@ describe("configureWorkTools", () => {
     it("should handle null team field values gracefully", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockResolvedValue({
@@ -2915,6 +2969,7 @@ describe("configureWorkTools", () => {
       (mockWorkApi.getTeamFieldValues as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -2938,8 +2993,8 @@ describe("configureWorkTools", () => {
     it("should handle getTeamSettings API error correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       const testError = new Error("Failed to retrieve team settings");
@@ -2947,6 +3002,7 @@ describe("configureWorkTools", () => {
       (mockWorkApi.getTeamFieldValues as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -2960,8 +3016,8 @@ describe("configureWorkTools", () => {
     it("should handle getTeamFieldValues API error correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockResolvedValue({
@@ -2978,6 +3034,7 @@ describe("configureWorkTools", () => {
       (mockWorkApi.getTeamFieldValues as jest.Mock).mockRejectedValue(testError);
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -2991,14 +3048,15 @@ describe("configureWorkTools", () => {
     it("should handle unknown error type correctly", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockWorkApi.getTeamSettings as jest.Mock).mockRejectedValue("string error");
       (mockWorkApi.getTeamFieldValues as jest.Mock).mockResolvedValue(null);
 
       const params = {
+        action: "get_team_settings" as const,
         project: "Fabrikam",
         team: "Team A",
       };
@@ -3012,8 +3070,8 @@ describe("configureWorkTools", () => {
     it("should elicit project and team when not provided and user accepts", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -3030,7 +3088,7 @@ describe("configureWorkTools", () => {
       });
       (mockWorkApi.getTeamFieldValues as jest.Mock).mockResolvedValue(null);
 
-      const result = await handler({ project: undefined, team: undefined });
+      const result = await handler({ action: "get_team_settings" as const, project: undefined, team: undefined });
 
       expect(elicitMock).toHaveBeenCalledTimes(2);
       expect(mockWorkApi.getTeamSettings).toHaveBeenCalled();
@@ -3041,8 +3099,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when project elicitation is declined for team settings", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -3050,7 +3108,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, team: undefined });
+      const result = await handler({ action: "get_team_settings" as const, project: undefined, team: undefined });
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getTeamSettings).not.toHaveBeenCalled();
@@ -3059,8 +3117,8 @@ describe("configureWorkTools", () => {
     it("should return cancellation when team elicitation is declined for team settings", async () => {
       configureWorkTools(server, tokenProvider, connectionProvider);
 
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_get_team_settings");
-      if (!call) throw new Error("work_get_team_settings tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
       const [, , , handler] = call;
 
       (mockCoreApi.getProjects as jest.Mock).mockResolvedValue([{ id: "proj-1", name: "ProjectAlpha" }]);
@@ -3069,7 +3127,7 @@ describe("configureWorkTools", () => {
       const elicitMock = (server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput as jest.Mock;
       elicitMock.mockResolvedValueOnce({ action: "accept", content: { project: "ProjectAlpha" } }).mockResolvedValueOnce({ action: "decline" });
 
-      const result = await handler({ project: undefined, team: undefined });
+      const result = await handler({ action: "get_team_settings" as const, project: undefined, team: undefined });
 
       expect(result.content[0].text).toBe("Team selection cancelled.");
       expect(mockWorkApi.getTeamSettings).not.toHaveBeenCalled();

--- a/test/src/tools/work.test.ts
+++ b/test/src/tools/work.test.ts
@@ -1297,6 +1297,61 @@ describe("configureWorkTools", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error assigning iterations: Unknown error occurred");
     });
+
+    it("should return error when team is not provided", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
+      if (!call) throw new Error("work_iteration_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({
+        action: "assign" as const,
+        project: "Fabrikam",
+        team: undefined,
+        iterations: [{ identifier: "iter-id", path: "Fabrikam\\Sprint 1" }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Team is required for assign");
+      expect(mockWorkApi.postTeamIteration).not.toHaveBeenCalled();
+    });
+
+    it("should return error when all iterations have missing identifier or path", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
+      if (!call) throw new Error("work_iteration_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({
+        action: "assign" as const,
+        project: "Fabrikam",
+        team: "Fabrikam Team",
+        iterations: [{ identifier: undefined, path: undefined }],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("No iterations were assigned to the team");
+      expect(mockWorkApi.postTeamIteration).not.toHaveBeenCalled();
+    });
+
+    it("should return error for an unknown action", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
+      if (!call) throw new Error("work_iteration_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({
+        action: "invalid_action" as unknown as "create",
+        project: "Fabrikam",
+        iterations: [],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Unknown action: invalid_action");
+    });
   });
 
   describe("create_iterations", () => {
@@ -1524,6 +1579,43 @@ describe("configureWorkTools", () => {
           2
         )
       );
+    });
+
+    it("should skip iterations without iterationName and return error when none created", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
+      if (!call) throw new Error("work_iteration_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({
+        action: "create" as const,
+        project: "Fabrikam",
+        iterations: [{ startDate: "2025-01-01T00:00:00Z", finishDate: "2025-01-14T00:00:00Z" }],
+      });
+
+      expect(mockWorkItemTrackingApi.createOrUpdateClassificationNode).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("No iterations were created");
+    });
+
+    it("should return generic error when connection fails with an unmapped action", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work_iteration_write");
+      if (!call) throw new Error("work_iteration_write tool not registered");
+      const [, , , handler] = call;
+
+      (connectionProvider as jest.Mock).mockRejectedValueOnce(new Error("Connection failed"));
+
+      const result = await handler({
+        action: "invalid_action" as unknown as "create",
+        project: "Fabrikam",
+        iterations: [],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error: Connection failed");
     });
   });
 
@@ -1972,6 +2064,62 @@ describe("configureWorkTools", () => {
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).not.toHaveBeenCalled();
+    });
+
+    it("should return error when team is not provided", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "get_team_capacity" as const, project: "SampleProject", team: undefined, iterationId: "iter-1" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Team is required for get_team_capacity");
+      expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).not.toHaveBeenCalled();
+    });
+
+    it("should return error when iterationId is not provided", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "get_team_capacity" as const, project: "SampleProject", team: "SampleTeam", iterationId: undefined });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("iterationId is required for get_team_capacity");
+      expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).not.toHaveBeenCalled();
+    });
+
+    it("should return error for an unknown action", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "invalid_action" as unknown as "list_iterations", project: "SampleProject" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Unknown action: invalid_action");
+    });
+
+    it("should return generic error when connection fails with an unmapped action", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      (connectionProvider as jest.Mock).mockRejectedValueOnce(new Error("Connection failed"));
+
+      const result = await handler({ action: "invalid_action" as unknown as "list_iterations", project: "SampleProject" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error: Connection failed");
     });
   });
 
@@ -2776,6 +2924,40 @@ describe("configureWorkTools", () => {
 
       expect(result.content[0].text).toBe("Project selection cancelled.");
       expect(mockWorkApi.getTotalIterationCapacities).not.toHaveBeenCalled();
+    });
+
+    it("should return error when iterationId is not provided", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "get_iteration_capacities" as const, project: "SampleProject", iterationId: undefined });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("iterationId is required for get_iteration_capacities");
+      expect(mockWorkApi.getTotalIterationCapacities).not.toHaveBeenCalled();
+    });
+
+    it("should return error when teams array is empty", async () => {
+      configureWorkTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "work");
+      if (!call) throw new Error("work tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkApi.getTotalIterationCapacities as jest.Mock).mockResolvedValue({
+        teams: [],
+        totalCapacityPerDay: 0,
+        totalDaysOff: 0,
+      });
+
+      const result = await handler({ action: "get_iteration_capacities" as const, project: "SampleProject", iterationId: "iter-1" });
+
+      expect(mockWorkApi.getTotalIterationCapacities).toHaveBeenCalledWith("SampleProject", "iter-1");
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("No iteration capacity assigned to the teams");
     });
   });
 


### PR DESCRIPTION

This pull request updates the tests for the `configureWorkTools` function to reflect recent changes in tool registration and handler invocation. The main focus is on consolidating tool names and ensuring the correct action parameters are passed in test cases.

**Test suite alignment with new tool registration:**

* Updated all test cases to look for the `"work"` tool instead of the previous `"work_list_team_iterations"` and `"work_list_iterations"` tool names, ensuring consistency with the refactored tool registration logic. [[1]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL86-R87) [[2]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL135-R144) [[3]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL158-R167) [[4]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL180-R190) [[5]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL202-R207) [[6]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL225-R238) [[7]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL243-R248) [[8]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL262-R267) [[9]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL285-R290) [[10]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL394-R400) [[11]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL438-R445) [[12]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL494-R502) [[13]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL526-R541) [[14]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL547-R563) [[15]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL568-R579) [[16]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL612-R631) [[17]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL634-R653)

**Parameterization improvements:**

* Added the appropriate `action` field (e.g., `"list_team_iterations"` or `"list_iterations"`) to the parameters passed to tool handlers in all relevant test cases, ensuring that the handler receives the correct context for each action. [[1]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR103) [[2]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL214-R218) [[3]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL253-R257) [[4]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL272-R276) [[5]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR344) [[6]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR417) [[7]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR472) [[8]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR519) [[9]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caR596) [[10]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL634-R653)

These changes keep the test suite in sync with the updated implementation and improve clarity and maintainability.

## GitHub issue number
N/A

## **Associated Risks**

Changing signatures of tools and consolidating. Starting with smaller toolsets to make sure this goes well.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
Ran several manual tests. Updated the automated tests
