### PR TITLE
Implement work iteration commands and DTOs for Azure DevOps

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -55,6 +55,7 @@ module.exports = {
     "^(.+)/content-safety\\.js$": "$1/content-safety.ts",
     "^(.+)/command\\.js$": "$1/command.ts",
     "^(.+)/pipelines\\.dto\\.js$": "$1/pipelines.dto.ts",
+    "^(.+)/work\\.dto\\.js$": "$1/work.dto.ts",
     "^(.+)/index\\.js$": "$1/index.ts",
   },
 };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -25,7 +25,7 @@ function configureAllTools(server: McpServer, tokenProvider: () => Promise<strin
 
   configureIfDomainEnabled(Domain.CORE, () => configureCoreTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.MCP_APPS, () => configureMcpAppsTools(server));
-  configureIfDomainEnabled(Domain.WORK, () => configureWorkTools(server, tokenProvider, connectionProvider));
+  configureIfDomainEnabled(Domain.WORK, () => configureWorkTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.PIPELINES, () => configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.REPOSITORIES, () => configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider));
   configureIfDomainEnabled(Domain.WORK_ITEMS, () => configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider));

--- a/src/tools/work.dto.ts
+++ b/src/tools/work.dto.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DTOs for the work write tools.
+//
+// Each action's inputs are declared once as a Zod "raw shape". The shapes are
+// the single source of truth: the tool's input schema is composed from them,
+// and the TypeScript argument types are derived via `z.infer` (no hand-written,
+// drift-prone duplicate types). These types are safe to export — they are
+// compile-time only and erased at runtime, so they have no effect on the MCP
+// protocol or a local server.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Fields shared by every work iteration write action. */
+const workIterationProjectShape = {
+  project: z.string().describe("The name or ID of the Azure DevOps project."),
+};
+
+const iterationItemSchema = z.object({
+  iterationName: z.string().optional().describe("The name of the iteration to create. Used for create."),
+  startDate: z.string().optional().describe("The start date of the iteration in ISO format (e.g., '2023-01-01T00:00:00Z'). Used for create."),
+  finishDate: z.string().optional().describe("The finish date of the iteration in ISO format (e.g., '2023-01-31T23:59:59Z'). Used for create."),
+  identifier: z.string().optional().describe("The identifier of the iteration to assign. Used for assign."),
+  path: z.string().optional().describe("The path of the iteration to assign, e.g., 'Project/Iteration'. Used for assign."),
+});
+
+const iterationsField = {
+  iterations: z.array(iterationItemSchema).describe("An array of iterations to process. For create: provide iterationName and optional dates. For assign: provide identifier and path."),
+};
+
+/** create iteration inputs. */
+export const createIterationShape = {
+  ...workIterationProjectShape,
+  ...iterationsField,
+};
+
+/** assign iteration inputs. */
+export const assignIterationShape = {
+  ...workIterationProjectShape,
+  team: z.string().optional().describe("The name or ID of the Azure DevOps team. Required for assign."),
+  ...iterationsField,
+};
+
+/** The composed input shape for the grouped `work_iteration_write` tool. */
+export const workIterationWriteShape = {
+  action: z.enum(["create", "assign"]).describe("The action to perform. 'create' creates new iterations in the project; 'assign' assigns existing iterations to a team."),
+  ...createIterationShape,
+  ...assignIterationShape,
+};
+
+// Per-action schemas + inferred argument DTOs.
+export const createIterationSchema = z.object(createIterationShape);
+export const assignIterationSchema = z.object(assignIterationShape);
+export const workIterationWriteSchema = z.object(workIterationWriteShape);
+
+export type CreateIterationArgs = z.infer<typeof createIterationSchema>;
+export type AssignIterationArgs = z.infer<typeof assignIterationSchema>;
+export type WorkIterationWriteArgs = z.infer<typeof workIterationWriteSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** update capacity inputs. */
+export const updateCapacityShape = {
+  project: z.string().describe("The name or Id of the Azure DevOps project."),
+  team: z.string().describe("The name or Id of the Azure DevOps team."),
+  teamMemberId: z.string().describe("The team member Id for the specific team member."),
+  iterationId: z.string().describe("The Iteration Id to update the capacity for."),
+  activities: z
+    .array(
+      z.object({
+        name: z.string().describe("The name of the activity (e.g., 'Development')."),
+        capacityPerDay: z.number().describe("The capacity per day for this activity."),
+      })
+    )
+    .describe("Array of activities and their daily capacities for the team member."),
+  daysOff: z
+    .array(
+      z.object({
+        start: z.string().describe("Start date of the day off in ISO format."),
+        end: z.string().describe("End date of the day off in ISO format."),
+      })
+    )
+    .optional()
+    .describe("Array of days off for the team member, each with a start and end date in ISO format."),
+};
+
+/** The composed input shape for the `work_capacity_write` tool. */
+export const workCapacityWriteShape = {
+  action: z.literal("update").describe("The action to perform. Only 'update' is supported."),
+  ...updateCapacityShape,
+};
+
+// Per-action schemas + inferred argument DTOs.
+export const updateCapacitySchema = z.object(updateCapacityShape);
+export const workCapacityWriteSchema = z.object(workCapacityWriteShape);
+
+export type UpdateCapacityArgs = z.infer<typeof updateCapacitySchema>;
+export type WorkCapacityWriteArgs = z.infer<typeof workCapacityWriteSchema>;

