### PR TITLE
refact: add Command on dispatch action functions and use compile-time data transfer objects (DTOs)

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -53,6 +53,8 @@ module.exports = {
     "^(.+)/logger\\.js$": "$1/logger.ts",
     "^(.+)/elicitations\\.js$": "$1/elicitations.ts",
     "^(.+)/content-safety\\.js$": "$1/content-safety.ts",
+    "^(.+)/command\\.js$": "$1/command.ts",
+    "^(.+)/pipelines\\.dto\\.js$": "$1/pipelines.dto.ts",
     "^(.+)/index\\.js$": "$1/index.ts",
   },
 };

--- a/src/shared/command.ts
+++ b/src/shared/command.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { WebApi } from "azure-devops-node-api";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z, ZodRawShape } from "zod";
+
+/**
+ * Shared infrastructure available to every command.
+ *
+ * Command-specific data is passed separately via the typed args object, so the
+ * `Command` interface stays stable even as individual commands evolve. This is
+ * the same "context + typed args" split used by frameworks like Express and
+ * NestJS: shared infrastructure goes into the context, request-specific data
+ * goes into the arguments.
+ */
+export interface CommandContext {
+  /** Returns an authenticated Azure DevOps Web API connection. */
+  connectionProvider: () => Promise<WebApi>;
+  /** Returns a bearer token for direct REST calls. */
+  tokenProvider: () => Promise<string>;
+  /** Returns the User-Agent string to attach to outbound requests. */
+  userAgentProvider: () => string;
+}
+
+/**
+ * Infers the typed args object from the Zod raw shape that is passed to
+ * `server.tool(...)`. Lets a command declare a single strongly-typed argument
+ * object instead of a long positional parameter list.
+ */
+export type CommandArgs<TShape extends ZodRawShape> = z.infer<z.ZodObject<TShape>>;
+
+/**
+ * A command encapsulates the behavior of a single MCP tool action.
+ *
+ * Shared infrastructure is received via `context`; command-specific input via
+ * the typed `args` object.
+ *
+ * @example
+ * const searchCommand: Command<SearchArgs> = {
+ *   async execute(context, args) {
+ *     const connection = await context.connectionProvider();
+ *     // ...use args.query, args.maxResults, etc.
+ *   },
+ * };
+ */
+export interface Command<TArgs> {
+  execute(context: CommandContext, args: TArgs): Promise<CallToolResult>;
+}
+
+/** A registry that maps each action name to the command that handles it. */
+export type CommandRegistry<TArgs extends { action: string }> = Partial<Record<TArgs["action"], Command<TArgs>>>;
+
+/** Builds an error `CallToolResult`. */
+export const errorResult = (text: string): CallToolResult => ({ content: [{ type: "text", text }], isError: true });
+
+/**
+ * Routes a validated, action-carrying args object to the matching command.
+ *
+ * This is what removes long positional parameter lists from grouped ("action")
+ * tools: instead of destructuring every possible field, the whole typed args
+ * object is forwarded to the single command keyed by `args.action`, coupling
+ * each action to exactly one command.
+ *
+ * - Unknown actions short-circuit with an "Unknown action" error and never
+ *   touch the context (so no connection is opened).
+ * - Errors thrown by a command are caught and formatted using the optional
+ *   per-action `errorPrefixes` map (falling back to a generic message).
+ * - Errors returned by a command (e.g. validation `errorResult`s) pass through
+ *   unchanged.
+ */
+export async function dispatchAction<TArgs extends { action: string }>(
+  commands: CommandRegistry<TArgs>,
+  context: CommandContext,
+  args: TArgs,
+  errorPrefixes?: Partial<Record<TArgs["action"], string>>
+): Promise<CallToolResult> {
+  const command = commands[args.action as TArgs["action"]];
+  if (!command) return errorResult(`Unknown action: ${args.action}`);
+
+  try {
+    return await command.execute(context, args);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error occurred";
+    const prefix = errorPrefixes?.[args.action as TArgs["action"]];
+    return errorResult(prefix ? `${prefix}${message}` : `Error: ${message}`);
+  }
+}

