### PR TITLE
fix: remove preinstall step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-devops/mcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-devops/mcp",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npm config set registry https://registry.npmjs.org/",
     "prebuild": "node -p \"'export const packageVersion = ' + JSON.stringify(require('./package.json').version) + ';\\n'\" > src/version.ts && prettier --write src/version.ts",
     "validate-tools": "tsc --noEmit && node scripts/build-validate-tools.js",
     "build": "tsc && shx chmod +x dist/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-devops/mcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "mcpName": "microsoft.com/azure-devops",
   "description": "MCP server for interacting with Azure DevOps",
   "license": "MIT",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const packageVersion = "2.8.0";
+export const packageVersion = "2.8.1";


### PR DESCRIPTION
Remove script that maybe in conflict with enterprise or engineering team settings/env

As a backup there is mention of that step in troubleshooting guide: https://github.com/microsoft/azure-devops-mcp/blob/544f445599e22862dc4af2a8c39f8f0b9db9070b/docs/TROUBLESHOOTING.md?plain=1#L63



## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

_Replace_ with use cases tested and models used