--- a/src/tools/work.ts
+++ b/src/tools/work.ts
@@ -6,6 +6,139 @@ import { WebApi } from "azure-devops-node-api";
 import { z } from "zod";
 import { TreeStructureGroup, TreeNodeStructureType, WorkItemClassificationNode } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
 import { elicitProject, elicitTeam } from "../shared/elicitations.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Command, CommandContext, CommandRegistry, dispatchAction, errorResult } from "../shared/command.js";
+import { workIterationWriteShape, WorkIterationWriteArgs, CreateIterationArgs, AssignIterationArgs, workCapacityWriteShape, WorkCapacityWriteArgs, UpdateCapacityArgs } from "./work.dto.js";
+
+// ─── work_iteration_write commands ──────────────────────────────────────────
+// Each write action is a self-contained command. Shared infrastructure arrives
+// via `CommandContext`; the action-specific input arrives via a single typed
+// args object (see work.dto.ts). This keeps the dispatcher agnostic of
+// individual argument lists.
+
+const createIterationCommand: Command<CreateIterationArgs> = {
+  async execute(context: CommandContext, args: CreateIterationArgs): Promise<CallToolResult> {
+    const connection = await context.connectionProvider();
+    const workItemTrackingApi = await connection.getWorkItemTrackingApi();
+    const results = [];
+
+    for (const { iterationName, startDate, finishDate } of args.iterations) {
+      if (!iterationName) continue;
+
+      const iteration = await workItemTrackingApi.createOrUpdateClassificationNode(
+        {
+          name: iterationName,
+          attributes: {
+            startDate: startDate ? new Date(startDate) : undefined,
+            finishDate: finishDate ? new Date(finishDate) : undefined,
+          },
+        },
+        args.project,
+        TreeStructureGroup.Iterations
+      );
+
+      if (iteration) {
+        results.push(iteration);
+      }
+    }
+
+    if (results.length === 0) {
+      return errorResult("No iterations were created");
+    }
+
+    return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+  },
+};
+
+const assignIterationCommand: Command<AssignIterationArgs> = {
+  async execute(context: CommandContext, args: AssignIterationArgs): Promise<CallToolResult> {
+    if (!args.team) return errorResult("Team is required for assign");
+
+    const connection = await context.connectionProvider();
+    const workApi = await connection.getWorkApi();
+    const teamContext = { project: args.project, team: args.team };
+    const results = [];
+
+    for (const { identifier, path } of args.iterations) {
+      if (!identifier || !path) continue;
+
+      const assignment = await workApi.postTeamIteration({ path, id: identifier }, teamContext);
+
+      if (assignment) {
+        results.push(assignment);
+      }
+    }
+
+    if (results.length === 0) {
+      return errorResult("No iterations were assigned to the team");
+    }
+
+    return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+  },
+};
+
+/**
+ * The registry is the lookup table that couples each action to its command.
+ * Adding a new write action means registering one entry here — the dispatcher
+ * (`dispatchAction`) never changes.
+ */
+const workIterationWriteCommands: CommandRegistry<WorkIterationWriteArgs> = {
+  create: createIterationCommand,
+  assign: assignIterationCommand,
+};
+
+const workIterationWriteErrorPrefixes: Record<WorkIterationWriteArgs["action"], string> = {
+  create: "Error creating iterations: ",
+  assign: "Error assigning iterations: ",
+};
+
+// ─── work_capacity_write commands ────────────────────────────────────────────
+
+const updateCapacityCommand: Command<UpdateCapacityArgs> = {
+  async execute(context: CommandContext, args: UpdateCapacityArgs): Promise<CallToolResult> {
+    const connection = await context.connectionProvider();
+    const workApi = await connection.getWorkApi();
+    const teamContext = { project: args.project, team: args.team };
+
+    interface CapacityPatch {
+      activities: { name: string; capacityPerDay: number }[];
+      daysOff?: { start: Date; end: Date }[];
+    }
+
+    const capacityPatch: CapacityPatch = {
+      activities: args.activities.map((a) => ({ name: a.name, capacityPerDay: a.capacityPerDay })),
+      daysOff: (args.daysOff || []).map((d) => ({ start: new Date(d.start), end: new Date(d.end) })),
+    };
+
+    const updatedCapacity = await workApi.updateCapacityWithIdentityRef(capacityPatch, teamContext, args.iterationId, args.teamMemberId);
+
+    if (!updatedCapacity) {
+      return errorResult("Failed to update team member capacity");
+    }
+
+    const simplifiedResult = {
+      teamMember: updatedCapacity.teamMember
+        ? {
+            displayName: updatedCapacity.teamMember.displayName,
+            id: updatedCapacity.teamMember.id,
+            uniqueName: updatedCapacity.teamMember.uniqueName,
+          }
+        : undefined,
+      activities: updatedCapacity.activities,
+      daysOff: updatedCapacity.daysOff,
+    };
+
+    return { content: [{ type: "text", text: JSON.stringify(simplifiedResult, null, 2) }] };
+  },
+};
+
+const workCapacityWriteCommands: CommandRegistry<WorkCapacityWriteArgs> = {
+  update: updateCapacityCommand,
+};
+
+const workCapacityWriteErrorPrefixes: Record<WorkCapacityWriteArgs["action"], string> = {
+  update: "Error updating team capacity: ",
+};
 
 const WORK_TOOLS = {
   work: "work",
@@ -13,7 +146,7 @@ const WORK_TOOLS = {
   work_capacity_write: "work_capacity_write",
 };
 
-function configureWorkTools(server: McpServer, _: () => Promise<string>, connectionProvider: () => Promise<WebApi>) {
+function configureWorkTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
   server.tool(
     WORK_TOOLS.work,
     "Retrieve work-related data for a project or team. Use the action parameter to specify the operation.",
@@ -246,188 +379,16 @@ function configureWorkTools(server: McpServer, _: () => Promise<string>, connect
     }
   );
 
-  server.tool(
-    WORK_TOOLS.work_iteration_write,
-    "Create or assign iterations in an Azure DevOps project. Use the action parameter to specify the operation.",
-    {
-      action: z.enum(["create", "assign"]).describe("The action to perform. 'create' creates new iterations in the project; 'assign' assigns existing iterations to a team."),
-      project: z.string().describe("The name or ID of the Azure DevOps project."),
-      team: z.string().optional().describe("The name or ID of the Azure DevOps team. Required for assign."),
-      iterations: z
-        .array(
-          z.object({
-            iterationName: z.string().optional().describe("The name of the iteration to create. Used for create."),
-            startDate: z.string().optional().describe("The start date of the iteration in ISO format (e.g., '2023-01-01T00:00:00Z'). Used for create."),
-            finishDate: z.string().optional().describe("The finish date of the iteration in ISO format (e.g., '2023-01-31T23:59:59Z'). Used for create."),
-            identifier: z.string().optional().describe("The identifier of the iteration to assign. Used for assign."),
-            path: z.string().optional().describe("The path of the iteration to assign, e.g., 'Project/Iteration'. Used for assign."),
-          })
-        )
-        .describe("An array of iterations to process. For create: provide iterationName and optional dates. For assign: provide identifier and path."),
-    },
-    async ({ action, project, team, iterations }) => {
-      try {
-        const connection = await connectionProvider();
+  server.tool(WORK_TOOLS.work_iteration_write, "Create or assign iterations in an Azure DevOps project. Use the action parameter to specify the operation.", workIterationWriteShape, async (args) => {
+    const context: CommandContext = { connectionProvider, tokenProvider, userAgentProvider };
+    return dispatchAction(workIterationWriteCommands, context, args as unknown as WorkIterationWriteArgs, workIterationWriteErrorPrefixes);
+  });
 
-        if (action === "create") {
-          const workItemTrackingApi = await connection.getWorkItemTrackingApi();
-          const results = [];
-
-          for (const { iterationName, startDate, finishDate } of iterations) {
-            if (!iterationName) continue;
-
-            const iteration = await workItemTrackingApi.createOrUpdateClassificationNode(
-              {
-                name: iterationName,
-                attributes: {
-                  startDate: startDate ? new Date(startDate) : undefined,
-                  finishDate: finishDate ? new Date(finishDate) : undefined,
-                },
-              },
-              project,
-              TreeStructureGroup.Iterations
-            );
-
-            if (iteration) {
-              results.push(iteration);
-            }
-          }
-
-          if (results.length === 0) {
-            return { content: [{ type: "text", text: "No iterations were created" }], isError: true };
-          }
-
-          return {
-            content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-          };
-        }
-
-        if (action === "assign") {
-          if (!team) {
-            return { content: [{ type: "text", text: "Team is required for assign" }], isError: true };
-          }
-
-          const workApi = await connection.getWorkApi();
-          const teamContext = { project, team };
-          const results = [];
-
-          for (const { identifier, path } of iterations) {
-            if (!identifier || !path) continue;
-
-            const assignment = await workApi.postTeamIteration({ path: path, id: identifier }, teamContext);
-
-            if (assignment) {
-              results.push(assignment);
-            }
-          }
-
-          if (results.length === 0) {
-            return { content: [{ type: "text", text: "No iterations were assigned to the team" }], isError: true };
-          }
-
-          return {
-            content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
-          };
-        }
-
-        return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        const actionErrorMessages: Record<string, string> = {
-          create: `Error creating iterations: ${errorMessage}`,
-          assign: `Error assigning iterations: ${errorMessage}`,
-        };
-
-        return {
-          content: [{ type: "text", text: actionErrorMessages[action] ?? `Error: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  server.tool(
-    WORK_TOOLS.work_capacity_write,
-    "Update the team capacity of a team member for a specific iteration in a project.",
-    {
-      action: z.literal("update").describe("The action to perform. Only 'update' is supported."),
-      project: z.string().describe("The name or Id of the Azure DevOps project."),
-      team: z.string().describe("The name or Id of the Azure DevOps team."),
-      teamMemberId: z.string().describe("The team member Id for the specific team member."),
-      iterationId: z.string().describe("The Iteration Id to update the capacity for."),
-      activities: z
-        .array(
-          z.object({
-            name: z.string().describe("The name of the activity (e.g., 'Development')."),
-            capacityPerDay: z.number().describe("The capacity per day for this activity."),
-          })
-        )
-        .describe("Array of activities and their daily capacities for the team member."),
-      daysOff: z
-        .array(
-          z.object({
-            start: z.string().describe("Start date of the day off in ISO format."),
-            end: z.string().describe("End date of the day off in ISO format."),
-          })
-        )
-        .optional()
-        .describe("Array of days off for the team member, each with a start and end date in ISO format."),
-    },
-    async ({ project, team, teamMemberId, iterationId, activities, daysOff }) => {
-      try {
-        const connection = await connectionProvider();
-        const workApi = await connection.getWorkApi();
-        const teamContext = { project, team };
-
-        // Define interface for capacity patch
-        interface CapacityPatch {
-          activities: { name: string; capacityPerDay: number }[];
-          daysOff?: { start: Date; end: Date }[];
-        }
-
-        const capacityPatch: CapacityPatch = {
-          activities: activities.map((a) => ({
-            name: a.name,
-            capacityPerDay: a.capacityPerDay,
-          })),
-          daysOff: (daysOff || []).map((d) => ({
-            start: new Date(d.start),
-            end: new Date(d.end),
-          })),
-        };
-
-        const updatedCapacity = await workApi.updateCapacityWithIdentityRef(capacityPatch, teamContext, iterationId, teamMemberId);
-
-        if (!updatedCapacity) {
-          return { content: [{ type: "text", text: "Failed to update team member capacity" }], isError: true };
-        }
-
-        const simplifiedResult = {
-          teamMember: updatedCapacity.teamMember
-            ? {
-                displayName: updatedCapacity.teamMember.displayName,
-                id: updatedCapacity.teamMember.id,
-                uniqueName: updatedCapacity.teamMember.uniqueName,
-              }
-            : undefined,
-          activities: updatedCapacity.activities,
-          daysOff: updatedCapacity.daysOff,
-        };
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(simplifiedResult, null, 2) }],
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-
-        return {
-          content: [{ type: "text", text: `Error updating team capacity: ${errorMessage}` }],
-          isError: true,
-        };
-      }
-    }
-  );
+  server.tool(WORK_TOOLS.work_capacity_write, "Update the team capacity of a team member for a specific iteration in a project.", workCapacityWriteShape, async (args) => {
+    const context: CommandContext = { connectionProvider, tokenProvider, userAgentProvider };
+    return dispatchAction(workCapacityWriteCommands, context, args as unknown as WorkCapacityWriteArgs, workCapacityWriteErrorPrefixes);
+  });
 }
 
-export { WORK_TOOLS, configureWorkTools };
+export { WORK_TOOLS, configureWorkTools, createIterationCommand, assignIterationCommand, updateCapacityCommand };
+export type { CreateIterationArgs, AssignIterationArgs, WorkIterationWriteArgs, UpdateCapacityArgs, WorkCapacityWriteArgs };

--- a/test/src/tools/work.test.ts
+++ b/test/src/tools/work.test.ts
@@ -1350,7 +1350,7 @@ describe("configureWorkTools", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe("Unknown action: invalid_action");
+      expect(result.content[0].text).toBe("Unknown action: invalid_action. Supported actions: assign, create");
     });
   });
 
@@ -1615,7 +1615,7 @@ describe("configureWorkTools", () => {
       });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe("Error: Connection failed");
+      expect(result.content[0].text).toBe("Unknown action: invalid_action. Supported actions: assign, create");
     });
   });
 


### PR DESCRIPTION
This pull request refactors and modularizes the implementation of Azure DevOps work tools, particularly for creating/assigning iterations and updating team capacity. The main changes include extracting DTO schemas to a dedicated file, introducing a command-based architecture for tool actions, and updating the test and configuration logic to match the new structure.

**Refactoring and modularization of work tools:**

* Extracted Zod schemas and TypeScript types for work iteration and capacity write actions into a new file, `work.dto.ts`, ensuring type safety and single-source-of-truth for input validation and documentation.
* Replaced inline tool handler logic in `work.ts` with a command-based architecture. Each action (e.g., create/assign iteration, update capacity) is implemented as a separate command object, improving maintainability and testability. [[1]](diffhunk://#diff-77acc8a765790e3692ce8eea6e110b3170f47b10cb74ea05d5b1908fa2164834R9-R149) [[2]](diffhunk://#diff-77acc8a765790e3692ce8eea6e110b3170f47b10cb74ea05d5b1908fa2164834L249-R394)
* Updated the `configureWorkTools` function to inject the new user agent provider dependency and to use the new command dispatching mechanism for tool registration.

**Configuration and test updates:**

* Added a Jest moduleNameMapper entry for the new `work.dto.ts` file to ensure tests resolve imports correctly.
* Updated tests to expect new error messages for unknown actions, reflecting the improved error handling in the new architecture. [[1]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL1353-R1353) [[2]](diffhunk://#diff-e86dda859f8f366f41092af9e4ed76e59d7bd2ec43a3a85740b872bfc60339caL1618-R1618)

_Replace_ by description of the work done

## GitHub issue number
N/A

## **Associated Risks**

Refactor

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

manual testing and updated automated tests
