### PR TITLE
Fix: apply multilineFieldsFormat regardless of field value length

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -566,8 +566,8 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
             value: encodeFormattedValue(value, format),
           }));
 
-          fields.forEach(({ name, value, format }) => {
-            if (value.length > 100 && format === "Markdown") {
+          fields.forEach(({ name, format }) => {
+            if (format === "Markdown") {
               document.push({
                 op: "add",
                 path: `/multilineFieldsFormat/${name}`,
@@ -610,8 +610,8 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               value: encodeFormattedValue(value, format),
             }));
 
-            workItemUpdates.forEach(({ path: fieldPath, value, format }) => {
-              if (format === "Markdown" && value && value.length > 100) {
+            workItemUpdates.forEach(({ path: fieldPath, format }) => {
+              if (format === "Markdown") {
                 operations.push({
                   op: "Add",
                   path: `/multilineFieldsFormat${fieldPath.replace("/fields", "")}`,

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -1683,6 +1683,40 @@ describe("configureWorkItemTools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
     });
 
+    it("should handle Markdown format for short fields", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_write");
+
+      if (!call) throw new Error("wit_work_item_write tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkItemTrackingApi.createWorkItem as jest.Mock).mockResolvedValue(_mockWorkItem);
+
+      const shortDescription = "Short markdown";
+
+      const params = {
+        project: "Contoso",
+        workItemType: "Task",
+        fields: [
+          { name: "System.Title", value: "Hello World!" },
+          { name: "System.Description", value: shortDescription, format: "Markdown" },
+        ],
+      };
+
+      const expectedDocument = [
+        { op: "add", path: "/fields/System.Title", value: "Hello World!" },
+        { op: "add", path: "/fields/System.Description", value: shortDescription },
+        { op: "add", path: "/multilineFieldsFormat/System.Description", value: "Markdown" },
+      ];
+
+      const result = await handler({ action: "create", ...params });
+
+      expect(mockWorkItemTrackingApi.createWorkItem).toHaveBeenCalledWith(null, expectedDocument, params.project, params.workItemType);
+
+      expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItem, null, 2));
+    });
+
     it("should handle null response from createWorkItem", async () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
@@ -1987,6 +2021,68 @@ describe("configureWorkItemTools", () => {
           body: [
             { op: "Add", path: "/fields/System.Description", value: longDescription },
             { op: "Add", path: "/fields/System.Title", value: "Simple Title" },
+            {
+              op: "Add",
+              path: "/multilineFieldsFormat/System.Description",
+              value: "Markdown",
+            },
+          ],
+        },
+      ];
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://dev.azure.com/contoso/_apis/wit/$batch?api-version=5.0",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: expect.objectContaining({
+            "Authorization": "Bearer fake-token",
+            "Content-Type": "application/json",
+          }),
+          body: JSON.stringify(expectedBody),
+        })
+      );
+
+      expect(result.content[0].text).toBe(JSON.stringify([{ id: 1, success: true }], null, 2));
+    });
+
+    it("should handle Markdown format for short fields in batch update", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_write");
+      if (!call) throw new Error("wit_work_item_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue([{ id: 1, success: true }]),
+      });
+
+      const shortDescription = "Short markdown";
+
+      const params = {
+        batchUpdates: [
+          {
+            op: "Add",
+            id: 1,
+            path: "/fields/System.Description",
+            value: shortDescription,
+            format: "Markdown",
+          },
+        ],
+      };
+
+      const result = await handler({ action: "update_batch", ...params });
+
+      const expectedBody = [
+        {
+          method: "PATCH",
+          uri: "/_apis/wit/workitems/1?api-version=5.0",
+          headers: { "Content-Type": "application/json-patch+json" },
+          body: [
+            { op: "Add", path: "/fields/System.Description", value: shortDescription },
             {
               op: "Add",
               path: "/multilineFieldsFormat/System.Description",


### PR DESCRIPTION
## Summary

Fixes #1445.

`wit_work_item_write` only added the `multilineFieldsFormat` patch operation for a `Markdown`-formatted field when its value was **longer than 100 characters** — both in the `create` action (`src/tools/work-items.ts` L569-577) and the `update_batch` action (L613-621).

Short Markdown values (e.g. a one-line description) never got the `multilineFieldsFormat` flag set, so Azure DevOps defaulted the field's rendering format to `Html` and stored/displayed the raw Markdown syntax literally instead of rendering it.

The fix removes the arbitrary `value.length > 100` gate: the flag is now set whenever `format === "Markdown"` is requested, regardless of value length.

## Test plan

- [x] Added a unit test for `create` covering a short (<100 char) Markdown description, confirming `multilineFieldsFormat` is now set.
- [x] Added a unit test for `update_batch` covering the same short-value case.
- [x] `npx jest test/src/tools/work-items.test.ts` — all 250 tests pass.
- [x] `npx eslint src/tools/work-items.ts test/src/tools/work-items.test.ts` — clean.
- [x] `npx prettier --check` — clean.
- [x] `npm run build` — succeeds.