### PR TITLE
feat(pipelines): add pipelines_rename_pipeline tool

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -24,6 +24,7 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 | Tool                                                                                                  | Description                                       |
 | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | [mcp_ado_pipelines_create_pipeline](#mcp_ado_pipelines_create_pipeline)                               | Create a new pipeline with YAML configuration     |
+| [mcp_ado_pipelines_rename_pipeline](#mcp_ado_pipelines_rename_pipeline)                               | Rename an existing pipeline (build definition)    |
 | [mcp_ado_pipelines_get_builds](#mcp_ado_pipelines_get_builds)                                         | Retrieve a list of builds with optional filters   |
 | [mcp_ado_pipelines_get_build_status](#mcp_ado_pipelines_get_build_status)                             | Get the status of a specific build                |
 | [mcp_ado_pipelines_get_build_log](#mcp_ado_pipelines_get_build_log)                                   | Retrieve complete logs for a build                |
@@ -190,6 +191,13 @@ Creates a pipeline definition with YAML configuration for a given project.
 
 - **Required**: `project`, `name`, `yamlPath`, `repositoryType`, `repositoryName`
 - **Optional**: `folder`, `repositoryConnectionId`, `repositoryId`
+
+#### mcp_ado_pipelines_rename_pipeline
+
+Renames an existing pipeline (build definition) in a given project.
+
+- **Required**: `project`, `pipelineId`, `name`
+- **Optional**: None
 
 #### mcp_ado_pipelines_get_builds
 

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -22,6 +22,7 @@ const PIPELINE_TOOLS = {
   pipelines_get_build_status: "pipelines_get_build_status",
   pipelines_update_build_stage: "pipelines_update_build_stage",
   pipelines_create_pipeline: "pipelines_create_pipeline",
+  pipelines_rename_pipeline: "pipelines_rename_pipeline",
   pipelines_get_run: "pipelines_get_run",
   pipelines_list_runs: "pipelines_list_runs",
   pipelines_run_pipeline: "pipelines_run_pipeline",
@@ -181,6 +182,28 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
       const newPipeline = await pipelinesApi.createPipeline(createPipelineParams, project);
       return {
         content: [{ type: "text", text: JSON.stringify(newPipeline, null, 2) }],
+      };
+    }
+  );
+
+  server.tool(
+    PIPELINE_TOOLS.pipelines_rename_pipeline,
+    "Renames an existing pipeline (build definition) in a given project.",
+    {
+      project: z.string().describe("Project ID or name that contains the pipeline."),
+      pipelineId: z.coerce.number().min(1).describe("ID of the pipeline (build definition) to rename."),
+      name: z.string().min(1).describe("The new name for the pipeline."),
+    },
+    async ({ project, pipelineId, name }) => {
+      const connection = await connectionProvider();
+      const buildApi = await connection.getBuildApi();
+
+      const definition = await buildApi.getDefinition(project, pipelineId);
+      definition.name = name;
+      const updatedDefinition = await buildApi.updateDefinition(definition, project, pipelineId);
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(updatedDefinition, null, 2) }],
       };
     }
   );

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1344,6 +1344,78 @@ describe("configurePipelineTools", () => {
     });
   });
 
+  describe("pipelines_rename_pipeline tool", () => {
+    it("should fetch the definition, update its name and return the updated definition", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_rename_pipeline");
+      if (!call) throw new Error("pipelines_rename_pipeline tool not registered");
+      const [, , , handler] = call;
+
+      const existingDefinition = { id: 42, name: "Old Name", revision: 3 };
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue(existingDefinition),
+        updateDefinition: jest.fn().mockResolvedValue({ id: 42, name: "New Name", revision: 4 }),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        pipelineId: 42,
+        name: "New Name",
+      };
+
+      const result = await handler(params);
+
+      expect(mockBuildApi.getDefinition).toHaveBeenCalledWith("test-project", 42);
+      expect(mockBuildApi.updateDefinition).toHaveBeenCalledWith({ id: 42, name: "New Name", revision: 3 }, "test-project", 42);
+      expect(result.content[0].text).toBe(JSON.stringify({ id: 42, name: "New Name", revision: 4 }, null, 2));
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("should propagate errors when the definition cannot be found", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_rename_pipeline");
+      if (!call) throw new Error("pipelines_rename_pipeline tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockRejectedValue(new Error("Definition not found")),
+        updateDefinition: jest.fn(),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        pipelineId: 999,
+        name: "New Name",
+      };
+
+      await expect(handler(params)).rejects.toThrow("Definition not found");
+      expect(mockBuildApi.updateDefinition).not.toHaveBeenCalled();
+    });
+
+    it("should propagate errors from updateDefinition", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_rename_pipeline");
+      if (!call) throw new Error("pipelines_rename_pipeline tool not registered");
+      const [, , , handler] = call;
+
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue({ id: 42, name: "Old Name" }),
+        updateDefinition: jest.fn().mockRejectedValue(new Error("API failure")),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const params = {
+        project: "test-project",
+        pipelineId: 42,
+        name: "New Name",
+      };
+
+      await expect(handler(params)).rejects.toThrow("API failure");
+    });
+  });
+
   describe("pipelines_list_runs tool", () => {
     it("should call listRuns with correct parameters", async () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);


### PR DESCRIPTION
Adds a new `pipelines_rename_pipeline` tool to rename an existing pipeline definition.

The Pipelines API only exposes pipeline creation (`pipelines_create_pipeline`) — there was no way to rename an existing pipeline definition. This tool fills that gap by renaming a pipeline (build definition) via the Build API: it fetches the definition, updates its `name`, and persists it with `updateDefinition`.

**Parameters**
- `project` (required) — Project ID or name that contains the pipeline
- `pipelineId` (required) — ID of the pipeline (build definition) to rename
- `name` (required) — The new name for the pipeline

## GitHub issue number

Closes #1426

## **Associated Risks**

Low. The tool performs a read (`getDefinition`) followed by an update (`updateDefinition`) scoped to the provided `pipelineId`/`project`. Only the `name` field of the fetched definition is mutated; all other definition properties are preserved and round-tripped back untouched. No new dependencies are introduced.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- Added unit tests in `test/src/tools/pipelines.test.ts` covering: successful rename (verifies `getDefinition` is called, the name is mutated, and `updateDefinition` receives the updated definition), error propagation when the definition is not found (and that `updateDefinition` is not called), and error propagation from `updateDefinition`.
- `npm test test/src/tools/pipelines.test.ts` → all 79 tests pass.
- `npm run build` (tsc) succeeds.
- `npm run format` reports the changed files as already formatted.