### PR TITLE
fix: correct advsec_get_alerts secret alert filtering and confidenceLevels default (#1395)

### DIFF
--- a/src/tools/advanced-security.ts
+++ b/src/tools/advanced-security.ts
@@ -15,7 +15,7 @@ const ADVSEC_TOOLS = {
 function configureAdvSecTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     ADVSEC_TOOLS.get_alerts,
-    "Retrieve Advanced Security alerts for a repository. Results are scoped to the specified project and repository. For secret alerts, branch filters (onlyDefaultBranch, ref) are not applicable and are ignored. When alertType is not specified and a branch filter is applied (onlyDefaultBranch=false or ref set), secret alerts may be excluded from the results because branch filters do not apply to secrets; query with alertType 'Secret' to retrieve all secret alerts.",
+    "Retrieve Advanced Security alerts for a repository. Results are scoped to the specified project and repository. Branch filters (onlyDefaultBranch, ref) apply only to code, dependency, and license alerts; they are not applicable to secret alerts and are ignored by the service, so they neither include nor exclude secrets. To narrow secret alerts by confidence, pass a single 'confidenceLevels' value ('High' or 'Other'); selecting every level is treated as no confidence filter.",
     {
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       repository: z.string().describe("The name or ID of the repository to get alerts for."),
@@ -49,9 +49,8 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
       confidenceLevels: z
         .array(z.enum(getEnumKeys(Confidence) as [string, ...string[]]))
         .optional()
-        .default(getEnumKeys(Confidence))
         .describe(
-          "Only applicable to secret alerts. Accepted values are 'High' and 'Other'; both must be included to return secrets of all confidence levels. Defaults to all confidence levels ('High' and 'Other') so no secrets are hidden by confidence; if the filter were omitted at the service level, only high-confidence secrets would be returned."
+          "Only applicable to secret alerts. Accepted values are 'High' and 'Other'. Pass a single value (e.g. ['High']) to narrow secrets to that confidence level. Leave unset to return secrets without a confidence filter. Do not select both levels to widen results: the Alerts service does not accept a multi-value confidence filter and would return no alerts, so this tool treats an all-levels selection as no filter and omits it."
         ),
       validity: z
         .array(z.enum(getEnumKeys(AlertValidityStatus) as [string, ...string[]]))
@@ -78,6 +77,14 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
         // the result set can contain secrets (an explicit "secret" type or no type filter at all).
         const canIncludeSecrets = !alertType || isSecretOnly;
 
+        // The Alerts service does not accept the multi-value (comma-serialized) confidence filter
+        // that the SDK emits: selecting every level (e.g. both "High" and "Other") returns zero
+        // alerts, and it is a no-op filter regardless. Only forward confidenceLevels when it
+        // narrows the result to a proper subset (a single level); otherwise omit it so secrets are
+        // returned without a confidence filter instead of an empty set.
+        const confidenceLevelValues = confidenceLevels ? mapStringArrayToEnum(confidenceLevels, Confidence) : [];
+        const narrowsByConfidence = confidenceLevelValues.length > 0 && confidenceLevelValues.length < getEnumKeys(Confidence).length;
+
         const criteria = {
           ...(alertType && { alertType: mapStringToEnum(alertType, AlertType) }),
           ...(states && { states: mapStringArrayToEnum(states, State) }),
@@ -87,7 +94,7 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
           ...(toolName && { toolName }),
           ...(!isSecretOnly && ref && { ref }),
           ...(!isSecretOnly && onlyDefaultBranch !== undefined && { onlyDefaultBranch }),
-          ...(canIncludeSecrets && confidenceLevels && { confidenceLevels: mapStringArrayToEnum(confidenceLevels, Confidence) }),
+          ...(canIncludeSecrets && narrowsByConfidence && { confidenceLevels: confidenceLevelValues }),
           ...(canIncludeSecrets && validity && { validity: mapStringArrayToEnum(validity, AlertValidityStatus) }),
         };
 

--- a/src/tools/advanced-security.ts
+++ b/src/tools/advanced-security.ts
@@ -15,7 +15,7 @@ const ADVSEC_TOOLS = {
 function configureAdvSecTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
   server.tool(
     ADVSEC_TOOLS.get_alerts,
-    "Retrieve Advanced Security alerts for a repository.",
+    "Retrieve Advanced Security alerts for a repository. Results are scoped to the specified project and repository. For secret alerts, branch filters (onlyDefaultBranch, ref) are not applicable and are ignored. When alertType is not specified and a branch filter is applied (onlyDefaultBranch=false or ref set), secret alerts may be excluded from the results because branch filters do not apply to secrets; query with alertType 'Secret' to retrieve all secret alerts.",
     {
       project: z.string().describe("The name or ID of the Azure DevOps project."),
       repository: z.string().describe("The name or ID of the repository to get alerts for."),
@@ -34,17 +34,31 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
       ruleId: z.string().optional().describe("Filter alerts by rule ID."),
       ruleName: z.string().optional().describe("Filter alerts by rule name."),
       toolName: z.string().optional().describe("Filter alerts by tool name."),
-      ref: z.string().optional().describe("Filter alerts by git reference (branch). If not provided and onlyDefaultBranch is true, only includes alerts from default branch."),
-      onlyDefaultBranch: z.boolean().optional().default(true).describe("If true, only return alerts found on the default branch. Defaults to true."),
+      ref: z
+        .string()
+        .optional()
+        .describe(
+          "Filter non-secret alerts by git reference (branch), e.g. 'refs/heads/main'. When omitted and onlyDefaultBranch is true, only alerts on the default branch are returned. Not applicable to secret alerts and ignored by this tool when alertType is 'Secret'. When alertType is unspecified, this filter is still sent and may exclude secret alerts from the results; query alertType 'Secret' separately to retrieve all secrets."
+        ),
+      onlyDefaultBranch: z
+        .boolean()
+        .optional()
+        .describe(
+          "For non-secret alerts: if true (the service default when omitted) only return alerts found on the default branch; if false, return alerts from all branches. Ignored when 'ref' is provided. Not applicable to secret alerts and ignored by this tool when alertType is 'Secret'. When alertType is unspecified, this filter is still sent and may exclude secret alerts from the results; query alertType 'Secret' separately to retrieve all secrets."
+        ),
       confidenceLevels: z
         .array(z.enum(getEnumKeys(Confidence) as [string, ...string[]]))
         .optional()
-        .default(["high", "other"])
-        .describe("Filter alerts by confidence levels. Only applicable for secret alerts. Defaults to both 'high' and 'other'."),
+        .default(getEnumKeys(Confidence))
+        .describe(
+          "Only applicable to secret alerts. Accepted values are 'High' and 'Other'; both must be included to return secrets of all confidence levels. Defaults to all confidence levels ('High' and 'Other') so no secrets are hidden by confidence; if the filter were omitted at the service level, only high-confidence secrets would be returned."
+        ),
       validity: z
         .array(z.enum(getEnumKeys(AlertValidityStatus) as [string, ...string[]]))
         .optional()
-        .describe("Filter alerts by validity status. Only applicable for secret alerts."),
+        .describe(
+          "Only applicable to secret alerts. If omitted, alerts of all validity statuses are returned (no validity filter is applied). Filtering by validity may return fewer alerts than 'top'; use the continuation token to fetch any remaining alerts."
+        ),
       top: z.coerce.number().optional().default(100).describe("Maximum number of alerts to return. Defaults to 100."),
       orderBy: z.enum(["id", "firstSeen", "lastSeen", "fixedOn", "severity"]).optional().default("severity").describe("Order results by specified field. Defaults to 'severity'."),
       continuationToken: z.string().optional().describe("Continuation token for pagination."),
@@ -54,7 +68,16 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
         const connection = await connectionProvider();
         const alertApi = await connection.getAlertApi();
 
-        const isSecretAlert = !alertType || alertType.toLowerCase() === "secret";
+        const normalizedAlertType = alertType?.toLowerCase();
+        // "onlyDefaultBranch" and "ref" are not applicable to secret alerts (secrets are not
+        // branch-scoped and carry a null gitRef). Forwarding them for a secret-only query diverges
+        // from the REST API / Advanced Security UI and can incorrectly return no alerts, so only
+        // include them when the query is not restricted to secret alerts.
+        const isSecretOnly = normalizedAlertType === "secret";
+        // "confidenceLevels" and "validity" only apply to secret alerts, so include them whenever
+        // the result set can contain secrets (an explicit "secret" type or no type filter at all).
+        const canIncludeSecrets = !alertType || isSecretOnly;
+
         const criteria = {
           ...(alertType && { alertType: mapStringToEnum(alertType, AlertType) }),
           ...(states && { states: mapStringArrayToEnum(states, State) }),
@@ -62,10 +85,10 @@ function configureAdvSecTools(server: McpServer, _: () => Promise<string>, conne
           ...(ruleId && { ruleId }),
           ...(ruleName && { ruleName }),
           ...(toolName && { toolName }),
-          ...(ref && { ref }),
-          ...(onlyDefaultBranch !== undefined && { onlyDefaultBranch }),
-          ...(isSecretAlert && confidenceLevels && { confidenceLevels: mapStringArrayToEnum(confidenceLevels, Confidence) }),
-          ...(isSecretAlert && validity && { validity: mapStringArrayToEnum(validity, AlertValidityStatus) }),
+          ...(!isSecretOnly && ref && { ref }),
+          ...(!isSecretOnly && onlyDefaultBranch !== undefined && { onlyDefaultBranch }),
+          ...(canIncludeSecrets && confidenceLevels && { confidenceLevels: mapStringArrayToEnum(confidenceLevels, Confidence) }),
+          ...(canIncludeSecrets && validity && { validity: mapStringArrayToEnum(validity, AlertValidityStatus) }),
         };
 
         const result = await alertApi.getAlerts(

--- a/test/src/tools/advanced-security.test.ts
+++ b/test/src/tools/advanced-security.test.ts
@@ -6,6 +6,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { Alert, AlertType, AlertValidityStatus, Confidence, Severity, State } from "azure-devops-node-api/interfaces/AlertInterfaces";
 import { PagedList } from "azure-devops-node-api/interfaces/common/VSSInterfaces";
+import { z } from "zod";
 import { configureAdvSecTools } from "../../../src/tools/advanced-security";
 
 type TokenProviderMock = () => Promise<string>;
@@ -612,6 +613,62 @@ describe("configureAdvSecTools", () => {
       expect(criteria).not.toHaveProperty("validity");
     });
 
+    it("should not send onlyDefaultBranch or ref in criteria for secret alerts", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , , handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      // Branch filters are not applicable to secret alerts and must be dropped so that the
+      // tool matches the REST API / Advanced Security UI instead of returning an empty set.
+      const params = {
+        project: "test-project",
+        repository: "test-repo",
+        alertType: "secret",
+        states: ["active"],
+        onlyDefaultBranch: false,
+        ref: "refs/heads/feature-branch",
+      };
+
+      await handler(params);
+
+      const lastCall = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0];
+      const criteria = lastCall[4];
+      expect(criteria).toHaveProperty("alertType", AlertType.Secret);
+      expect(criteria).toHaveProperty("states", [State.Active]);
+      expect(criteria).not.toHaveProperty("onlyDefaultBranch");
+      expect(criteria).not.toHaveProperty("ref");
+    });
+
+    it("should still send onlyDefaultBranch and ref for non-secret alert queries", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , , handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      const params = {
+        project: "test-project",
+        repository: "test-repo",
+        alertType: "code",
+        onlyDefaultBranch: false,
+        ref: "refs/heads/feature-branch",
+      };
+
+      await handler(params);
+
+      const lastCall = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0];
+      const criteria = lastCall[4];
+      expect(criteria).toHaveProperty("alertType", AlertType.Code);
+      expect(criteria).toHaveProperty("onlyDefaultBranch", false);
+      expect(criteria).toHaveProperty("ref", "refs/heads/feature-branch");
+    });
+
     it("should handle non-Error exception types", async () => {
       configureAdvSecTools(server, tokenProvider, connectionProvider);
 
@@ -631,6 +688,104 @@ describe("configureAdvSecTools", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error fetching Advanced Security alerts: Unknown error occurred");
+    });
+
+    // The following tests drive the real Zod schema (schema = call[2]) instead of calling the
+    // handler directly, so that schema-level defaults and enum validation are exercised the same
+    // way the MCP runtime applies them before the handler runs.
+    it("applies schema defaults (confidenceLevels, top, orderBy) and drops branch filters for a secret query", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , schema, handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      // Enum values must be the PascalCase enum keys the schema exposes (e.g. "Secret"), and
+      // confidenceLevels is intentionally omitted so the schema default is applied.
+      const parsed = z.object(schema).parse({
+        project: "test-project",
+        repository: "test-repo",
+        alertType: "Secret",
+      });
+
+      await handler(parsed);
+
+      expect(mockAlertApi.getAlerts).toHaveBeenCalledWith(
+        "test-project",
+        "test-repo",
+        100, // top default
+        "severity", // orderBy default
+        expect.objectContaining({
+          alertType: AlertType.Secret,
+          confidenceLevels: [Confidence.High, Confidence.Other],
+        }),
+        undefined, // expand
+        undefined // continuationToken
+      );
+
+      const criteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
+      expect(criteria).not.toHaveProperty("onlyDefaultBranch");
+      expect(criteria).not.toHaveProperty("ref");
+      expect(criteria).not.toHaveProperty("validity");
+    });
+
+    it("does not throw when confidenceLevels is omitted for a minimal query", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , schema, handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      // Regression: the schema default for confidenceLevels must be valid against its own enum,
+      // otherwise parsing a call that omits confidenceLevels (the common case) throws.
+      const parseInput = () =>
+        z.object(schema).parse({
+          project: "test-project",
+          repository: "test-repo",
+        });
+      expect(parseInput).not.toThrow();
+
+      await handler(parseInput());
+
+      expect(mockAlertApi.getAlerts).toHaveBeenLastCalledWith(
+        "test-project",
+        "test-repo",
+        100, // top default
+        "severity", // orderBy default
+        expect.objectContaining({
+          confidenceLevels: [Confidence.High, Confidence.Other],
+        }),
+        undefined, // expand
+        undefined // continuationToken
+      );
+    });
+
+    it("still forwards onlyDefaultBranch for a mixed (unspecified alertType) query, which can exclude secrets", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , schema, handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      // Documents the known limitation: with no alertType, the branch filter is still sent, so a
+      // caller asking for all branches (onlyDefaultBranch=false) may not receive secret alerts.
+      const parsed = z.object(schema).parse({
+        project: "test-project",
+        repository: "test-repo",
+        onlyDefaultBranch: false,
+      });
+
+      await handler(parsed);
+
+      const criteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
+      expect(criteria).toHaveProperty("onlyDefaultBranch", false);
+      expect(criteria).toHaveProperty("confidenceLevels", [Confidence.High, Confidence.Other]);
     });
   });
 

