### PR TITLE
Consolidating `test-plan` tools to match remote

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -77,17 +77,19 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 
 ### Test Plans
 
-| Tool                                                                                                  | Description                            |
-| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| [mcp_ado_testplan_list_test_plans](#mcp_ado_testplan_list_test_plans)                                 | List test plans in a project           |
-| [mcp_ado_testplan_create_test_plan](#mcp_ado_testplan_create_test_plan)                               | Create a new test plan                 |
-| [mcp_ado_testplan_list_test_suites](#mcp_ado_testplan_list_test_suites)                               | List test suites in a test plan        |
-| [mcp_ado_testplan_create_test_suite](#mcp_ado_testplan_create_test_suite)                             | Create a test suite within a test plan |
-| [mcp_ado_testplan_add_test_cases_to_suite](#mcp_ado_testplan_add_test_cases_to_suite)                 | Add test cases to a test suite         |
-| [mcp_ado_testplan_list_test_cases](#mcp_ado_testplan_list_test_cases)                                 | List test cases in a test suite        |
-| [mcp_ado_testplan_create_test_case](#mcp_ado_testplan_create_test_case)                               | Create a new test case work item       |
-| [mcp_ado_testplan_update_test_case_steps](#mcp_ado_testplan_update_test_case_steps)                   | Update steps of an existing test case  |
-| [mcp_ado_testplan_show_test_results_from_build_id](#mcp_ado_testplan_show_test_results_from_build_id) | Get test results for a specific build  |
+> **Note:** The test plan tools are being aligned with the [Azure DevOps remote MCP server](https://learn.microsoft.com/en-us/azure/devops/mcp-server/remote-mcp-server?view=azure-devops#test-plans) tool structure.
+
+| Tool                                                                                  | Action           | Description                            |
+| ------------------------------------------------------------------------------------- | ---------------- | -------------------------------------- |
+| [testplan](#testplan)                                                                 | `list_plans`     | List test plans in a project           |
+| [testplan](#testplan)                                                                 | `list_suites`    | List test suites under a test plan     |
+| [testplan](#testplan)                                                                 | `list_cases`     | List test cases under a test suite     |
+| [testplan_show_test_results_from_build_id](#testplan_show_test_results_from_build_id) |                  | Get test results for a specific build  |
+| [testplan_test_plan_write](#testplan_test_plan_write)                                 | `create`         | Create a new test plan                 |
+| [testplan_test_suite_write](#testplan_test_suite_write)                               | `create`         | Create a test suite within a test plan |
+| [testplan_test_suite_write](#testplan_test_suite_write)                               | `add_test_cases` | Add test cases to a test suite         |
+| [testplan_test_case_write](#testplan_test_case_write)                                 | `create`         | Create a new test case work item       |
+| [testplan_test_case_write](#testplan_test_case_write)                                 | `update_steps`   | Update steps of an existing test case  |
 
 ### Wiki
 
@@ -440,68 +442,52 @@ Get Azure DevOps Work Item search results for a given search text.
 
 ### Test Plans
 
-#### mcp_ado_testplan_list_test_plans
+> **Note:** The test plan tools are being aligned with the [Azure DevOps remote MCP server](https://learn.microsoft.com/en-us/azure/devops/mcp-server/remote-mcp-server?view=azure-devops#test-plans) tool structure.
 
-Retrieve a paginated list of test plans from an Azure DevOps project.
+The test plan tools are consolidated into grouped dispatchers using an `action` parameter.
 
-- **Required**: `project`
-- **Optional**: `continuationToken`, `filterActivePlans`, `includePlanDetails`
+#### testplan
 
-#### mcp_ado_testplan_create_test_plan
+Retrieve test plan data for a project.
 
-Creates a new test plan in the project.
+| Action        | Required params                | Optional params                                                |
+| ------------- | ------------------------------ | -------------------------------------------------------------- |
+| `list_plans`  | `project`                      | `filterActivePlans`, `includePlanDetails`, `continuationToken` |
+| `list_suites` | `project`, `planId`            | `continuationToken`                                            |
+| `list_cases`  | `project`, `planId`, `suiteId` | `continuationToken`                                            |
 
-- **Required**: `project`, `name`, `iteration`
-- **Optional**: `areaPath`, `description`, `endDate`, `startDate`
-
-#### mcp_ado_testplan_list_test_suites
-
-Retrieve a paginated list of test suites from an Azure DevOps project and Test Plan Id. Returns test suites in a properly nested hierarchical structure.
-
-- **Required**: `project`, `planId`
-- **Optional**: `continuationToken`
-
-#### mcp_ado_testplan_create_test_suite
-
-Creates a new test suite in a test plan.
-
-- **Required**: `project`, `planId`, `parentSuiteId`, `name`
-- **Optional**: None
-
-#### mcp_ado_testplan_add_test_cases_to_suite
-
-Adds existing test cases to a test suite.
-
-- **Required**: `project`, `planId`, `suiteId`, `testCaseIds`
-- **Optional**: None
-
-#### mcp_ado_testplan_list_test_cases
-
-Gets a list of test cases in the test plan.
-
-- **Required**: `project`, `planid`, `suiteid`
-- **Optional**: `continuationToken`
-
-#### mcp_ado_testplan_create_test_case
-
-Creates a new test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
-
-- **Required**: `project`, `title`
-- **Optional**: `areaPath`, `iterationPath`, `priority`, `steps`, `testsWorkItemId`
-
-#### mcp_ado_testplan_update_test_case_steps
-
-Update the steps of an existing test case work item. Step content supports text formatting — use HTML tags (`<b>`, `<i>`, `<u>`, `<code>`) or Markdown markers (`**bold**`, `*italic*`, `` `code` ``, `[label](url)`) directly in step text and expected results.
-
-- **Required**: `id`, `steps`
-- **Optional**: None
-
-#### mcp_ado_testplan_show_test_results_from_build_id
+#### testplan_show_test_results_from_build_id
 
 Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes.
 
 - **Required**: `project`, `buildid`
 - **Optional**: `outcomes`
+
+#### testplan_test_plan_write
+
+Write operations for test plans.
+
+| Action   | Required params                | Optional params                                   |
+| -------- | ------------------------------ | ------------------------------------------------- |
+| `create` | `project`, `name`, `iteration` | `description`, `startDate`, `endDate`, `areaPath` |
+
+#### testplan_test_suite_write
+
+Write operations for test suites.
+
+| Action           | Required params                               | Optional params |
+| ---------------- | --------------------------------------------- | --------------- |
+| `create`         | `project`, `planId`, `parentSuiteId`, `name`  | None            |
+| `add_test_cases` | `project`, `planId`, `suiteId`, `testCaseIds` | None            |
+
+#### testplan_test_case_write
+
+Write operations for test cases. Step content supports text formatting — use Markdown markers (`**bold**`, `*italic*`, `__underline__`, `` `code` ``, `[label](url)`) directly in step text and expected results.
+
+| Action         | Required params    | Optional params                                                     |
+| -------------- | ------------------ | ------------------------------------------------------------------- |
+| `create`       | `project`, `title` | `steps`, `priority`, `areaPath`, `iterationPath`, `testsWorkItemId` |
+| `update_steps` | `id`, `steps`      | None                                                                |
 
 ### Wiki
 

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -411,7 +411,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
           return {
             content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
           };
-        } else {
+        } else if (action == "update_steps") {
           if (!id) return { content: [{ type: "text", text: "id is required for update_steps" }], isError: true };
           if (!steps) return { content: [{ type: "text", text: "steps is required for update_steps" }], isError: true };
 

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -142,6 +142,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
 
           return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
         }
+        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
         const prefix = action === "list_plans" ? "Error listing test plans" : action === "list_suites" ? "Error listing test suites" : "Error listing test cases";
@@ -331,6 +332,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
             content: [{ type: "text", text: JSON.stringify(addedTestCases, null, 2) }],
           };
         }
+        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
         return {
@@ -411,7 +413,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
           return {
             content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
           };
-        } else if (action == "update_steps") {
+        } else if (action === "update_steps") {
           if (!id) return { content: [{ type: "text", text: "id is required for update_steps" }], isError: true };
           if (!steps) return { content: [{ type: "text", text: "steps is required for update_steps" }], isError: true };
 
@@ -429,6 +431,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
             content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
           };
         }
+        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
         const prefix = action === "create" ? "Error creating test case" : "Error updating test case steps";

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -316,7 +316,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
             content: [{ type: "text", text: "Error creating test suite: Maximum retries exceeded" }],
             isError: true,
           };
-        } else {
+        } else if (action === "add_test_cases") {
           if (!planId) return { content: [{ type: "text", text: "planId is required for add_test_cases" }], isError: true };
           if (!suiteId) return { content: [{ type: "text", text: "suiteId is required for add_test_cases" }], isError: true };
           if (!testCaseIds) return { content: [{ type: "text", text: "testCaseIds is required for add_test_cases" }], isError: true };

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -118,7 +118,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
           if (nextToken) result.continuationToken = nextToken;
 
           return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
-        } else {
+        } else if (action === "list_cases") {
           if (!planId) return { content: [{ type: "text", text: "planId is required for list_cases" }], isError: true };
           if (!suiteId) return { content: [{ type: "text", text: "suiteId is required for list_cases" }], isError: true };
 

--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -7,94 +7,225 @@ import { TestPlanCreateParams } from "azure-devops-node-api/interfaces/TestPlanI
 import { z } from "zod";
 import { apiVersion } from "../utils.js";
 
-const Test_Plan_Tools = {
-  create_test_plan: "testplan_create_test_plan",
-  create_test_case: "testplan_create_test_case",
-  update_test_case_steps: "testplan_update_test_case_steps",
-  add_test_cases_to_suite: "testplan_add_test_cases_to_suite",
+const TEST_PLAN_TOOLS = {
+  testplan: "testplan",
   test_results_from_build_id: "testplan_show_test_results_from_build_id",
-  list_test_cases: "testplan_list_test_cases",
-  list_test_plans: "testplan_list_test_plans",
-  list_test_suites: "testplan_list_test_suites",
-  create_test_suite: "testplan_create_test_suite",
+  testplan_test_plan_write: "testplan_test_plan_write",
+  testplan_test_suite_write: "testplan_test_suite_write",
+  testplan_test_case_write: "testplan_test_case_write",
 };
 
 function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider?: () => string) {
+  // ─── testplan (read-only) ────────────────────────────────────────────
   server.tool(
-    Test_Plan_Tools.list_test_plans,
-    "Retrieve a paginated list of test plans from an Azure DevOps project. Allows filtering for active plans and toggling detailed information.",
+    TEST_PLAN_TOOLS.testplan,
+    "Retrieve test plan data for a project. Use the action parameter to specify the operation.",
     {
+      action: z
+        .enum(["list_plans", "list_suites", "list_cases"])
+        .describe("The action to perform. Options: list_plans (list test plans in a project), list_suites (list test suites under a test plan), list_cases (list test cases under a test suite)."),
       project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      filterActivePlans: z.boolean().default(true).describe("Filter to include only active test plans. Defaults to true."),
-      includePlanDetails: z.boolean().default(false).describe("Include detailed information about each test plan."),
-      continuationToken: z.string().optional().describe("Token to continue fetching test plans from a previous request."),
+      filterActivePlans: z.boolean().default(true).describe("Filter to include only active test plans. Used for: list_plans. Defaults to true."),
+      includePlanDetails: z.boolean().default(false).describe("Include detailed information about each test plan. Used for: list_plans."),
+      planId: z.coerce.number().min(1).optional().describe("The ID of the test plan. Required for: list_suites, list_cases."),
+      suiteId: z.coerce.number().min(1).optional().describe("The ID of the test suite. Required for: list_cases."),
+      continuationToken: z.string().optional().describe("Token to continue fetching results from a previous request. Used for: list_plans, list_suites, list_cases."),
     },
-    async ({ project, filterActivePlans, includePlanDetails, continuationToken }) => {
+    async ({ action, project, filterActivePlans, includePlanDetails, planId, suiteId, continuationToken }) => {
       try {
         const connection = await connectionProvider();
         const accessToken = await tokenProvider();
-        const params = new URLSearchParams({ "api-version": apiVersion });
-        if (filterActivePlans) params.append("filterActivePlans", "true");
-        if (includePlanDetails) params.append("includePlanDetails", "true");
-        if (continuationToken) params.append("continuationToken", continuationToken);
-        const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans?${params.toString()}`;
+
         const headers: Record<string, string> = {
           Authorization: `Bearer ${accessToken}`,
         };
 
         const userAgent = userAgentProvider?.();
+
         if (userAgent) {
           headers["User-Agent"] = userAgent;
         }
 
-        const response = await fetch(url, {
-          method: "GET",
-          headers,
-        });
+        if (action === "list_plans") {
+          const params = new URLSearchParams({ "api-version": apiVersion });
+          if (filterActivePlans) params.append("filterActivePlans", "true");
+          if (includePlanDetails) params.append("includePlanDetails", "true");
+          if (continuationToken) params.append("continuationToken", continuationToken);
+          const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans?${params.toString()}`;
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`Failed to list test plans (${response.status}): ${errorText}`);
+          const response = await fetch(url, { method: "GET", headers });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Failed to list test plans (${response.status}): ${errorText}`);
+          }
+
+          const body = await response.json();
+          const testPlans = body.value ?? [];
+          const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
+
+          const result: { testPlans: typeof testPlans; continuationToken?: string } = { testPlans };
+          if (nextToken) result.continuationToken = nextToken;
+
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } else if (action === "list_suites") {
+          if (!planId) return { content: [{ type: "text", text: "planId is required for list_suites" }], isError: true };
+
+          const params = new URLSearchParams({ "api-version": apiVersion, "expand": "children" });
+          if (continuationToken) params.append("continuationToken", continuationToken);
+          const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans/${planId}/Suites?${params.toString()}`;
+
+          const response = await fetch(url, { method: "GET", headers });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Failed to list test suites (${response.status}): ${errorText}`);
+          }
+
+          const body = await response.json();
+          const testSuites = body.value ?? [];
+          const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
+
+          const suiteMap = new Map();
+          testSuites.forEach((suite: any) => {
+            suiteMap.set(suite.id, {
+              id: suite.id,
+              name: suite.name,
+              parentSuiteId: suite.parentSuite?.id,
+              children: [] as any[],
+            });
+          });
+
+          const roots: any[] = [];
+          suiteMap.forEach((suite: any) => {
+            if (suite.parentSuiteId && suiteMap.has(suite.parentSuiteId)) {
+              suiteMap.get(suite.parentSuiteId).children.push(suite);
+            } else {
+              roots.push(suite);
+            }
+          });
+
+          const cleanSuite = (suite: any): any => {
+            const cleaned: any = { id: suite.id, name: suite.name };
+            if (suite.children && suite.children.length > 0) {
+              cleaned.children = suite.children.map((child: any) => cleanSuite(child));
+            }
+            return cleaned;
+          };
+
+          const cleanedSuites = roots.map((root: any) => cleanSuite(root));
+          const result: { testSuites: typeof cleanedSuites; continuationToken?: string } = { testSuites: cleanedSuites };
+          if (nextToken) result.continuationToken = nextToken;
+
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        } else {
+          if (!planId) return { content: [{ type: "text", text: "planId is required for list_cases" }], isError: true };
+          if (!suiteId) return { content: [{ type: "text", text: "suiteId is required for list_cases" }], isError: true };
+
+          const params = new URLSearchParams({ "api-version": "7.2-preview.3" });
+          if (continuationToken) params.append("continuationToken", continuationToken);
+          const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans/${planId}/Suites/${suiteId}/TestCase?${params.toString()}`;
+
+          const response = await fetch(url, { method: "GET", headers });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Failed to list test cases (${response.status}): ${errorText}`);
+          }
+
+          const body = await response.json();
+          const testcases = body.value ?? [];
+          const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
+
+          const result: { testCases: typeof testcases; continuationToken?: string } = { testCases: testcases };
+          if (nextToken) result.continuationToken = nextToken;
+
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
         }
-
-        const body = await response.json();
-        const testPlans = body.value ?? [];
-        const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
-
-        const result: { testPlans: typeof testPlans; continuationToken?: string } = {
-          testPlans: testPlans,
-        };
-        if (nextToken) {
-          result.continuationToken = nextToken;
-        }
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        const prefix = action === "list_plans" ? "Error listing test plans" : action === "list_suites" ? "Error listing test suites" : "Error listing test cases";
         return {
-          content: [{ type: "text", text: `Error listing test plans: ${errorMessage}` }],
+          content: [{ type: "text", text: `${prefix}: ${errorMessage}` }],
           isError: true,
         };
       }
     }
   );
 
+  // ─── testplan_show_test_results_from_build_id ──────────────────────────────────────
   server.tool(
-    Test_Plan_Tools.create_test_plan,
-    "Creates a new test plan in the project.",
+    TEST_PLAN_TOOLS.test_results_from_build_id,
+    "Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes. Efficiently handles builds with large numbers of test runs.",
     {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project where the test plan will be created."),
-      name: z.string().describe("The name of the test plan to be created."),
-      iteration: z.string().describe("The iteration path for the test plan"),
-      description: z.string().optional().describe("The description of the test plan"),
-      startDate: z.string().optional().describe("The start date of the test plan"),
-      endDate: z.string().optional().describe("The end date of the test plan"),
-      areaPath: z.string().optional().describe("The area path for the test plan"),
+      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
+      buildid: z.coerce.number().min(1).describe("The ID of the build."),
+      outcomes: z.array(z.string()).optional().describe("Filter results by test outcome, e.g. ['Failed', 'Passed', 'Aborted']."),
+    },
+    async ({ project, buildid, outcomes }) => {
+      try {
+        const connection = await connectionProvider();
+        const testResultsApi = await connection.getTestResultsApi();
+
+        const outcomeFilter = outcomes?.length ? `Outcome eq ${outcomes.join(",")}` : undefined;
+
+        const testResultDetails = await testResultsApi.getTestResultDetailsForBuild(project, buildid, undefined, undefined, outcomeFilter, undefined, true);
+
+        const allResults: any[] = [];
+        if (testResultDetails.resultsForGroup) {
+          for (const group of testResultDetails.resultsForGroup) {
+            if (group.results) {
+              for (const result of group.results) {
+                allResults.push(result);
+              }
+            }
+          }
+        }
+
+        const formattedResults = allResults.map((r) => ({
+          id: r.id,
+          testCaseTitle: r.testCaseTitle,
+          outcome: r.outcome,
+          errorMessage: r.errorMessage,
+          stackTrace: r.stackTrace,
+          automatedTestName: r.automatedTestName,
+          automatedTestStorage: r.automatedTestStorage,
+          durationInMs: r.durationInMs,
+          runId: r.testRun?.id,
+        }));
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(formattedResults, null, 2) }],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        return {
+          content: [{ type: "text", text: `Error fetching test results: ${errorMessage}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ─── testplan_test_plan_write ─────────────────────────────────────────────────────
+  server.tool(
+    TEST_PLAN_TOOLS.testplan_test_plan_write,
+    "Write operations for test plans. Use the action parameter to specify the operation.",
+    {
+      action: z.enum(["create"]).describe("The action to perform. Options: create (create a new test plan)."),
+      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
+      name: z.string().optional().describe("The name of the test plan. Required for: create."),
+      iteration: z.string().optional().describe("The iteration path for the test plan. Required for: create."),
+      description: z.string().optional().describe("The description of the test plan. Used for: create."),
+      startDate: z.string().optional().describe("The start date of the test plan. Used for: create."),
+      endDate: z.string().optional().describe("The end date of the test plan. Used for: create."),
+      areaPath: z.string().optional().describe("The area path for the test plan. Used for: create."),
     },
     async ({ project, name, iteration, description, startDate, endDate, areaPath }) => {
       try {
+        if (!name) return { content: [{ type: "text", text: "name is required for create" }], isError: true };
+        if (!iteration) return { content: [{ type: "text", text: "iteration is required for create" }], isError: true };
+
         const connection = await connectionProvider();
         const testPlanApi = await connection.getTestPlanApi();
 
@@ -122,89 +253,84 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
     }
   );
 
+  // ─── testplan_test_suite_write ────────────────────────────────────────────────────
   server.tool(
-    Test_Plan_Tools.create_test_suite,
-    "Creates a new test suite in a test plan.",
+    TEST_PLAN_TOOLS.testplan_test_suite_write,
+    "Write operations for test suites. Use the action parameter to specify the operation.",
     {
-      project: z.string().describe("Project ID or project name"),
-      planId: z.coerce.number().min(1).describe("ID of the test plan that contains the suites"),
-      parentSuiteId: z.coerce.number().min(1).describe("ID of the parent suite under which the new suite will be created, if not given by user this can be id of a root suite of the test plan"),
-      name: z.string().describe("Name of the child test suite"),
+      action: z
+        .enum(["create", "add_test_cases"])
+        .describe("The action to perform. Options: create (create a new test suite in a test plan), add_test_cases (add existing test cases to a test suite)."),
+      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
+      planId: z.coerce.number().min(1).optional().describe("The ID of the test plan. Required for: create, add_test_cases."),
+      parentSuiteId: z.coerce.number().min(1).optional().describe("ID of the parent suite under which the new suite will be created. Required for: create."),
+      name: z.string().optional().describe("Name of the child test suite. Required for: create."),
+      suiteId: z.coerce.number().min(1).optional().describe("The ID of the test suite. Required for: add_test_cases."),
+      testCaseIds: z.string().or(z.array(z.string())).optional().describe("The ID(s) of the test case(s) to add. Required for: add_test_cases."),
     },
-    async ({ project, planId, parentSuiteId, name }) => {
-      const maxRetries = 5;
-      const baseDelay = 500; // milliseconds
+    async ({ action, project, planId, parentSuiteId, name, suiteId, testCaseIds }) => {
+      try {
+        if (action === "create") {
+          if (!planId) return { content: [{ type: "text", text: "planId is required for create" }], isError: true };
+          if (!parentSuiteId) return { content: [{ type: "text", text: "parentSuiteId is required for create" }], isError: true };
+          if (!name) return { content: [{ type: "text", text: "name is required for create" }], isError: true };
 
-      for (let attempt = 0; attempt <= maxRetries; attempt++) {
-        try {
-          const connection = await connectionProvider();
-          const testPlanApi = await connection.getTestPlanApi();
+          const maxRetries = 5;
+          const baseDelay = 500;
 
-          const testSuiteToCreate = {
-            name,
-            parentSuite: {
-              id: parentSuiteId,
-              name: "",
-            },
-            suiteType: 2,
-          };
+          for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+              const connection = await connectionProvider();
+              const testPlanApi = await connection.getTestPlanApi();
 
-          const createdTestSuite = await testPlanApi.createTestSuite(testSuiteToCreate, project, planId);
+              const testSuiteToCreate = {
+                name,
+                parentSuite: { id: parentSuiteId, name: "" },
+                suiteType: 2,
+              };
 
-          return {
-            content: [{ type: "text", text: JSON.stringify(createdTestSuite, null, 2) }],
-          };
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+              const createdTestSuite = await testPlanApi.createTestSuite(testSuiteToCreate, project, planId);
 
-          // Check if it's a concurrency conflict error
-          const isConcurrencyError = errorMessage.includes("TF26071") || errorMessage.includes("got update") || errorMessage.includes("changed by someone else");
+              return {
+                content: [{ type: "text", text: JSON.stringify(createdTestSuite, null, 2) }],
+              };
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+              const isConcurrencyError = errorMessage.includes("TF26071") || errorMessage.includes("got update") || errorMessage.includes("changed by someone else");
 
-          // If it's a concurrency error and we have retries left, wait and retry
-          if (isConcurrencyError && attempt < maxRetries) {
-            const delay = baseDelay * Math.pow(2, attempt) + Math.random() * 200; // Exponential backoff with jitter
-            await new Promise((resolve) => setTimeout(resolve, delay));
-            continue; // Retry
+              if (isConcurrencyError && attempt < maxRetries) {
+                const delay = baseDelay * Math.pow(2, attempt) + Math.random() * 200;
+                await new Promise((resolve) => setTimeout(resolve, delay));
+                continue;
+              }
+
+              return {
+                content: [{ type: "text", text: `Error creating test suite: ${errorMessage}` }],
+                isError: true,
+              };
+            }
           }
 
-          // If not a concurrency error or out of retries, return error
+          /* istanbul ignore next */
           return {
-            content: [{ type: "text", text: `Error creating test suite: ${errorMessage}` }],
+            content: [{ type: "text", text: "Error creating test suite: Maximum retries exceeded" }],
             isError: true,
           };
+        } else {
+          if (!planId) return { content: [{ type: "text", text: "planId is required for add_test_cases" }], isError: true };
+          if (!suiteId) return { content: [{ type: "text", text: "suiteId is required for add_test_cases" }], isError: true };
+          if (!testCaseIds) return { content: [{ type: "text", text: "testCaseIds is required for add_test_cases" }], isError: true };
+
+          const connection = await connectionProvider();
+          const testApi = await connection.getTestApi();
+
+          const testCaseIdsString = Array.isArray(testCaseIds) ? testCaseIds.join(",") : testCaseIds;
+          const addedTestCases = await testApi.addTestCasesToSuite(project, planId, suiteId, testCaseIdsString);
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(addedTestCases, null, 2) }],
+          };
         }
-      }
-
-      // This should never be reached, but TypeScript requires a return value
-      return {
-        content: [{ type: "text", text: "Error creating test suite: Maximum retries exceeded" }],
-        isError: true,
-      };
-    }
-  );
-
-  server.tool(
-    Test_Plan_Tools.add_test_cases_to_suite,
-    "Adds existing test cases to a test suite.",
-    {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      planId: z.coerce.number().min(1).describe("The ID of the test plan."),
-      suiteId: z.coerce.number().min(1).describe("The ID of the test suite."),
-      testCaseIds: z.string().or(z.array(z.string())).describe("The ID(s) of the test case(s) to add. "),
-    },
-    async ({ project, planId, suiteId, testCaseIds }) => {
-      try {
-        const connection = await connectionProvider();
-        const testApi = await connection.getTestApi();
-
-        // If testCaseIds is an array, convert it to comma-separated string
-        const testCaseIdsString = Array.isArray(testCaseIds) ? testCaseIds.join(",") : testCaseIds;
-
-        const addedTestCases = await testApi.addTestCasesToSuite(project, planId, suiteId, testCaseIdsString);
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(addedTestCases, null, 2) }],
-        };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
         return {
@@ -215,367 +341,99 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
     }
   );
 
+  // ─── testplan_test_case_write ─────────────────────────────────────────────────────
   server.tool(
-    Test_Plan_Tools.create_test_case,
-    "Creates a new test case work item.",
+    TEST_PLAN_TOOLS.testplan_test_case_write,
+    "Write operations for test cases. Use the action parameter to specify the operation.",
     {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      title: z.string().describe("The title of the test case."),
+      action: z.enum(["create", "update_steps"]).describe("The action to perform. Options: create (create a new test case work item), update_steps (update steps on an existing test case)."),
+      project: z.string().optional().describe("The unique identifier (ID or name) of the Azure DevOps project. Required for: create."),
+      title: z.string().optional().describe("The title of the test case. Required for: create."),
+      priority: z.coerce.number().optional().describe("The priority of the test case. Used for: create."),
+      areaPath: z.string().optional().describe("The area path for the test case. Used for: create."),
+      iterationPath: z.string().optional().describe("The iteration path for the test case. Used for: create."),
+      testsWorkItemId: z.coerce.number().min(1).optional().describe("Work item ID to set as a Microsoft.VSTS.Common.TestedBy-Reverse link. Used for: create."),
+      id: z.coerce.number().min(1).optional().describe("The ID of the test case work item to update. Required for: update_steps."),
       steps: z
         .string()
         .optional()
         .describe(
-          "The steps to reproduce the test case. Make sure to format each step as '1. Step one|Expected result one\n2. Step two|Expected result two. USE '|' as the delimiter between step and expected result. DO NOT use '|' in the description of the step or expected result."
-        ),
-      priority: z.coerce.number().optional().describe("The priority of the test case."),
-      areaPath: z.string().optional().describe("The area path for the test case."),
-      iterationPath: z.string().optional().describe("The iteration path for the test case."),
-      testsWorkItemId: z.coerce.number().min(1).optional().describe("Optional work item id that will be set as a Microsoft.VSTS.Common.TestedBy-Reverse link to the test case."),
-    },
-    async ({ project, title, steps, priority, areaPath, iterationPath, testsWorkItemId }) => {
-      try {
-        const connection = await connectionProvider();
-        const witClient = await connection.getWorkItemTrackingApi();
-
-        let stepsXml;
-        if (steps) {
-          stepsXml = convertStepsToXml(steps);
-        }
-
-        // Create JSON patch document for work item
-        const patchDocument = [];
-
-        patchDocument.push({
-          op: "add",
-          path: "/fields/System.Title",
-          value: title,
-        });
-
-        if (testsWorkItemId) {
-          patchDocument.push({
-            op: "add",
-            path: "/relations/-",
-            value: {
-              rel: "Microsoft.VSTS.Common.TestedBy-Reverse",
-              url: `${connection.serverUrl}/${project}/_apis/wit/workItems/${testsWorkItemId}`,
-            },
-          });
-        }
-
-        if (stepsXml) {
-          patchDocument.push({
-            op: "add",
-            path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: stepsXml,
-          });
-        }
-
-        if (priority) {
-          patchDocument.push({
-            op: "add",
-            path: "/fields/Microsoft.VSTS.Common.Priority",
-            value: priority,
-          });
-        }
-
-        if (areaPath) {
-          patchDocument.push({
-            op: "add",
-            path: "/fields/System.AreaPath",
-            value: areaPath,
-          });
-        }
-
-        if (iterationPath) {
-          patchDocument.push({
-            op: "add",
-            path: "/fields/System.IterationPath",
-            value: iterationPath,
-          });
-        }
-
-        const workItem = await witClient.createWorkItem({}, patchDocument, project, "Test Case");
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-        return {
-          content: [{ type: "text", text: `Error creating test case: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    Test_Plan_Tools.update_test_case_steps,
-    "Update an existing test case work item.",
-    {
-      id: z.coerce.number().min(1).describe("The ID of the test case work item to update."),
-      steps: z
-        .string()
-        .describe(
-          "The steps to reproduce the test case. Make sure to format each step as '1. Step one|Expected result one\n2. Step two|Expected result two. USE '|' as the delimiter between step and expected result. DO NOT use '|' in the description of the step or expected result."
+          "The steps for the test case. Format each step as '1. Step one|Expected result one\n2. Step two|Expected result two'. Use '|' as the delimiter between step and expected result. Required for: update_steps. Used for: create."
         ),
     },
-    async ({ id, steps }) => {
+    async ({ action, project, title, steps, priority, areaPath, iterationPath, testsWorkItemId, id }) => {
       try {
-        const connection = await connectionProvider();
-        const witClient = await connection.getWorkItemTrackingApi();
+        if (action === "create") {
+          if (!project) return { content: [{ type: "text", text: "project is required for create" }], isError: true };
+          if (!title) return { content: [{ type: "text", text: "title is required for create" }], isError: true };
 
-        let stepsXml;
-        if (steps) {
-          stepsXml = convertStepsToXml(steps);
-        }
+          const connection = await connectionProvider();
+          const witClient = await connection.getWorkItemTrackingApi();
 
-        // Create JSON patch document for work item
-        const patchDocument = [];
-
-        if (stepsXml) {
-          patchDocument.push({
-            op: "add",
-            path: "/fields/Microsoft.VSTS.TCM.Steps",
-            value: stepsXml,
-          });
-        }
-
-        const workItem = await witClient.updateWorkItem({}, patchDocument, id);
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-        return {
-          content: [{ type: "text", text: `Error updating test case steps: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    Test_Plan_Tools.list_test_cases,
-    "Gets a list of test cases in the test plan.",
-    {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      planid: z.coerce.number().min(1).describe("The ID of the test plan."),
-      suiteid: z.coerce.number().min(1).describe("The ID of the test suite."),
-      continuationToken: z.string().optional().describe("Token to continue fetching test cases from a previous request."),
-    },
-    async ({ project, planid, suiteid, continuationToken }) => {
-      try {
-        const connection = await connectionProvider();
-        const accessToken = await tokenProvider();
-        const params = new URLSearchParams({ "api-version": "7.2-preview.3" });
-        if (continuationToken) params.append("continuationToken", continuationToken);
-        const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans/${planid}/Suites/${suiteid}/TestCase?${params.toString()}`;
-        const headers: Record<string, string> = {
-          Authorization: `Bearer ${accessToken}`,
-        };
-
-        const userAgent = userAgentProvider?.();
-        if (userAgent) {
-          headers["User-Agent"] = userAgent;
-        }
-
-        const response = await fetch(url, {
-          method: "GET",
-          headers,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`Failed to list test cases (${response.status}): ${errorText}`);
-        }
-
-        const body = await response.json();
-        const testcases = body.value ?? [];
-        const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
-
-        const result: { testCases: typeof testcases; continuationToken?: string } = {
-          testCases: testcases,
-        };
-        if (nextToken) {
-          result.continuationToken = nextToken;
-        }
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-        return {
-          content: [{ type: "text", text: `Error listing test cases: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    Test_Plan_Tools.test_results_from_build_id,
-    "Gets a list of test results for a given project and build ID. Can filter by test outcome (e.g. Failed, Passed, Aborted). Returns test case titles, error messages, stack traces, and outcomes. Efficiently handles builds with large numbers of test runs.",
-    {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      buildid: z.coerce.number().min(1).describe("The ID of the build."),
-      outcomes: z.array(z.string()).optional().describe("Filter results by test outcome, e.g. ['Failed', 'Passed', 'Aborted']."),
-    },
-    async ({ project, buildid, outcomes }) => {
-      try {
-        const connection = await connectionProvider();
-        const testResultsApi = await connection.getTestResultsApi();
-
-        // Build filter expression for outcomes if specified.
-        // The API accepts: Outcome eq Failed,Passed (unquoted, comma-separated)
-        const outcomeFilter = outcomes?.length ? `Outcome eq ${outcomes.join(",")}` : undefined;
-
-        // Fetch test result details for the build in a single API call
-        // This is more efficient than getTestRuns + getTestResults per run,
-        // especially for builds with many test runs (e.g., cloud testing with one run per test case)
-        const testResultDetails = await testResultsApi.getTestResultDetailsForBuild(
-          project,
-          buildid,
-          undefined, // publishContext
-          undefined, // groupBy
-          outcomeFilter, // filter by outcome
-          undefined, // orderby
-          true // shouldIncludeResults - get individual test results, not just aggregates
-        );
-
-        // Extract individual test results from the grouped response
-        const allResults: any[] = [];
-        if (testResultDetails.resultsForGroup) {
-          for (const group of testResultDetails.resultsForGroup) {
-            if (group.results) {
-              for (const result of group.results) {
-                allResults.push(result);
-              }
-            }
+          let stepsXml;
+          if (steps) {
+            stepsXml = convertStepsToXml(steps);
           }
-        }
 
-        // Format results to extract useful fields
-        const formattedResults = allResults.map((r) => ({
-          id: r.id,
-          testCaseTitle: r.testCaseTitle,
-          outcome: r.outcome,
-          errorMessage: r.errorMessage,
-          stackTrace: r.stackTrace,
-          automatedTestName: r.automatedTestName,
-          automatedTestStorage: r.automatedTestStorage,
-          durationInMs: r.durationInMs,
-          runId: r.testRun?.id,
-        }));
+          const patchDocument: any[] = [];
 
-        return {
-          content: [{ type: "text", text: JSON.stringify(formattedResults, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-        return {
-          content: [{ type: "text", text: `Error fetching test results: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
+          patchDocument.push({ op: "add", path: "/fields/System.Title", value: title });
 
-  server.tool(
-    Test_Plan_Tools.list_test_suites,
-    "Retrieve a paginated list of test suites from an Azure DevOps project and Test Plan Id.",
-    {
-      project: z.string().describe("The unique identifier (ID or name) of the Azure DevOps project."),
-      planId: z.coerce.number().min(1).describe("The ID of the test plan."),
-      continuationToken: z.string().optional().describe("Token to continue fetching test plans from a previous request."),
-    },
-    async ({ project, planId, continuationToken }) => {
-      try {
-        const connection = await connectionProvider();
-        const accessToken = await tokenProvider();
-        const params = new URLSearchParams({ "api-version": apiVersion, "expand": "children" });
-        if (continuationToken) params.append("continuationToken", continuationToken);
-        const url = `${connection.serverUrl}/${encodeURIComponent(project)}/_apis/testplan/Plans/${planId}/Suites?${params.toString()}`;
-        const headers: Record<string, string> = {
-          Authorization: `Bearer ${accessToken}`,
-        };
-
-        const userAgent = userAgentProvider?.();
-        if (userAgent) {
-          headers["User-Agent"] = userAgent;
-        }
-
-        const response = await fetch(url, {
-          method: "GET",
-          headers,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`Failed to list test suites (${response.status}): ${errorText}`);
-        }
-
-        const body = await response.json();
-        const testSuites = body.value ?? [];
-        const nextToken = response.headers.get("x-ms-continuationtoken") ?? undefined;
-
-        // The API returns a flat list where the root suite is first, followed by all nested suites
-        // We need to build a proper hierarchy by creating a map and assembling the tree
-
-        // Create a map of all suites by ID for quick lookup
-        const suiteMap = new Map();
-        testSuites.forEach((suite: any) => {
-          suiteMap.set(suite.id, {
-            id: suite.id,
-            name: suite.name,
-            parentSuiteId: suite.parentSuite?.id,
-            children: [] as any[],
-          });
-        });
-
-        // Build the hierarchy by linking children to parents
-        const roots: any[] = [];
-        suiteMap.forEach((suite: any) => {
-          if (suite.parentSuiteId && suiteMap.has(suite.parentSuiteId)) {
-            // This is a child suite, add it to its parent's children array
-            const parent = suiteMap.get(suite.parentSuiteId);
-            parent.children.push(suite);
-          } else {
-            // This is a root suite (no parent or parent not in map)
-            roots.push(suite);
+          if (testsWorkItemId) {
+            patchDocument.push({
+              op: "add",
+              path: "/relations/-",
+              value: {
+                rel: "Microsoft.VSTS.Common.TestedBy-Reverse",
+                url: `${connection.serverUrl}/${project}/_apis/wit/workItems/${testsWorkItemId}`,
+              },
+            });
           }
-        });
 
-        // Clean up the output - remove parentSuiteId and empty children arrays
-        const cleanSuite = (suite: any): any => {
-          const cleaned: any = {
-            id: suite.id,
-            name: suite.name,
+          if (stepsXml) {
+            patchDocument.push({ op: "add", path: "/fields/Microsoft.VSTS.TCM.Steps", value: stepsXml });
+          }
+
+          if (priority) {
+            patchDocument.push({ op: "add", path: "/fields/Microsoft.VSTS.Common.Priority", value: priority });
+          }
+
+          if (areaPath) {
+            patchDocument.push({ op: "add", path: "/fields/System.AreaPath", value: areaPath });
+          }
+
+          if (iterationPath) {
+            patchDocument.push({ op: "add", path: "/fields/System.IterationPath", value: iterationPath });
+          }
+
+          const workItem = await witClient.createWorkItem({}, patchDocument, project, "Test Case");
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
           };
-          if (suite.children && suite.children.length > 0) {
-            cleaned.children = suite.children.map((child: any) => cleanSuite(child));
-          }
-          return cleaned;
-        };
+        } else {
+          if (!id) return { content: [{ type: "text", text: "id is required for update_steps" }], isError: true };
+          if (!steps) return { content: [{ type: "text", text: "steps is required for update_steps" }], isError: true };
 
-        const cleanedSuites = roots.map((root: any) => cleanSuite(root));
+          const connection = await connectionProvider();
+          const witClient = await connection.getWorkItemTrackingApi();
 
-        const result: { testSuites: typeof cleanedSuites; continuationToken?: string } = {
-          testSuites: cleanedSuites,
-        };
-        if (nextToken) {
-          result.continuationToken = nextToken;
+          const stepsXml = convertStepsToXml(steps);
+          const patchDocument: any[] = [];
+
+          patchDocument.push({ op: "add", path: "/fields/Microsoft.VSTS.TCM.Steps", value: stepsXml });
+
+          const workItem = await witClient.updateWorkItem({}, patchDocument, id);
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(workItem, null, 2) }],
+          };
         }
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-        };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+        const prefix = action === "create" ? "Error creating test case" : "Error updating test case steps";
         return {
-          content: [{ type: "text", text: `Error listing test suites: ${errorMessage}` }],
+          content: [{ type: "text", text: `${prefix}: ${errorMessage}` }],
           isError: true,
         };
       }
@@ -589,7 +447,6 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
  * element, which is the format Azure DevOps expects for rendered step content.
  */
 function formatStepContent(text: string): string {
-  // Convert Markdown markers to HTML tags (** before * and __ before _ to avoid conflicts)
   const htmlContent = text
     .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
     .replace(/\*(.+?)\*/g, "<i>$1</i>")
@@ -597,7 +454,6 @@ function formatStepContent(text: string): string {
     .replace(/`(.+?)`/g, "<code>$1</code>")
     .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2">$1</a>');
 
-  // Wrap in ADO rich text envelope and XML-escape the entire HTML string
   return escapeXml(`${htmlContent}`);
 }
 
@@ -605,26 +461,22 @@ function formatStepContent(text: string): string {
  * Helper function to convert steps text to XML format required
  */
 function convertStepsToXml(steps: string): string {
-  // Accepts steps in the format: '1. Step one|Expected result one\n2. Step two|Expected result two'
   const stepsLines = steps.split("\n").filter((line) => line.trim() !== "");
 
   let xmlSteps = `<steps id="0" last="${stepsLines.length}">`;
 
   for (let i = 0; i < stepsLines.length; i++) {
     const stepLine = stepsLines[i].trim();
-    if (stepLine) {
-      // Split step and expected result by '|', fallback to default if not provided
-      const [stepPart, expectedPart] = stepLine.split("|").map((s) => s.trim());
-      const stepMatch = stepPart.match(/^(\d+)\.\s*(.+)$/);
-      const stepText = stepMatch ? stepMatch[2] : stepPart;
-      const expectedText = expectedPart || "Verify step completes successfully";
+    const [stepPart, expectedPart] = stepLine.split("|").map((s) => s.trim());
+    const stepMatch = stepPart.match(/^(\d+)\.\s*(.+)$/);
+    const stepText = stepMatch ? stepMatch[2] : stepPart;
+    const expectedText = expectedPart || "Verify step completes successfully";
 
-      xmlSteps += `
+    xmlSteps += `
                 <step id="${i + 1}" type="ActionStep">
                     <parameterizedString isformatted="true">${formatStepContent(stepText)}</parameterizedString>
                     <parameterizedString isformatted="true">${formatStepContent(expectedText)}</parameterizedString>
                 </step>`;
-    }
   }
 
   xmlSteps += "</steps>";
@@ -647,10 +499,11 @@ function escapeXml(unsafe: string): string {
         return "&apos;";
       case '"':
         return "&quot;";
+      /* istanbul ignore next */
       default:
         return c;
     }
   });
 }
 
-export { Test_Plan_Tools, configureTestPlanTools };
+export { TEST_PLAN_TOOLS, configureTestPlanTools };

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -68,17 +68,7 @@ describe("configureTestPlanTools", () => {
     it("registers test plan tools on the server", () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
       expect((server.tool as jest.Mock).mock.calls.map((call) => call[0])).toEqual(
-        expect.arrayContaining([
-          "testplan_list_test_plans",
-          "testplan_create_test_plan",
-          "testplan_create_test_suite",
-          "testplan_add_test_cases_to_suite",
-          "testplan_create_test_case",
-          "testplan_update_test_case_steps",
-          "testplan_list_test_cases",
-          "testplan_show_test_results_from_build_id",
-          "testplan_list_test_suites",
-        ])
+        expect.arrayContaining(["testplan", "testplan_show_test_results_from_build_id", "testplan_test_plan_write", "testplan_test_suite_write", "testplan_test_case_write"])
       );
     });
   });
@@ -101,12 +91,13 @@ describe("configureTestPlanTools", () => {
 
     it("should fetch test plans and return the expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
-      if (!call) throw new Error("testplan_list_test_plans tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchPlansResponse([{ id: 1, name: "Test Plan 1" }]);
       const params = {
+        action: "list_plans" as const,
         project: "proj1",
         filterActivePlans: true,
         includePlanDetails: false,
@@ -121,13 +112,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when listing test plans", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
-      if (!call) throw new Error("testplan_list_test_plans tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       (global.fetch as jest.Mock) = jest.fn().mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "list_plans" as const,
         project: "proj1",
         filterActivePlans: true,
         includePlanDetails: false,
@@ -141,13 +133,13 @@ describe("configureTestPlanTools", () => {
 
     it("should pass continuation token in URL when provided", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
-      if (!call) throw new Error("testplan_list_test_plans tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchPlansResponse([{ id: 1, name: "Test Plan 1" }], "nextPageToken");
 
-      const result = await handler({ project: "proj1", filterActivePlans: true, includePlanDetails: false, continuationToken: "token123" });
+      const result = await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: true, includePlanDetails: false, continuationToken: "token123" });
 
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("continuationToken=token123"), expect.anything());
       const parsed = JSON.parse(result.content[0].text);
@@ -156,16 +148,97 @@ describe("configureTestPlanTools", () => {
 
     it("should handle non-ok response with status and error text", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_plans");
-      if (!call) throw new Error("testplan_list_test_plans tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchPlansResponse([], undefined, false, 404, "Resource not found");
 
-      const result = await handler({ project: "proj1", filterActivePlans: true, includePlanDetails: false });
+      const result = await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: true, includePlanDetails: false });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Failed to list test plans (404)");
       expect(result.content[0].text).toContain("Resource not found");
+    });
+
+    it("should not set User-Agent header when userAgentProvider is omitted", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: [] }),
+        headers: { get: () => null },
+      });
+
+      await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: true, includePlanDetails: false });
+
+      expect(global.fetch).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ headers: expect.not.objectContaining({ "User-Agent": expect.anything() }) }));
+    });
+
+    it("should not append filterActivePlans when false", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: [] }),
+        headers: { get: () => null },
+      });
+
+      await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: false, includePlanDetails: false });
+
+      expect(global.fetch).toHaveBeenCalledWith(expect.not.stringContaining("filterActivePlans"), expect.anything());
+    });
+
+    it("should append includePlanDetails when true", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: [] }),
+        headers: { get: () => null },
+      });
+
+      await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: false, includePlanDetails: true });
+
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("includePlanDetails=true"), expect.anything());
+    });
+
+    it("should return empty testPlans array when body.value is null", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: null }),
+        headers: { get: () => null },
+      });
+
+      const result = await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: false, includePlanDetails: false });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.testPlans).toEqual([]);
+    });
+
+    it("should handle non-Error throws and return fallback message", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockRejectedValue("plain string error");
+
+      const result = await handler({ action: "list_plans" as const, project: "proj1", filterActivePlans: false, includePlanDetails: false });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
     });
   });
 
@@ -187,8 +260,8 @@ describe("configureTestPlanTools", () => {
 
     it("should fetch test suites and return properly nested hierarchy", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([
@@ -221,6 +294,7 @@ describe("configureTestPlanTools", () => {
       ]);
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 1,
       };
@@ -253,13 +327,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle test suite with no children", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([{ id: 200, name: "Single Suite", hasChildren: false }]);
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 2,
       };
@@ -272,13 +347,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty test suite list", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([]);
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 3,
       };
@@ -290,8 +366,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle deeply nested suite hierarchy", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([
@@ -323,6 +399,7 @@ describe("configureTestPlanTools", () => {
       ]);
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 4,
       };
@@ -355,13 +432,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when listing test suites", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       (global.fetch as jest.Mock) = jest.fn().mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 5,
       };
@@ -373,13 +451,14 @@ describe("configureTestPlanTools", () => {
 
     it("should pass continuation token in URL when provided", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([{ id: 400, name: "Suite with Token" }], "nextSuiteToken");
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 6,
         continuationToken: "token123",
@@ -393,8 +472,8 @@ describe("configureTestPlanTools", () => {
 
     it("should not include empty children arrays in output", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([
@@ -413,6 +492,7 @@ describe("configureTestPlanTools", () => {
       ]);
 
       const params = {
+        action: "list_suites" as const,
         project: "proj1",
         planId: 7,
       };
@@ -425,28 +505,57 @@ describe("configureTestPlanTools", () => {
 
     it("should handle non-ok response with status and error text", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_suites");
-      if (!call) throw new Error("testplan_list_test_suites tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchSuitesResponse([], undefined, false, 404, "Suite not found");
 
-      const result = await handler({ project: "proj1", planId: 1 });
+      const result = await handler({ action: "list_suites" as const, project: "proj1", planId: 1 });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Failed to list test suites (404)");
       expect(result.content[0].text).toContain("Suite not found");
+    });
+
+    it("should return error when planId is missing for list_suites", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "list_suites" as const, project: "proj1" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("planId is required for list_suites");
+    });
+
+    it("should return empty testSuites array when body.value is null", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: null }),
+        headers: { get: () => null },
+      });
+
+      const result = await handler({ action: "list_suites" as const, project: "proj1", planId: 1 });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.testSuites).toEqual([]);
     });
   });
 
   describe("create_test_plan tool", () => {
     it("should call createTestPlan with the correct parameters and return the expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_plan");
-      if (!call) throw new Error("testplan_create_test_plan tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_plan_write");
+      if (!call) throw new Error("testplan_test_plan_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestPlan as jest.Mock).mockResolvedValue({ id: 1, name: "New Test Plan" });
       const params = {
+        action: "create" as const,
         project: "proj1",
         name: "New Test Plan",
         iteration: "Iteration 1",
@@ -473,13 +582,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when creating test plan", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_plan");
-      if (!call) throw new Error("testplan_create_test_plan tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_plan_write");
+      if (!call) throw new Error("testplan_test_plan_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestPlan as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         name: "Failed Plan",
         iteration: "Iteration 1",
@@ -490,17 +600,53 @@ describe("configureTestPlanTools", () => {
       expect(result.content[0].text).toContain("Error creating test plan");
       expect(result.content[0].text).toContain("API Error");
     });
+
+    it("should return error when name is missing", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_plan_write");
+      if (!call) throw new Error("testplan_test_plan_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ project: "proj1", iteration: "Sprint 1" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("name is required for create");
+    });
+
+    it("should return error when iteration is missing", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_plan_write");
+      if (!call) throw new Error("testplan_test_plan_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ project: "proj1", name: "Plan" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("iteration is required for create");
+    });
+
+    it("should handle non-Error throws and return fallback message", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_plan_write");
+      if (!call) throw new Error("testplan_test_plan_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestPlanApi.createTestPlan as jest.Mock).mockRejectedValue("plain string error");
+
+      const result = await handler({ project: "proj1", name: "Plan", iteration: "Sprint 1" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
   });
 
   describe("create_test_suite tool", () => {
     it("should call createTestSuite with the correct parameters and return the expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
-      if (!call) throw new Error("testplan_create_test_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue({ id: 10, name: "New Test Suite" });
       const params = {
+        action: "create" as const,
         project: "proj1",
         planId: 1,
         parentSuiteId: 5,
@@ -525,13 +671,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when creating test suite", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
-      if (!call) throw new Error("testplan_create_test_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         planId: 1,
         parentSuiteId: 5,
@@ -546,8 +693,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test suite with different parent suite IDs", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
-      if (!call) throw new Error("testplan_create_test_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue({
@@ -556,6 +703,7 @@ describe("configureTestPlanTools", () => {
         parentSuite: { id: 10 },
       });
       const params = {
+        action: "create" as const,
         project: "proj1",
         planId: 2,
         parentSuiteId: 10,
@@ -590,12 +738,13 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty or null response from createTestSuite", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_suite");
-      if (!call) throw new Error("testplan_create_test_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestPlanApi.createTestSuite as jest.Mock).mockResolvedValue(null);
       const params = {
+        action: "create" as const,
         project: "proj1",
         planId: 1,
         parentSuiteId: 5,
@@ -604,6 +753,111 @@ describe("configureTestPlanTools", () => {
       const result = await handler(params);
 
       expect(result.content[0].text).toBe(JSON.stringify(null, null, 2));
+    });
+
+    it("should retry on concurrency error (TF26071) and succeed on second attempt", async () => {
+      jest.useFakeTimers();
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestPlanApi.createTestSuite as jest.Mock).mockRejectedValueOnce(new Error("TF26071: concurrency conflict")).mockResolvedValueOnce({ id: 10, name: "Retry Suite" });
+
+      const params = {
+        action: "create" as const,
+        project: "proj1",
+        planId: 1,
+        parentSuiteId: 5,
+        name: "Retry Suite",
+      };
+
+      const handlerPromise = handler(params);
+      await jest.runAllTimersAsync();
+      const result = await handlerPromise;
+
+      jest.useRealTimers();
+
+      expect(mockTestPlanApi.createTestSuite).toHaveBeenCalledTimes(2);
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe(JSON.stringify({ id: 10, name: "Retry Suite" }, null, 2));
+    });
+
+    it("should retry on 'got update' concurrency error and succeed on third attempt", async () => {
+      jest.useFakeTimers();
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestPlanApi.createTestSuite as jest.Mock)
+        .mockRejectedValueOnce(new Error("got update conflict"))
+        .mockRejectedValueOnce(new Error("changed by someone else"))
+        .mockResolvedValueOnce({ id: 20, name: "Multi-Retry Suite" });
+
+      const params = {
+        action: "create" as const,
+        project: "proj1",
+        planId: 2,
+        parentSuiteId: 10,
+        name: "Multi-Retry Suite",
+      };
+
+      const handlerPromise = handler(params);
+      await jest.runAllTimersAsync();
+      const result = await handlerPromise;
+
+      jest.useRealTimers();
+
+      expect(mockTestPlanApi.createTestSuite).toHaveBeenCalledTimes(3);
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toBe(JSON.stringify({ id: 20, name: "Multi-Retry Suite" }, null, 2));
+    });
+
+    it("should return error when planId is missing for create", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "create" as const, project: "proj1", parentSuiteId: 5, name: "Suite" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("planId is required for create");
+    });
+
+    it("should return error when parentSuiteId is missing for create", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "create" as const, project: "proj1", planId: 1, name: "Suite" } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("parentSuiteId is required for create");
+    });
+
+    it("should return error when name is missing for create", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "create" as const, project: "proj1", planId: 1, parentSuiteId: 5 } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("name is required for create");
+    });
+
+    it("should handle non-Error throws in inner retry catch", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestPlanApi.createTestSuite as jest.Mock).mockRejectedValue("plain string error");
+
+      const result = await handler({ action: "create" as const, project: "proj1", planId: 1, parentSuiteId: 5, name: "Suite" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
     });
   });
 
@@ -625,13 +879,13 @@ describe("configureTestPlanTools", () => {
 
     it("should fetch test cases and return the expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
-      if (!call) throw new Error("testplan_list_test_cases tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchResponse([{ id: 1, name: "Test Case 1" }]);
 
-      const result = await handler({ project: "proj1", planid: 1, suiteid: 2 });
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2 });
 
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("proj1/_apis/testplan/Plans/1/Suites/2/TestCase"), expect.objectContaining({ method: "GET" }));
       expect(result.content[0].text).toBe(JSON.stringify({ testCases: [{ id: 1, name: "Test Case 1" }] }, null, 2));
@@ -639,13 +893,13 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when listing test cases", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
-      if (!call) throw new Error("testplan_list_test_cases tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       (global.fetch as jest.Mock) = jest.fn().mockRejectedValue(new Error("API Error"));
 
-      const result = await handler({ project: "proj1", planid: 1, suiteid: 2 });
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2 });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error listing test cases");
       expect(result.content[0].text).toContain("API Error");
@@ -653,13 +907,13 @@ describe("configureTestPlanTools", () => {
 
     it("should pass continuation token when provided", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
-      if (!call) throw new Error("testplan_list_test_cases tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchResponse([{ id: 1, name: "Test Case 1" }], "nextToken456");
 
-      const result = await handler({ project: "proj1", planid: 1, suiteid: 2, continuationToken: "token123" });
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2, continuationToken: "token123" });
 
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("continuationToken=token123"), expect.anything());
       const parsed = JSON.parse(result.content[0].text);
@@ -669,13 +923,13 @@ describe("configureTestPlanTools", () => {
 
     it("should not include continuationToken when API does not return one", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
-      if (!call) throw new Error("testplan_list_test_cases tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchResponse([{ id: 1, name: "Test Case 1" }]);
 
-      const result = await handler({ project: "proj1", planid: 1, suiteid: 2 });
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2 });
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.continuationToken).toBeUndefined();
       expect(parsed.testCases).toEqual([{ id: 1, name: "Test Case 1" }]);
@@ -683,16 +937,55 @@ describe("configureTestPlanTools", () => {
 
     it("should handle non-ok response with status and error text", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_list_test_cases");
-      if (!call) throw new Error("testplan_list_test_cases tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
       const [, , , handler] = call;
 
       mockFetchResponse([], undefined, false, 404, "Test case not found");
 
-      const result = await handler({ project: "proj1", planid: 1, suiteid: 2 });
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2 });
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Failed to list test cases (404)");
       expect(result.content[0].text).toContain("Test case not found");
+    });
+
+    it("should return error when planId is missing for list_cases", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "list_cases" as const, project: "proj1", suiteId: 2 } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("planId is required for list_cases");
+    });
+
+    it("should return error when suiteId is missing for list_cases", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1 } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("suiteId is required for list_cases");
+    });
+
+    it("should return empty testCases array when body.value is null", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ value: null }),
+        headers: { get: () => null },
+      });
+
+      const result = await handler({ action: "list_cases" as const, project: "proj1", planId: 1, suiteId: 2 });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.testCases).toEqual([]);
     });
   });
 