--- a/src/shared/command.ts
+++ b/src/shared/command.ts
@@ -76,7 +76,10 @@ export async function dispatchAction<TArgs extends { action: string }>(
   errorPrefixes?: Partial<Record<TArgs["action"], string>>
 ): Promise<CallToolResult> {
   const command = commands[args.action as TArgs["action"]];
-  if (!command) return errorResult(`Unknown action: ${args.action}`);
+  if (!command) {
+    const supportedActions = Object.keys(commands).sort().join(", ");
+    return errorResult(`Unknown action: ${args.action}. Supported actions: ${supportedActions}`);
+  }
 
   try {
     return await command.execute(context, args);

--- a/src/tools/pipelines.dto.ts
+++ b/src/tools/pipelines.dto.ts
@@ -26,13 +26,15 @@ export const resourcesSchema = z.object({
   builds: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
   containers: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
   packages: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-  pipelines: z.record(
-    z.string(),
-    z.object({
-      runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
-      version: z.string().optional(),
-    })
-  ),
+  pipelines: z
+    .record(
+      z.string(),
+      z.object({
+        runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
+        version: z.string().optional(),
+      })
+    )
+    .optional(),
   repositories: z
     .record(
       z.string(),

--- a/src/tools/pipelines.dto.ts
+++ b/src/tools/pipelines.dto.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { z } from "zod";
+import { getEnumKeys } from "../utils.js";
+import { RepositoryType } from "azure-devops-node-api/interfaces/PipelinesInterfaces.js";
+import { StageUpdateType } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DTOs for the pipelines_write tool.
+//
+// Each action's inputs are declared once as a Zod "raw shape". The shapes are
+// the single source of truth: the tool's input schema is composed from them,
+// and the TypeScript argument types are derived via `z.infer` (no hand-written,
+// drift-prone duplicate types). These types are safe to export — they are
+// compile-time only and erased at runtime, so they have no effect on the MCP
+// protocol or a local server.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const variableSchema = z.object({
+  value: z.string().optional(),
+  isSecret: z.boolean().optional(),
+});
+
+export const resourcesSchema = z.object({
+  builds: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  containers: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  packages: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  pipelines: z.record(
+    z.string(),
+    z.object({
+      runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
+      version: z.string().optional(),
+    })
+  ),
+  repositories: z
+    .record(
+      z.string(),
+      z.object({
+        refName: z.string().describe("Reference name, e.g., refs/heads/main."),
+        token: z.string().optional(),
+        tokenType: z.string().optional(),
+        version: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+/** Fields shared by every write action. */
+const projectShape = {
+  project: z.string().describe("Project ID or name."),
+};
+
+/** run_pipeline inputs. */
+export const runPipelineShape = {
+  ...projectShape,
+  pipelineId: z.coerce.number().min(1).optional().describe("ID of the pipeline to run. Required for: run_pipeline."),
+  pipelineVersion: z.coerce.number().min(1).optional().describe("Version of the pipeline to run. Used for: run_pipeline."),
+  previewRun: z.boolean().optional().describe("If true, returns the final YAML without creating a run. Used for: run_pipeline."),
+  resources: resourcesSchema.optional().describe("Resources to pass to the pipeline. Used for: run_pipeline."),
+  stagesToSkip: z.array(z.string()).optional().describe("Stages to skip. Used for: run_pipeline."),
+  templateParameters: z.record(z.string(), z.string()).optional().describe("Custom build parameters as key-value pairs. Used for: run_pipeline."),
+  variables: z.record(z.string(), variableSchema).optional().describe("Variables to pass to the pipeline. Used for: run_pipeline."),
+  yamlOverride: z.string().optional().describe("YAML override (only valid with previewRun). Used for: run_pipeline."),
+};
+
+/** create_pipeline inputs. */
+export const createPipelineShape = {
+  ...projectShape,
+  name: z.string().optional().describe("Name of the new pipeline. Required for: create_pipeline."),
+  folder: z.string().optional().describe("Folder path for the new pipeline. Used for: create_pipeline."),
+  yamlPath: z.string().optional().describe("Path to the YAML file in the repository. Required for: create_pipeline."),
+  repositoryType: z
+    .enum(getEnumKeys(RepositoryType) as [string, ...string[]])
+    .optional()
+    .describe("Type of the repository. Required for: create_pipeline."),
+  repositoryName: z.string().optional().describe("Name of the repository (for GitHub: owner/repo). Required for: create_pipeline."),
+  repositoryId: z.string().optional().describe("ID of the repository. Used for: create_pipeline."),
+  repositoryConnectionId: z.string().optional().describe("Service connection ID for GitHub repositories. Used for: create_pipeline."),
+};
+
+/** update_build_stage inputs. */
+export const updateBuildStageShape = {
+  ...projectShape,
+  buildId: z.coerce.number().min(1).optional().describe("ID of the build to update. Required for: update_build_stage."),
+  stageName: z.string().optional().describe("Name of the stage to update. Required for: update_build_stage."),
+  status: z
+    .enum(getEnumKeys(StageUpdateType) as [string, ...string[]])
+    .optional()
+    .describe("New status for the stage. Required for: update_build_stage."),
+  forceRetryAllJobs: z.boolean().default(false).describe("Whether to force retry all jobs in the stage. Used for: update_build_stage."),
+};
+
+/** The composed input shape for the grouped `pipelines_write` tool. */
+export const pipelinesWriteShape = {
+  action: z
+    .enum(["run_pipeline", "create_pipeline", "update_build_stage"])
+    .describe(
+      "The action to perform. Options: run_pipeline (queue a new pipeline run), create_pipeline (create a new YAML pipeline definition), update_build_stage (cancel, retry, or run a stage on an in-flight build)."
+    ),
+  ...runPipelineShape,
+  ...createPipelineShape,
+  ...updateBuildStageShape,
+};
+
+// Per-action schemas + inferred argument DTOs. `z.infer` keeps these types in
+// lockstep with the schemas above.
+export const runPipelineSchema = z.object(runPipelineShape);
+export const createPipelineSchema = z.object(createPipelineShape);
+export const updateBuildStageSchema = z.object(updateBuildStageShape);
+export const pipelinesWriteSchema = z.object(pipelinesWriteShape);
+
+export type RunPipelineArgs = z.infer<typeof runPipelineSchema>;
+export type CreatePipelineArgs = z.infer<typeof createPipelineSchema>;
+export type UpdateBuildStageArgs = z.infer<typeof updateBuildStageSchema>;
+export type PipelinesWriteArgs = z.infer<typeof pipelinesWriteSchema>;

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -11,6 +11,179 @@ import { ConfigurationType, RepositoryType } from "azure-devops-node-api/interfa
 import { mkdirSync, createWriteStream } from "fs";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 import { join, posix, resolve, win32 } from "path";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Command, CommandContext, CommandRegistry, dispatchAction, errorResult } from "../shared/command.js";
+
+const variableSchema = z.object({
+  value: z.string().optional(),
+  isSecret: z.boolean().optional(),
+});
+
+const resourcesSchema = z.object({
+  builds: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  containers: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  packages: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
+  pipelines: z.record(
+    z.string(),
+    z.object({
+      runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
+      version: z.string().optional(),
+    })
+  ),
+  repositories: z
+    .record(
+      z.string(),
+      z.object({
+        refName: z.string().describe("Reference name, e.g., refs/heads/main."),
+        token: z.string().optional(),
+        tokenType: z.string().optional(),
+        version: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+// ─── pipelines_write commands ────────────────────────────────────────────────
+// Each write action is a self-contained command. Shared infrastructure arrives
+// via `CommandContext`; the action-specific input arrives via a single typed
+// args object. This keeps the dispatcher agnostic of individual argument lists.
+
+type RunPipelineArgs = {
+  project: string;
+  pipelineId?: number;
+  pipelineVersion?: number;
+  previewRun?: boolean;
+  resources?: z.infer<typeof resourcesSchema>;
+  stagesToSkip?: string[];
+  templateParameters?: Record<string, string>;
+  variables?: Record<string, z.infer<typeof variableSchema>>;
+  yamlOverride?: string;
+};
+
+const runPipelineCommand: Command<RunPipelineArgs> = {
+  async execute(context: CommandContext, args: RunPipelineArgs): Promise<CallToolResult> {
+    if (!args.pipelineId) return errorResult("pipelineId is required for run_pipeline");
+    if (!args.previewRun && args.yamlOverride) throw new Error("Parameter 'yamlOverride' can only be specified together with parameter 'previewRun'.");
+
+    const connection = await context.connectionProvider();
+    const pipelinesApi = await connection.getPipelinesApi();
+    const runRequest = {
+      previewRun: args.previewRun,
+      resources: { ...args.resources },
+      stagesToSkip: args.stagesToSkip,
+      templateParameters: args.templateParameters,
+      variables: args.variables,
+      yamlOverride: args.yamlOverride,
+    };
+    const pipelineRun = await pipelinesApi.runPipeline(runRequest, args.project, args.pipelineId, args.pipelineVersion);
+
+    if (pipelineRun.id === undefined) throw new Error("Failed to get build ID from pipeline run");
+
+    return { content: [{ type: "text", text: JSON.stringify(pipelineRun, null, 2) }] };
+  },
+};
+
+type CreatePipelineArgs = {
+  project: string;
+  name?: string;
+  folder?: string;
+  yamlPath?: string;
+  repositoryType?: string;
+  repositoryName?: string;
+  repositoryId?: string;
+  repositoryConnectionId?: string;
+};
+
+const createPipelineCommand: Command<CreatePipelineArgs> = {
+  async execute(context: CommandContext, args: CreatePipelineArgs): Promise<CallToolResult> {
+    if (!args.name) return errorResult("name is required for create_pipeline");
+    if (!args.yamlPath) return errorResult("yamlPath is required for create_pipeline");
+    if (!args.repositoryType) return errorResult("repositoryType is required for create_pipeline");
+    if (!args.repositoryName) return errorResult("repositoryName is required for create_pipeline");
+
+    const connection = await context.connectionProvider();
+    const pipelinesApi = await connection.getPipelinesApi();
+    const repositoryTypeEnumValue = safeEnumConvert(RepositoryType, args.repositoryType);
+    const repositoryPayload: Record<string, unknown> = { type: args.repositoryType };
+
+    if (repositoryTypeEnumValue === RepositoryType.AzureReposGit) {
+      repositoryPayload.id = args.repositoryId;
+      repositoryPayload.name = args.repositoryName;
+    } else if (repositoryTypeEnumValue === RepositoryType.GitHub) {
+      if (!args.repositoryConnectionId) throw new Error("Parameter 'repositoryConnectionId' is required for GitHub repositories.");
+      repositoryPayload.connection = { id: args.repositoryConnectionId };
+      repositoryPayload.fullname = args.repositoryName;
+    } else {
+      throw new Error("Unsupported repository type");
+    }
+
+    const yamlConfigurationType = getEnumKeys(ConfigurationType).find((k) => ConfigurationType[k as keyof typeof ConfigurationType] === ConfigurationType.Yaml);
+    const createParams: Record<string, unknown> = {
+      name: args.name,
+      folder: args.folder || "\\",
+      configuration: { type: yamlConfigurationType, path: args.yamlPath, repository: repositoryPayload, variables: undefined },
+    };
+    const newPipeline = await pipelinesApi.createPipeline(createParams, args.project);
+
+    return { content: [{ type: "text", text: JSON.stringify(newPipeline, null, 2) }] };
+  },
+};
+
+type UpdateBuildStageArgs = {
+  project: string;
+  buildId?: number;
+  stageName?: string;
+  status?: string;
+  forceRetryAllJobs: boolean;
+};
+
+const updateBuildStageCommand: Command<UpdateBuildStageArgs> = {
+  async execute(context: CommandContext, args: UpdateBuildStageArgs): Promise<CallToolResult> {
+    if (!args.buildId) return errorResult("buildId is required for update_build_stage");
+    if (!args.stageName) return errorResult("stageName is required for update_build_stage");
+    if (!args.status) return errorResult("status is required for update_build_stage");
+
+    const connection = await context.connectionProvider();
+    const orgUrl = connection.serverUrl;
+    const endpoint = `${orgUrl}/${encodeURIComponent(args.project)}/_apis/build/builds/${args.buildId}/stages/${encodeURIComponent(args.stageName)}?api-version=${apiVersion}`;
+    const token = await context.tokenProvider();
+    const body = { forceRetryAllJobs: args.forceRetryAllJobs, state: safeEnumConvert(StageUpdateType, args.status) };
+    const response = await fetch(endpoint, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}`, "User-Agent": context.userAgentProvider() },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update build stage: ${response.status} ${errorText}`);
+    }
+
+    const updatedBuild = await response.text();
+
+    return { content: [{ type: "text", text: JSON.stringify(updatedBuild, null, 2) }] };
+  },
+};
+
+/** The full, action-carrying args object accepted by the `pipelines_write` tool. */
+type PipelinesWriteArgs = { action: "run_pipeline" | "create_pipeline" | "update_build_stage" } & RunPipelineArgs & CreatePipelineArgs & UpdateBuildStageArgs;
+
+/**
+ * The registry is the lookup table that couples each action to its command.
+ * Adding a new write action means registering one entry here — the dispatcher
+ * (`dispatchAction`) never changes.
+ */
+const pipelinesWriteCommands: CommandRegistry<PipelinesWriteArgs> = {
+  run_pipeline: runPipelineCommand,
+  create_pipeline: createPipelineCommand,
+  update_build_stage: updateBuildStageCommand,
+};
+
+const pipelinesWriteErrorPrefixes: Record<PipelinesWriteArgs["action"], string> = {
+  run_pipeline: "Error running pipeline: ",
+  create_pipeline: "Error creating pipeline: ",
+  update_build_stage: "Error updating build stage: ",
+};
 
 const PIPELINE_TOOLS = {
   pipelines_build: "pipelines_build",
@@ -329,7 +502,6 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     }
   );
 
-  // ─── pipelines_artifact ─────────────────────────────────────────────────────
   server.tool(
     PIPELINE_TOOLS.pipelines_artifact,
     "Retrieve and download build artifacts. Use the action parameter to specify the operation.",
@@ -419,35 +591,6 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
     }
   );
 
-  const variableSchema = z.object({
-    value: z.string().optional(),
-    isSecret: z.boolean().optional(),
-  });
-
-  const resourcesSchema = z.object({
-    builds: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-    containers: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-    packages: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-    pipelines: z.record(
-      z.string(),
-      z.object({
-        runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
-        version: z.string().optional(),
-      })
-    ),
-    repositories: z
-      .record(
-        z.string(),
-        z.object({
-          refName: z.string().describe("Reference name, e.g., refs/heads/main."),
-          token: z.string().optional(),
-          tokenType: z.string().optional(),
-          version: z.string().optional(),
-        })
-      )
-      .optional(),
-  });
-
   // ─── pipelines_write ────────────────────────────────────────────────────────
   server.tool(
     PIPELINE_TOOLS.pipelines_write,
@@ -488,120 +631,12 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
         .describe("New status for the stage. Required for: update_build_stage."),
       forceRetryAllJobs: z.boolean().default(false).describe("Whether to force retry all jobs in the stage. Used for: update_build_stage."),
     },
-    async ({
-      action,
-      project,
-      pipelineId,
-      pipelineVersion,
-      previewRun,
-      resources,
-      stagesToSkip,
-      templateParameters,
-      variables,
-      yamlOverride,
-      name,
-      folder,
-      yamlPath,
-      repositoryType,
-      repositoryName,
-      repositoryId,
-      repositoryConnectionId,
-      buildId,
-      stageName,
-      status,
-      forceRetryAllJobs,
-    }) => {
-      try {
-        if (action === "run_pipeline") {
-          if (!pipelineId) return { content: [{ type: "text", text: "pipelineId is required for run_pipeline" }], isError: true };
-          if (!previewRun && yamlOverride) throw new Error("Parameter 'yamlOverride' can only be specified together with parameter 'previewRun'.");
-        }
-
-        if (action === "create_pipeline") {
-          if (!name) return { content: [{ type: "text", text: "name is required for create_pipeline" }], isError: true };
-          if (!yamlPath) return { content: [{ type: "text", text: "yamlPath is required for create_pipeline" }], isError: true };
-          if (!repositoryType) return { content: [{ type: "text", text: "repositoryType is required for create_pipeline" }], isError: true };
-          if (!repositoryName) return { content: [{ type: "text", text: "repositoryName is required for create_pipeline" }], isError: true };
-        }
-
-        if (action === "update_build_stage") {
-          if (!buildId) return { content: [{ type: "text", text: "buildId is required for update_build_stage" }], isError: true };
-          if (!stageName) return { content: [{ type: "text", text: "stageName is required for update_build_stage" }], isError: true };
-          if (!status) return { content: [{ type: "text", text: "status is required for update_build_stage" }], isError: true };
-        }
-
-        const connection = await connectionProvider();
-
-        if (action === "run_pipeline") {
-          const pipelinesApi = await connection.getPipelinesApi();
-          const runRequest = { previewRun, resources: { ...resources }, stagesToSkip, templateParameters, variables, yamlOverride };
-          const pipelineRun = await pipelinesApi.runPipeline(runRequest, project, pipelineId as number, pipelineVersion);
-
-          if (pipelineRun.id === undefined) throw new Error("Failed to get build ID from pipeline run");
-
-          return { content: [{ type: "text", text: JSON.stringify(pipelineRun, null, 2) }] };
-        }
-
-        if (action === "create_pipeline") {
-          const pipelinesApi = await connection.getPipelinesApi();
-          const repositoryTypeEnumValue = safeEnumConvert(RepositoryType, repositoryType);
-          const repositoryPayload: Record<string, unknown> = { type: repositoryType };
-
-          if (repositoryTypeEnumValue === RepositoryType.AzureReposGit) {
-            repositoryPayload.id = repositoryId;
-            repositoryPayload.name = repositoryName;
-          } else if (repositoryTypeEnumValue === RepositoryType.GitHub) {
-            if (!repositoryConnectionId) throw new Error("Parameter 'repositoryConnectionId' is required for GitHub repositories.");
-            repositoryPayload.connection = { id: repositoryConnectionId };
-            repositoryPayload.fullname = repositoryName;
-          } else {
-            throw new Error("Unsupported repository type");
-          }
-
-          const yamlConfigurationType = getEnumKeys(ConfigurationType).find((k) => ConfigurationType[k as keyof typeof ConfigurationType] === ConfigurationType.Yaml);
-          const createParams: Record<string, unknown> = {
-            name,
-            folder: folder || "\\",
-            configuration: { type: yamlConfigurationType, path: yamlPath, repository: repositoryPayload, variables: undefined },
-          };
-          const newPipeline = await pipelinesApi.createPipeline(createParams, project);
-
-          return { content: [{ type: "text", text: JSON.stringify(newPipeline, null, 2) }] };
-        }
-
-        if (action === "update_build_stage") {
-          const orgUrl = connection.serverUrl;
-          const endpoint = `${orgUrl}/${encodeURIComponent(project)}/_apis/build/builds/${buildId as number}/stages/${encodeURIComponent(stageName as string)}?api-version=${apiVersion}`;
-          const token = await tokenProvider();
-          const body = { forceRetryAllJobs, state: safeEnumConvert(StageUpdateType, status as string) };
-          const response = await fetch(endpoint, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}`, "User-Agent": userAgentProvider() },
-            body: JSON.stringify(body),
-          });
-
-          if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`Failed to update build stage: ${response.status} ${errorText}`);
-          }
-
-          const updatedBuild = await response.text();
-
-          return { content: [{ type: "text", text: JSON.stringify(updatedBuild, null, 2) }] };
-        }
-
-        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-        const msgs: Record<string, string> = {
-          run_pipeline: `Error running pipeline: ${errorMessage}`,
-          create_pipeline: `Error creating pipeline: ${errorMessage}`,
-          update_build_stage: `Error updating build stage: ${errorMessage}`,
-        };
-        return { content: [{ type: "text", text: msgs[action] ?? `Error: ${errorMessage}` }], isError: true };
-      }
+    async (args) => {
+      const context: CommandContext = { connectionProvider, tokenProvider, userAgentProvider };
+      return dispatchAction(pipelinesWriteCommands, context, args as unknown as PipelinesWriteArgs, pipelinesWriteErrorPrefixes);
     }
   );
 }
 
-export { PIPELINE_TOOLS, configurePipelineTools };
+export { PIPELINE_TOOLS, configurePipelineTools, runPipelineCommand, createPipelineCommand, updateBuildStageCommand };
+export type { RunPipelineArgs, CreatePipelineArgs, UpdateBuildStageArgs };

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -13,52 +13,13 @@ import { createExternalContentResponse } from "../shared/content-safety.js";
 import { join, posix, resolve, win32 } from "path";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { Command, CommandContext, CommandRegistry, dispatchAction, errorResult } from "../shared/command.js";
-
-const variableSchema = z.object({
-  value: z.string().optional(),
-  isSecret: z.boolean().optional(),
-});
-
-const resourcesSchema = z.object({
-  builds: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-  containers: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-  packages: z.record(z.string(), z.object({ version: z.string().optional() })).optional(),
-  pipelines: z.record(
-    z.string(),
-    z.object({
-      runId: z.coerce.number().min(1).optional().describe("Id of the source pipeline run."),
-      version: z.string().optional(),
-    })
-  ),
-  repositories: z
-    .record(
-      z.string(),
-      z.object({
-        refName: z.string().describe("Reference name, e.g., refs/heads/main."),
-        token: z.string().optional(),
-        tokenType: z.string().optional(),
-        version: z.string().optional(),
-      })
-    )
-    .optional(),
-});
+import { pipelinesWriteShape, RunPipelineArgs, CreatePipelineArgs, UpdateBuildStageArgs, PipelinesWriteArgs } from "./pipelines.dto.js";
 
 // ─── pipelines_write commands ────────────────────────────────────────────────
 // Each write action is a self-contained command. Shared infrastructure arrives
 // via `CommandContext`; the action-specific input arrives via a single typed
-// args object. This keeps the dispatcher agnostic of individual argument lists.
-
-type RunPipelineArgs = {
-  project: string;
-  pipelineId?: number;
-  pipelineVersion?: number;
-  previewRun?: boolean;
-  resources?: z.infer<typeof resourcesSchema>;
-  stagesToSkip?: string[];
-  templateParameters?: Record<string, string>;
-  variables?: Record<string, z.infer<typeof variableSchema>>;
-  yamlOverride?: string;
-};
+// args object (see pipelines.dto.ts). This keeps the dispatcher agnostic of
+// individual argument lists.
 
 const runPipelineCommand: Command<RunPipelineArgs> = {
   async execute(context: CommandContext, args: RunPipelineArgs): Promise<CallToolResult> {
@@ -81,17 +42,6 @@ const runPipelineCommand: Command<RunPipelineArgs> = {
 
     return { content: [{ type: "text", text: JSON.stringify(pipelineRun, null, 2) }] };
   },
-};
-
-type CreatePipelineArgs = {
-  project: string;
-  name?: string;
-  folder?: string;
-  yamlPath?: string;
-  repositoryType?: string;
-  repositoryName?: string;
-  repositoryId?: string;
-  repositoryConnectionId?: string;
 };
 
 const createPipelineCommand: Command<CreatePipelineArgs> = {
@@ -129,14 +79,6 @@ const createPipelineCommand: Command<CreatePipelineArgs> = {
   },
 };
 
-type UpdateBuildStageArgs = {
-  project: string;
-  buildId?: number;
-  stageName?: string;
-  status?: string;
-  forceRetryAllJobs: boolean;
-};
-
 const updateBuildStageCommand: Command<UpdateBuildStageArgs> = {
   async execute(context: CommandContext, args: UpdateBuildStageArgs): Promise<CallToolResult> {
     if (!args.buildId) return errorResult("buildId is required for update_build_stage");
@@ -164,9 +106,6 @@ const updateBuildStageCommand: Command<UpdateBuildStageArgs> = {
     return { content: [{ type: "text", text: JSON.stringify(updatedBuild, null, 2) }] };
   },
 };
-
-/** The full, action-carrying args object accepted by the `pipelines_write` tool. */
-type PipelinesWriteArgs = { action: "run_pipeline" | "create_pipeline" | "update_build_stage" } & RunPipelineArgs & CreatePipelineArgs & UpdateBuildStageArgs;
 
 /**
  * The registry is the lookup table that couples each action to its command.
@@ -592,50 +531,10 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
   );
 
   // ─── pipelines_write ────────────────────────────────────────────────────────
-  server.tool(
-    PIPELINE_TOOLS.pipelines_write,
-    "Write operations for pipelines and builds. Use the action parameter to specify the operation.",
-    {
-      action: z
-        .enum(["run_pipeline", "create_pipeline", "update_build_stage"])
-        .describe(
-          "The action to perform. Options: run_pipeline (queue a new pipeline run), create_pipeline (create a new YAML pipeline definition), update_build_stage (cancel, retry, or run a stage on an in-flight build)."
-        ),
-      project: z.string().describe("Project ID or name."),
-      // run_pipeline params
-      pipelineId: z.coerce.number().min(1).optional().describe("ID of the pipeline to run. Required for: run_pipeline."),
-      pipelineVersion: z.coerce.number().min(1).optional().describe("Version of the pipeline to run. Used for: run_pipeline."),
-      previewRun: z.boolean().optional().describe("If true, returns the final YAML without creating a run. Used for: run_pipeline."),
-      resources: resourcesSchema.optional().describe("Resources to pass to the pipeline. Used for: run_pipeline."),
-      stagesToSkip: z.array(z.string()).optional().describe("Stages to skip. Used for: run_pipeline."),
-      templateParameters: z.record(z.string(), z.string()).optional().describe("Custom build parameters as key-value pairs. Used for: run_pipeline."),
-      variables: z.record(z.string(), variableSchema).optional().describe("Variables to pass to the pipeline. Used for: run_pipeline."),
-      yamlOverride: z.string().optional().describe("YAML override (only valid with previewRun). Used for: run_pipeline."),
-      // create_pipeline params
-      name: z.string().optional().describe("Name of the new pipeline. Required for: create_pipeline."),
-      folder: z.string().optional().describe("Folder path for the new pipeline. Used for: create_pipeline."),
-      yamlPath: z.string().optional().describe("Path to the YAML file in the repository. Required for: create_pipeline."),
-      repositoryType: z
-        .enum(getEnumKeys(RepositoryType) as [string, ...string[]])
-        .optional()
-        .describe("Type of the repository. Required for: create_pipeline."),
-      repositoryName: z.string().optional().describe("Name of the repository (for GitHub: owner/repo). Required for: create_pipeline."),
-      repositoryId: z.string().optional().describe("ID of the repository. Used for: create_pipeline."),
-      repositoryConnectionId: z.string().optional().describe("Service connection ID for GitHub repositories. Used for: create_pipeline."),
-      // update_build_stage params
-      buildId: z.coerce.number().min(1).optional().describe("ID of the build to update. Required for: update_build_stage."),
-      stageName: z.string().optional().describe("Name of the stage to update. Required for: update_build_stage."),
-      status: z
-        .enum(getEnumKeys(StageUpdateType) as [string, ...string[]])
-        .optional()
-        .describe("New status for the stage. Required for: update_build_stage."),
-      forceRetryAllJobs: z.boolean().default(false).describe("Whether to force retry all jobs in the stage. Used for: update_build_stage."),
-    },
-    async (args) => {
-      const context: CommandContext = { connectionProvider, tokenProvider, userAgentProvider };
-      return dispatchAction(pipelinesWriteCommands, context, args as unknown as PipelinesWriteArgs, pipelinesWriteErrorPrefixes);
-    }
-  );
+  server.tool(PIPELINE_TOOLS.pipelines_write, "Write operations for pipelines and builds. Use the action parameter to specify the operation.", pipelinesWriteShape, async (args) => {
+    const context: CommandContext = { connectionProvider, tokenProvider, userAgentProvider };
+    return dispatchAction(pipelinesWriteCommands, context, args as unknown as PipelinesWriteArgs, pipelinesWriteErrorPrefixes);
+  });
 }
 
 export { PIPELINE_TOOLS, configurePipelineTools, runPipelineCommand, createPipelineCommand, updateBuildStageCommand };

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1864,7 +1864,7 @@ describe("configurePipelineTools", () => {
       const result = await handler({ action: "unknown" as any, project: "test-project" });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe("Unknown action: unknown");
+      expect(result.content[0].text).toBe("Unknown action: unknown. Supported actions: create_pipeline, run_pipeline, update_build_stage");
       expect(connectionProvider as jest.Mock).not.toHaveBeenCalled();
     });
 

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1601,10 +1601,10 @@ describe("configurePipelineTools", () => {
     });
 
     it.each([
-      ["name", { yamlPath: "p.yml", repositoryType: "AzureReposGit" as const, repositoryName: "repo" }, "name is required for create_pipeline"],
-      ["yamlPath", { name: "pipe", repositoryType: "AzureReposGit" as const, repositoryName: "repo" }, "yamlPath is required for create_pipeline"],
+      ["name", { yamlPath: "p.yml", repositoryType: "AzureReposGit", repositoryName: "repo" }, "name is required for create_pipeline"],
+      ["yamlPath", { name: "pipe", repositoryType: "AzureReposGit", repositoryName: "repo" }, "yamlPath is required for create_pipeline"],
       ["repositoryType", { name: "pipe", yamlPath: "p.yml", repositoryName: "repo" }, "repositoryType is required for create_pipeline"],
-      ["repositoryName", { name: "pipe", yamlPath: "p.yml", repositoryType: "AzureReposGit" as const }, "repositoryName is required for create_pipeline"],
+      ["repositoryName", { name: "pipe", yamlPath: "p.yml", repositoryType: "AzureReposGit" }, "repositoryName is required for create_pipeline"],
     ])("should return error when %s is missing for create_pipeline", async (_field, extra, expectedMsg) => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_write");
@@ -1851,6 +1851,8 @@ describe("configurePipelineTools", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toBe(expectedMsg);
+      expect(connectionProvider).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("should return an unknown action message without opening a connection for an unknown action", async () => {

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1852,18 +1852,17 @@ describe("configurePipelineTools", () => {
       expect(result.content[0].text).toBe(expectedMsg);
     });
 
-    it("should use generic error message when action is unknown and connectionProvider throws", async () => {
+    it("should return an unknown action message without opening a connection for an unknown action", async () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_write");
       if (!call) fail("Tool not found");
       const [, , , handler] = call;
 
-      (connectionProvider as jest.Mock).mockRejectedValueOnce(new Error("connection failed"));
-
       const result = await handler({ action: "unknown" as any, project: "test-project" });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe("Error: connection failed");
+      expect(result.content[0].text).toBe("Unknown action: unknown");
+      expect(connectionProvider as jest.Mock).not.toHaveBeenCalled();
     });
 
     it("should handle non-Error thrown values in pipelines_write", async () => {

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, beforeEach } from "@jest/globals";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
 import { StageUpdateType } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
-import { configurePipelineTools } from "../../../src/tools/pipelines";
+import { configurePipelineTools, runPipelineCommand, createPipelineCommand, updateBuildStageCommand } from "../../../src/tools/pipelines";
+import { CommandContext } from "../../../src/shared/command";
 import { apiVersion } from "../../../src/utils.js";
 import { mockUpdateBuildStageResponse, mockMultipleArtifacts, mockArtifact } from "../../mocks/pipelines";
 import { Readable } from "stream";
@@ -2237,6 +2238,256 @@ describe("configurePipelineTools", () => {
       const expectedBase64 = testContent.toString("base64");
       expect(result.content[0].resource.text).toBe(expectedBase64);
       expect(result.content[0].resource.uri).toContain(expectedBase64);
+    });
+  });
+});
+
+// Direct, isolated unit tests for each pipelines_write command. These exercise
+// the Command implementations against a mock CommandContext, independent of the
+// tool dispatcher.
+describe("pipelines_write commands", () => {
+  let tokenProvider: jest.Mock;
+  let userAgentProvider: () => string;
+  let mockConnection: { getPipelinesApi: jest.Mock; serverUrl: string };
+  let connectionProvider: jest.Mock;
+  let context: CommandContext;
+
+  beforeEach(() => {
+    tokenProvider = jest.fn();
+    userAgentProvider = () => "Jest";
+    mockConnection = {
+      getPipelinesApi: jest.fn(),
+      serverUrl: "https://dev.azure.com/test-org",
+    };
+    connectionProvider = jest.fn().mockResolvedValue(mockConnection);
+    context = {
+      connectionProvider: connectionProvider as unknown as CommandContext["connectionProvider"],
+      tokenProvider: tokenProvider as unknown as CommandContext["tokenProvider"],
+      userAgentProvider,
+    };
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockClear();
+  });
+
+  describe("runPipelineCommand", () => {
+    it("runs a pipeline with the given resources and parameters", async () => {
+      const runPipeline = jest.fn().mockResolvedValue({ id: 456 });
+      mockConnection.getPipelinesApi.mockResolvedValue({ runPipeline });
+
+      const result = await runPipelineCommand.execute(context, {
+        project: "test-project",
+        pipelineId: 123,
+        resources: { repositories: { self: { refName: "refs/heads/main" } } },
+        templateParameters: { key1: "value1" },
+      });
+
+      expect(runPipeline).toHaveBeenCalledWith(
+        {
+          previewRun: undefined,
+          resources: { repositories: { self: { refName: "refs/heads/main" } } },
+          stagesToSkip: undefined,
+          templateParameters: { key1: "value1" },
+          variables: undefined,
+          yamlOverride: undefined,
+        },
+        "test-project",
+        123,
+        undefined
+      );
+      expect(result.content[0].text).toBe(JSON.stringify({ id: 456 }, null, 2));
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("returns an error when pipelineId is missing", async () => {
+      const result = await runPipelineCommand.execute(context, { project: "test-project" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("pipelineId is required for run_pipeline");
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
+    it("throws when yamlOverride is provided without previewRun", async () => {
+      await expect(
+        runPipelineCommand.execute(context, {
+          project: "test-project",
+          pipelineId: 123,
+          previewRun: false,
+          yamlOverride: "some yaml",
+        })
+      ).rejects.toThrow("Parameter 'yamlOverride' can only be specified together with parameter 'previewRun'.");
+    });
+
+    it("throws when the pipeline run has no id", async () => {
+      const runPipeline = jest.fn().mockResolvedValue({});
+      mockConnection.getPipelinesApi.mockResolvedValue({ runPipeline });
+
+      await expect(runPipelineCommand.execute(context, { project: "test-project", pipelineId: 123 })).rejects.toThrow("Failed to get build ID from pipeline run");
+    });
+  });
+
+  describe("createPipelineCommand", () => {
+    it("creates a YAML pipeline for AzureReposGit", async () => {
+      const createPipeline = jest.fn().mockResolvedValue({ id: 100, name: "Pipeline" });
+      mockConnection.getPipelinesApi.mockResolvedValue({ createPipeline });
+
+      const result = await createPipelineCommand.execute(context, {
+        project: "ProjectName",
+        name: "Pipeline",
+        yamlPath: "pipeline.yml",
+        repositoryType: "AzureReposGit",
+        repositoryName: "RepositoryName",
+        repositoryId: "46DEE968-EAE5-41AA-97B1-E8B71DC287C2",
+      });
+
+      expect(createPipeline).toHaveBeenCalledWith(
+        {
+          name: "Pipeline",
+          folder: "\\",
+          configuration: {
+            type: "Yaml",
+            path: "pipeline.yml",
+            repository: {
+              type: "AzureReposGit",
+              name: "RepositoryName",
+              id: "46DEE968-EAE5-41AA-97B1-E8B71DC287C2",
+            },
+            variables: undefined,
+          },
+        },
+        "ProjectName"
+      );
+      expect(result.content[0].text).toBe(JSON.stringify({ id: 100, name: "Pipeline" }, null, 2));
+    });
+
+    it("creates a YAML pipeline for GitHub", async () => {
+      const createPipeline = jest.fn().mockResolvedValue({ id: 200, name: "GH Pipeline" });
+      mockConnection.getPipelinesApi.mockResolvedValue({ createPipeline });
+
+      await createPipelineCommand.execute(context, {
+        project: "ProjectName",
+        name: "GH Pipeline",
+        yamlPath: "pipeline.yml",
+        repositoryType: "GitHub",
+        repositoryName: "owner/repo",
+        repositoryConnectionId: "conn-id-123",
+      });
+
+      expect(createPipeline).toHaveBeenCalledWith(
+        expect.objectContaining({
+          configuration: expect.objectContaining({
+            repository: expect.objectContaining({
+              type: "GitHub",
+              fullname: "owner/repo",
+              connection: { id: "conn-id-123" },
+            }),
+          }),
+        }),
+        "ProjectName"
+      );
+    });
+
+    it("throws when repositoryConnectionId is missing for GitHub", async () => {
+      mockConnection.getPipelinesApi.mockResolvedValue({ createPipeline: jest.fn() });
+
+      await expect(
+        createPipelineCommand.execute(context, {
+          project: "ProjectName",
+          name: "GH Pipeline",
+          yamlPath: "pipeline.yml",
+          repositoryType: "GitHub",
+          repositoryName: "owner/repo",
+        })
+      ).rejects.toThrow("Parameter 'repositoryConnectionId' is required for GitHub repositories.");
+    });
+
+    it("throws for an unsupported repository type", async () => {
+      mockConnection.getPipelinesApi.mockResolvedValue({ createPipeline: jest.fn() });
+
+      await expect(
+        createPipelineCommand.execute(context, {
+          project: "ProjectName",
+          name: "Pipeline",
+          yamlPath: "pipeline.yml",
+          repositoryType: "BitbucketCloud",
+          repositoryName: "owner/repo",
+        })
+      ).rejects.toThrow("Unsupported repository type");
+    });
+
+    it.each([
+      ["name", { yamlPath: "p.yml", repositoryType: "AzureReposGit", repositoryName: "repo" }, "name is required for create_pipeline"],
+      ["yamlPath", { name: "pipe", repositoryType: "AzureReposGit", repositoryName: "repo" }, "yamlPath is required for create_pipeline"],
+      ["repositoryType", { name: "pipe", yamlPath: "p.yml", repositoryName: "repo" }, "repositoryType is required for create_pipeline"],
+      ["repositoryName", { name: "pipe", yamlPath: "p.yml", repositoryType: "AzureReposGit" }, "repositoryName is required for create_pipeline"],
+    ])("returns an error when %s is missing", async (_field, extra, expectedMsg) => {
+      const result = await createPipelineCommand.execute(context, { project: "proj", ...(extra as Record<string, string>) });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(expectedMsg);
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateBuildStageCommand", () => {
+    it("sends a PATCH request with encoded path segments and returns the response", async () => {
+      tokenProvider.mockResolvedValue("mock-token");
+      const mockResponse = {
+        ok: true,
+        text: jest.fn().mockResolvedValue(JSON.stringify(mockUpdateBuildStageResponse)),
+      };
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await updateBuildStageCommand.execute(context, {
+        project: "test-project",
+        buildId: 123,
+        stageName: "Build",
+        status: "Retry",
+        forceRetryAllJobs: true,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(`https://dev.azure.com/test-org/test-project/_apis/build/builds/123/stages/Build?api-version=${apiVersion}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer mock-token",
+          "User-Agent": "Jest",
+        },
+        body: JSON.stringify({ forceRetryAllJobs: true, state: StageUpdateType.Retry.valueOf() }),
+      });
+      expect(result.content[0].text).toBe(JSON.stringify(JSON.stringify(mockUpdateBuildStageResponse), null, 2));
+      expect(result.isError).toBeUndefined();
+    });
+
+    it("throws when the response is not ok", async () => {
+      tokenProvider.mockResolvedValue("mock-token");
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        text: jest.fn().mockResolvedValue("Build stage not found"),
+      };
+      (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        updateBuildStageCommand.execute(context, {
+          project: "test-project",
+          buildId: 999,
+          stageName: "Build",
+          status: "Retry",
+          forceRetryAllJobs: false,
+        })
+      ).rejects.toThrow("Failed to update build stage: 404 Build stage not found");
+    });
+
+    it.each([
+      ["buildId", { stageName: "Build", status: "Retry", forceRetryAllJobs: false }, "buildId is required for update_build_stage"],
+      ["stageName", { buildId: 1, status: "Retry", forceRetryAllJobs: false }, "stageName is required for update_build_stage"],
+      ["status", { buildId: 1, stageName: "Build", forceRetryAllJobs: false }, "status is required for update_build_stage"],
+    ])("returns an error when %s is missing", async (_field, extra, expectedMsg) => {
+      const result = await updateBuildStageCommand.execute(context, { project: "test-project", ...(extra as Record<string, unknown>) } as Parameters<typeof updateBuildStageCommand.execute>[1]);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(expectedMsg);
+      expect(connectionProvider).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This pull request introduces a blueprint pattern to be applied on the recent functions aggregating tools.

A new command-based architecture for handling grouped actions is applied in the `pipelines_write` tool. It adds a type-safe DTO layer for all pipeline write actions, centralizes argument validation, and decouples the dispatcher logic from individual actions. The main improvements are the introduction of a shared command infrastructure, the addition of type-safe DTOs for pipeline actions, and the refactoring of `pipelines.ts` to use this new pattern.

**Command infrastructure and dispatcher:**
- Added a generic, type-safe command interface (`Command<TArgs>`) and dispatcher (`dispatchAction`) in `src/shared/command.ts`, enabling decoupled and robust action routing for grouped tools.

**Type-safe DTOs for pipeline actions:**
- Introduced `src/tools/pipelines.dto.ts` to define Zod-based schemas and inferred TypeScript types for all `pipelines_write` actions, ensuring a single source of truth for validation and argument types.
- Updated Jest config to support `.ts` versions of new shared files (`command.ts`, `pipelines.dto.ts`).

**Refactoring pipelines write actions:**
- Refactored `src/tools/pipelines.ts` to implement each write action (`run_pipeline`, `create_pipeline`, `update_build_stage`) as a self-contained command using the new infrastructure, and registered them in a central command registry.
- Centralized error handling for all pipelines write actions using per-action error prefixes.
- Cleaned up legacy code to remove now-obsolete pipelines write logic.