### PR TITLE
Add remotes configuration for streamable HTTP in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,6 +4,12 @@
   "description": "The MCP server for Azure DevOps, bringing the power of Azure DevOps directly to your agents.",
   "version": "2.4.0",
   "title": "Azure DevOps",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.dev.azure.com"
+    }
+  ],
   "packages": [
     {
       "registryType": "npm",

--- a/server.json
+++ b/server.json
@@ -7,7 +7,13 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://mcp.dev.azure.com"
+      "url": "https://mcp.dev.azure.com/{organization}",
+      "variables": {
+        "organization": {
+          "description": "Your Azure DevOps organization identifier (e.g., 'contoso', 'fabrikam')",
+          "isRequired": false
+        }
+      }
     }
   ],
   "packages": [


### PR DESCRIPTION
This pull request adds a new remote configuration to the `server.json` file. This update allows the MCP server to connect to an external service endpoint.

Configuration changes:

* Added a `remotes` section to `server.json`, specifying a `streamable-http` remote with the URL `https://mcp.dev.azure.com`.

## GitHub issue number
N/A

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

N/A