@@ -951,13 +1244,55 @@ describe("configureTestPlanTools", () => {
       expect(parsed[2]).toHaveProperty("testCaseTitle");
       expect(parsed[2].testCaseTitle).toBe("Another Manual Test Case");
     });
+
+    it("should return empty array when resultsForGroup is null", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({ resultsForGroup: null });
+
+      const result = await handler({ project: "proj1", buildid: 123 });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toEqual([]);
+    });
+
+    it("should skip groups that have no results property", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockResolvedValue({
+        resultsForGroup: [{ groupByValue: "NoResults" }, { results: [{ id: 1, testCaseTitle: "Test", outcome: "Passed" }] }],
+      });
+
+      const result = await handler({ project: "proj1", buildid: 123 });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].testCaseTitle).toBe("Test");
+    });
+
+    it("should handle non-Error throws and return fallback message", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_show_test_results_from_build_id");
+      if (!call) throw new Error("testplan_show_test_results_from_build_id tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestResultsApi.getTestResultDetailsForBuild as jest.Mock).mockRejectedValue("plain string error");
+
+      const result = await handler({ project: "proj1", buildid: 123 });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
   });
 
   describe("create_test_case tool", () => {
     it("should create test case with proper parameters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -969,6 +1304,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "New Test Case",
         steps: "1. Test step 1\n2. Test step 2",
@@ -993,8 +1329,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case & expected result with proper parameters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1006,6 +1342,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "New Test Case",
         steps: "1. Test step 1 | Expected result 1\n2. Test step 2 | Expected result 2",
@@ -1030,8 +1367,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle multiple steps in test case", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1042,6 +1379,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Multi-step Test Case",
         steps: "1. Step 1\n2. Step 2",
@@ -1064,13 +1402,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors in test case creation", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Failed Test Case",
         steps: "1. Test step",
@@ -1084,8 +1423,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case with all optional parameters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1099,6 +1438,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Full Test Case",
         steps: "1. Step with <special> & 'quotes' and \"double quotes\"",
@@ -1151,8 +1491,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle non-numbered step formats", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1163,6 +1503,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Non-numbered Test Case",
         steps: "Click the button\nVerify result\n\n3. Numbered step",
@@ -1208,8 +1549,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty lines in steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1220,6 +1561,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Empty Lines Test Case",
         steps: "1. First step\n\n\n2. Second step\n   \n3. Third step",
@@ -1243,8 +1585,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case without steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1255,6 +1597,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "No Steps Test Case",
         // no steps parameter
@@ -1288,8 +1631,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle edge case XML characters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1300,6 +1643,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Edge Case XML Test",
         steps: "1. Test with all XML chars: < > & ' \" and some unicode: \u00A0\u2028\u2029",
@@ -1333,8 +1677,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty string steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1345,6 +1689,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Empty String Steps Test",
         steps: "",
@@ -1367,8 +1712,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle only whitespace steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1379,6 +1724,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Whitespace Steps Test",
         steps: "   \n\t\n   ",
@@ -1401,8 +1747,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle steps with pipe delimiter for expected results", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1413,6 +1759,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Pipe Delimiter Test",
         steps: "1. Navigate to login page|Login page loads successfully\n2. Enter username|Username is accepted in field",
@@ -1451,8 +1798,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle steps without pipe delimiter using default expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1463,6 +1810,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Default Expected Result Test",
         steps: "1. Click the button\n2. Navigate to page",
@@ -1493,8 +1841,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle mixed steps with and without pipe delimiter", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1505,6 +1853,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Mixed Delimiter Test",
         steps: "1. Click login button|Login form appears\n2. Enter credentials\n3. Submit form|User is logged in successfully",
@@ -1547,8 +1896,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty expected result after pipe delimiter", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1559,6 +1908,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Empty Expected Result Test",
         steps: "1. Perform action|\n2. Another action|",
@@ -1589,8 +1939,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle multiple pipe characters in expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1601,6 +1951,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Multiple Pipes Test",
         steps: "1. Check message|Message shows 'Success | Error | Warning'",
@@ -1631,8 +1982,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle whitespace around pipe delimiter", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1643,6 +1994,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Whitespace Pipe Test",
         steps: "1. Action with spaces   |   Expected result with spaces   \n2. Another action|\n3. Third action|Expected result",
@@ -1685,8 +2037,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle special characters in expected results", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1697,6 +2049,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Special Characters Expected Test",
         steps: "1. Test XML chars|Result contains < > & ' \" characters\n2. Test unicode|Result shows unicode: \u00A0\u2028\u2029",
@@ -1735,8 +2088,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle non-numbered steps with pipe delimiter", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1747,6 +2100,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Non-numbered Pipe Test",
         steps: "Click button|Button is clicked\nVerify result|Result is displayed\nAction without number|Expected without number",
@@ -1789,8 +2143,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case with testsWorkItemId relationship", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1807,6 +2161,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Test Case with Link",
         steps: "1. Execute test|Test passes",
@@ -1855,8 +2210,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case without testsWorkItemId when not provided", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1867,6 +2222,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Test Case without Link",
         steps: "1. Execute test|Test passes",
@@ -1905,8 +2261,8 @@ describe("configureTestPlanTools", () => {
 
     it("should create test case with testsWorkItemId and all other optional parameters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_create_test_case");
-      if (!call) throw new Error("testplan_create_test_case tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.createWorkItem as jest.Mock).mockResolvedValue({
@@ -1926,6 +2282,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "create" as const,
         project: "proj1",
         title: "Complete Test Case with Link",
         steps: "1. Execute comprehensive test|All tests pass successfully",
@@ -1969,13 +2326,37 @@ describe("configureTestPlanTools", () => {
       );
       expect(result.content[0].text).toContain("Complete Test Case with Link");
     });
+
+    it("should return error when project is missing for create", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "create" as const, title: "Some Test" } as any);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("project is required for create");
+    });
+
+    it("should return error when title is missing for create", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "create" as const, project: "proj1" } as any);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("title is required for create");
+    });
   });
 
   describe("update_test_case_steps tool", () => {
     it("should update test case steps with proper parameters", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -1988,6 +2369,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136717,
         steps: "1. Updated step 1|Expected result 1\n2. Updated step 2|Expected result 2",
       };
@@ -2012,8 +2394,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle steps with pipe delimiter for expected results", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2025,6 +2407,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136718,
         steps: "1. Login to application|User is logged in successfully\n2. Navigate to dashboard|Dashboard page loads correctly\n3. Perform action|Action completes as expected",
       };
@@ -2057,8 +2440,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle steps without pipe delimiter using default expected result", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2070,6 +2453,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136719,
         steps: "1. Click button\n2. Verify result\n3. Close application",
       };