--- a/test/src/tools/advanced-security.test.ts
+++ b/test/src/tools/advanced-security.test.ts
@@ -693,7 +693,7 @@ describe("configureAdvSecTools", () => {
     // The following tests drive the real Zod schema (schema = call[2]) instead of calling the
     // handler directly, so that schema-level defaults and enum validation are exercised the same
     // way the MCP runtime applies them before the handler runs.
-    it("applies schema defaults (confidenceLevels, top, orderBy) and drops branch filters for a secret query", async () => {
+    it("applies schema defaults (top, orderBy) and drops branch and confidence filters for a secret query", async () => {
       configureAdvSecTools(server, tokenProvider, connectionProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
@@ -702,8 +702,9 @@ describe("configureAdvSecTools", () => {
 
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
 
-      // Enum values must be the PascalCase enum keys the schema exposes (e.g. "Secret"), and
-      // confidenceLevels is intentionally omitted so the schema default is applied.
+      // Enum values must be the PascalCase enum keys the schema exposes (e.g. "Secret").
+      // confidenceLevels is intentionally omitted; it has no default, so no confidence filter is
+      // sent (an all-levels filter makes the Alerts service return zero alerts).
       const parsed = z.object(schema).parse({
         project: "test-project",
         repository: "test-repo",
@@ -719,19 +720,19 @@ describe("configureAdvSecTools", () => {
         "severity", // orderBy default
         expect.objectContaining({
           alertType: AlertType.Secret,
-          confidenceLevels: [Confidence.High, Confidence.Other],
         }),
         undefined, // expand
         undefined // continuationToken
       );
 
       const criteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
+      expect(criteria).not.toHaveProperty("confidenceLevels");
       expect(criteria).not.toHaveProperty("onlyDefaultBranch");
       expect(criteria).not.toHaveProperty("ref");
       expect(criteria).not.toHaveProperty("validity");
     });
 
-    it("does not throw when confidenceLevels is omitted for a minimal query", async () => {
+    it("does not throw and sends no confidence filter when confidenceLevels is omitted for a minimal query", async () => {
       configureAdvSecTools(server, tokenProvider, connectionProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
@@ -740,8 +741,8 @@ describe("configureAdvSecTools", () => {
 
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
 
-      // Regression: the schema default for confidenceLevels must be valid against its own enum,
-      // otherwise parsing a call that omits confidenceLevels (the common case) throws.
+      // Omitting confidenceLevels (the common case) must not throw and must NOT send a confidence
+      // filter: an all-levels filter is rejected by the Alerts service and returns zero alerts.
       const parseInput = () =>
         z.object(schema).parse({
           project: "test-project",
@@ -751,20 +752,20 @@ describe("configureAdvSecTools", () => {
 
       await handler(parseInput());
 
+      const criteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
+      expect(criteria).not.toHaveProperty("confidenceLevels");
       expect(mockAlertApi.getAlerts).toHaveBeenLastCalledWith(
         "test-project",
         "test-repo",
         100, // top default
         "severity", // orderBy default
-        expect.objectContaining({
-          confidenceLevels: [Confidence.High, Confidence.Other],
-        }),
+        criteria,
         undefined, // expand
         undefined // continuationToken
       );
     });
 
-    it("still forwards onlyDefaultBranch for a mixed (unspecified alertType) query, which can exclude secrets", async () => {
+    it("forwards onlyDefaultBranch for a mixed (unspecified alertType) query without adding a confidence filter", async () => {
       configureAdvSecTools(server, tokenProvider, connectionProvider);
 
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
@@ -773,8 +774,8 @@ describe("configureAdvSecTools", () => {
 
       (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
 
-      // Documents the known limitation: with no alertType, the branch filter is still sent, so a
-      // caller asking for all branches (onlyDefaultBranch=false) may not receive secret alerts.
+      // With no alertType the branch filter is still forwarded (it applies to non-secret alerts and
+      // is ignored by the service for secrets). No confidenceLevels default is added.
       const parsed = z.object(schema).parse({
         project: "test-project",
         repository: "test-repo",
@@ -785,7 +786,39 @@ describe("configureAdvSecTools", () => {
 
       const criteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
       expect(criteria).toHaveProperty("onlyDefaultBranch", false);
-      expect(criteria).toHaveProperty("confidenceLevels", [Confidence.High, Confidence.Other]);
+      expect(criteria).not.toHaveProperty("confidenceLevels");
+    });
+
+    it("sends a single confidence level but omits the filter when all levels are selected", async () => {
+      configureAdvSecTools(server, tokenProvider, connectionProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "advsec_get_alerts");
+      if (!call) throw new Error("advsec_get_alerts tool not registered");
+      const [, , schema, handler] = call;
+
+      (mockAlertApi.getAlerts as jest.Mock).mockResolvedValue([]);
+
+      // A single confidence level narrows the query and is forwarded.
+      const single = z.object(schema).parse({
+        project: "test-project",
+        repository: "test-repo",
+        alertType: "Secret",
+        confidenceLevels: ["High"],
+      });
+      await handler(single);
+      const singleCriteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[0][4];
+      expect(singleCriteria).toHaveProperty("confidenceLevels", [Confidence.High]);
+
+      // Selecting every level is a no-op the Alerts service rejects (returns zero), so it is omitted.
+      const all = z.object(schema).parse({
+        project: "test-project",
+        repository: "test-repo",
+        alertType: "Secret",
+        confidenceLevels: ["High", "Other"],
+      });
+      await handler(all);
+      const allCriteria = (mockAlertApi.getAlerts as jest.Mock).mock.calls[1][4];
+      expect(allCriteria).not.toHaveProperty("confidenceLevels");
     });
   });
 


### PR DESCRIPTION
Fixes #1395

## Summary
`advsec_get_alerts` returned an empty array for secret alerts that exist (and are visible in the Advanced Security UI). The root cause is the tool's `confidenceLevels` handling: the schema **force-defaulted** it to all levels (`[High, Other]`), and the `azure-devops-node-api` SDK serializes a multi-value confidence filter as `criteria.confidenceLevels=0,1` — a form the Alerts service rejects by returning **zero** alerts. So every secret query silently sent a filter that guaranteed an empty result. This PR removes that default, forwards `confidenceLevels` only when it narrows to a single level, and corrects the related secret-alert request construction. Verified end-to-end against a live org.

## Root cause — `confidenceLevels` multi-value filter
- The Alerts service does **not** accept the multi-value (comma-serialized) confidence filter the SDK emits. `criteria.confidenceLevels=0,1` (both `High` and `Other`) returns **0** alerts; a single value (`=0`) works.
- The schema force-defaulted `confidenceLevels` to every level, so *every* secret query — even one that intended no confidence filter — sent the broken `0,1` and got `[]`. This is the actual cause of the "secret alerts return empty" reports in #1395.
- **Fix:** removed the forced default; the tool now forwards `confidenceLevels` only when it narrows the result to a proper subset (a single level), and omits it when all — or no — levels are selected (all levels = no filter anyway).

## Other changes
- **Secret branch filters:** `onlyDefaultBranch` and `ref` are "Not applicable for secret alerts" per the REST API (secrets carry `gitRef: null`). For an explicit `alertType: "Secret"` query the tool no longer sends them. Live testing confirmed these filters are a no-op for secrets (they neither include nor exclude), so this is a correctness/clarity change rather than the root-cause fix.
- **Zod default crash (found while fixing this):** the original default was lowercase `["high","other"]` while the schema enum keys are PascalCase, so Zod threw `invalid_enum_value` whenever `confidenceLevels` was omitted. Removing the default eliminates this class of bug entirely.
- **Descriptions updated:** the tool and parameter descriptions now state that branch filters apply only to code/dependency/license alerts, and that a single `confidenceLevels` value narrows secrets while selecting every level is treated as no filter.

## Verification (live org)
Ran directly against a live Advanced Security repository with 4 open secret alerts:

| criteria | result |
| --- | --- |
| `{ alertType: Secret }` | 4 secrets |
| `{ alertType: Secret, confidenceLevels: [High, Other] }` | **0** (multi-value rejected by service) |
| `{ alertType: Secret, confidenceLevels: [High] }` | 4 |
| `{ alertType: Secret, confidenceLevels: [Other] }` | 0 (all 4 are High confidence) |
| `{ alertType: Secret, onlyDefaultBranch: false }` | 4 (branch flag ignored for secrets) |

Through the fixed tool, an `alertType: "Secret"` query — including one that selects both confidence levels — now returns the alerts instead of `[]`.

## Tests
- Schema-driven tests that parse through the real Zod schema; updated to assert that no `confidenceLevels` default is sent, that a single level is forwarded, and that an all-levels selection is omitted.
- `npx jest`: **1021 passed / 18 suites**. `tsc --noEmit`: clean. `node scripts/build-validate-tools.js`: clean.