@@ -2102,8 +2486,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle XML special characters in steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2115,6 +2499,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136720,
         steps: "1. Enter text with <special> & 'quotes' and \"double quotes\"|Text is accepted correctly\n2. Submit form|Form submits without errors",
       };
@@ -2139,8 +2524,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty or whitespace-only steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2152,6 +2537,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136721,
         steps: "1. Valid step\n\n   \n2. Another valid step",
       };
@@ -2176,13 +2562,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when updating test case steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "update_steps" as const,
         id: 136722,
         steps: "1. Test step that will fail",
       };
@@ -2195,13 +2582,14 @@ describe("configureTestPlanTools", () => {
 
     it("should store HTML tags as XML-escaped formatting in step content", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200001, rev: 2, fields: {} });
 
       const params = {
+        action: "update_steps" as const,
         id: 200001,
         steps: "1. Click <b>Save</b> button|Button <i>highlights</i> and form submits",
       };
@@ -2226,13 +2614,14 @@ describe("configureTestPlanTools", () => {
 
     it("should convert Markdown bold and italic to XML-escaped HTML", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200002, rev: 2, fields: {} });
 
       const params = {
+        action: "update_steps" as const,
         id: 200002,
         steps: "1. Press **Submit**|Result shows *success* message",
       };
@@ -2257,13 +2646,14 @@ describe("configureTestPlanTools", () => {
 
     it("should convert Markdown inline code to XML-escaped HTML code tags", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200003, rev: 2, fields: {} });
 
       const params = {
+        action: "update_steps" as const,
         id: 200003,
         steps: "1. Run `npm install`|Command exits with code `0`",
       };
@@ -2288,13 +2678,14 @@ describe("configureTestPlanTools", () => {
 
     it("should escape non-whitelisted HTML tags", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200004, rev: 2, fields: {} });
 
       const params = {
+        action: "update_steps" as const,
         id: 200004,
         steps: "1. Inject <script>alert(1)</script>|Should be escaped",
       };
@@ -2315,13 +2706,14 @@ describe("configureTestPlanTools", () => {
 
     it("should convert Markdown links to XML-escaped anchor tags", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({ id: 200005, rev: 2, fields: {} });
 
       const params = {
+        action: "update_steps" as const,
         id: 200005,
         steps: "1. Open [Azure Portal](https://portal.azure.com)|Portal loads",
       };
@@ -2342,8 +2734,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle mixed numbered and non-numbered steps", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2355,6 +2747,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136723,
         steps: "1. Numbered step one|Expected result one\nNon-numbered step\n3. Another numbered step|Expected result three",
       };
@@ -2391,8 +2784,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle multiple pipe characters in expected results", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2404,6 +2797,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136724,
         steps: "1. Check status message|Message shows 'Success | Warning | Error' status options",
       };
@@ -2428,8 +2822,8 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty expected results after pipe delimiter", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_update_test_case_steps");
-      if (!call) throw new Error("testplan_update_test_case_steps tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
       const [, , , handler] = call;
 
       (mockWitApi.updateWorkItem as jest.Mock).mockResolvedValue({
@@ -2441,6 +2835,7 @@ describe("configureTestPlanTools", () => {
       });
 
       const params = {
+        action: "update_steps" as const,
         id: 136725,
         steps: "1. Perform action|\n2. Another action|",
       };
@@ -2466,18 +2861,58 @@ describe("configureTestPlanTools", () => {
       );
       expect(result.content[0].text).toContain("Empty Expected Results Test Case");
     });
+
+    it("should return error when id is missing for update_steps", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "update_steps" as const, steps: "1. Step one" } as any);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("id is required for update_steps");
+    });
+
+    it("should return error when steps is missing for update_steps", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "update_steps" as const, id: 1 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("steps is required for update_steps");
+    });
+
+    it("should handle non-Error throws in update_steps and use fallback message", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockWitApi.updateWorkItem as jest.Mock).mockRejectedValue("non-Error string thrown");
+
+      const params = { action: "update_steps" as const, id: 1, steps: "1. step" };
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
   });
 
   describe("add_test_cases_to_suite tool", () => {
     it("should add test cases to suite with array of IDs", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
-      if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([{ testCase: { id: 1001 } }, { testCase: { id: 1002 } }]);
 
       const params = {
+        action: "add_test_cases" as const,
         project: "proj1",
         planId: 1,
         suiteId: 2,
@@ -2491,13 +2926,14 @@ describe("configureTestPlanTools", () => {
 
     it("should add test cases to suite with comma-separated string", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
-      if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([{ testCase: { id: 1003 } }, { testCase: { id: 1004 } }]);
 
       const params = {
+        action: "add_test_cases" as const,
         project: "proj1",
         planId: 1,
         suiteId: 2,
@@ -2511,13 +2947,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle empty results when adding test cases", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
-      if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockResolvedValue([]);
 
       const params = {
+        action: "add_test_cases" as const,
         project: "proj1",
         planId: 1,
         suiteId: 2,
@@ -2530,13 +2967,14 @@ describe("configureTestPlanTools", () => {
 
     it("should handle API errors when adding test cases to suite", async () => {
       configureTestPlanTools(server, tokenProvider, connectionProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_add_test_cases_to_suite");
-      if (!call) throw new Error("testplan_add_test_cases_to_suite tool not registered");
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
       const [, , , handler] = call;
 
       (mockTestApi.addTestCasesToSuite as jest.Mock).mockRejectedValue(new Error("API Error"));
 
       const params = {
+        action: "add_test_cases" as const,
         project: "proj1",
         planId: 1,
         suiteId: 2,
@@ -2547,6 +2985,54 @@ describe("configureTestPlanTools", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Error adding test cases to suite");
       expect(result.content[0].text).toContain("API Error");
+    });
+
+    it("should handle non-Error throws in add_test_cases and use fallback message", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockTestApi.addTestCasesToSuite as jest.Mock).mockRejectedValue("non-Error string thrown");
+
+      const params = { action: "add_test_cases" as const, project: "proj1", planId: 1, suiteId: 2, testCaseIds: ["1001"] };
+      const result = await handler(params);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown error occurred");
+    });
+
+    it("should return error when planId is missing for add_test_cases", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "add_test_cases" as const, project: "proj1", suiteId: 2, testCaseIds: ["1001"] } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("planId is required for add_test_cases");
+    });
+
+    it("should return error when suiteId is missing for add_test_cases", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "add_test_cases" as const, project: "proj1", planId: 1, testCaseIds: ["1001"] } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("suiteId is required for add_test_cases");
+    });
+
+    it("should return error when testCaseIds is missing for add_test_cases", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "add_test_cases" as const, project: "proj1", planId: 1, suiteId: 2 } as any);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("testCaseIds is required for add_test_cases");
     });
   });
 });

--- a/test/src/tools/test-plan.test.ts
+++ b/test/src/tools/test-plan.test.ts
@@ -987,6 +987,17 @@ describe("configureTestPlanTools", () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.testCases).toEqual([]);
     });
+
+    it("should return error for unknown action", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan");
+      if (!call) throw new Error("testplan tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "unknown_action" as any, project: "proj1", filterActivePlans: true, includePlanDetails: false });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown action: unknown_action");
+    });
   });
 
   describe("test_results_from_build_id tool", () => {
@@ -2900,6 +2911,17 @@ describe("configureTestPlanTools", () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("Unknown error occurred");
     });
+
+    it("should return error for unknown action", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_case_write");
+      if (!call) throw new Error("testplan_test_case_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "unknown_action" as any });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown action: unknown_action");
+    });
   });
 
   describe("add_test_cases_to_suite tool", () => {
@@ -3033,6 +3055,17 @@ describe("configureTestPlanTools", () => {
       const result = await handler({ action: "add_test_cases" as const, project: "proj1", planId: 1, suiteId: 2 } as any);
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain("testCaseIds is required for add_test_cases");
+    });
+
+    it("should return error for unknown action", async () => {
+      configureTestPlanTools(server, tokenProvider, connectionProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "testplan_test_suite_write");
+      if (!call) throw new Error("testplan_test_suite_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "unknown_action" as any, project: "proj1" });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Unknown action: unknown_action");
     });
   });
 });


### PR DESCRIPTION
This pull request updates the documentation for Azure DevOps test plan tools to align with the structure used by the Azure DevOps remote MCP server. The changes consolidate and reorganize the test plan tools into grouped dispatchers using an `action` parameter, making the documentation more consistent and easier to use.

**Test Plan Tool Restructuring:**

* The test plan tools are now grouped under dispatcher endpoints like `testplan`, `testplan_test_plan_write`, `testplan_test_suite_write`, and `testplan_test_case_write`, each supporting multiple actions via an `action` parameter. [[1]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L80-R92) [[2]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L443-R490)
* The documentation table has been updated to reflect the new tool names, actions, and required/optional parameters for each operation. [[1]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L80-R92) [[2]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L443-R490)
* Deprecated individual tool endpoints (e.g., `mcp_ado_testplan_list_test_plans`, `mcp_ado_testplan_create_test_plan`, etc.) in favor of the new grouped dispatcher structure.

**Documentation Improvements:**

* Added a prominent note explaining the alignment with the Azure DevOps remote MCP server tool structure and the consolidation of test plan tools. [[1]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L80-R92) [[2]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025L443-R490)
* Updated descriptions and parameter lists to clarify usage and support for Markdown formatting in test case steps.

## GitHub issue number
N/A

## **Associated Risks**

Changes to tools signatures and descriptions

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual tested and updated all automated tests
