### PR TITLE
fix(auth): use empty-username Basic credential for PAT raw-fetch calls (fixes $batch/comments/wiki 401)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,8 +109,18 @@ async function main() {
   const authenticator = createAuthenticator(argv.authentication, tenantId);
 
   if (argv.authentication === "pat") {
-    const basicValue = await authenticator();
-    // basicValue is already base64("{email}:{token}") — use it directly in the Authorization header
+    // authenticator() returns base64("{username}:{token}"). Azure DevOps rejects Basic auth
+    // when the username is a non-empty, non-identity value (e.g. the docs' "kiro"), returning
+    // 401 on the raw-fetch endpoints (e.g. wit $batch, comments, wiki) even though the
+    // azure-devops-node-api tools work. Normalize to base64(":{token}") — an empty username —
+    // matching getAzureDevOpsClient() above, so the "text before the colon is ignored" contract
+    // holds for every code path.
+    const rawToken = Buffer.from(await authenticator(), "base64")
+      .toString("utf8")
+      .split(":")
+      .slice(1)
+      .join(":");
+    const basicValue = Buffer.from(`:${rawToken}`).toString("base64");
     const _originalFetch = globalThis.fetch;
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (init?.headers) {


### PR DESCRIPTION
## What & why

Fixes #1452.

In **PAT mode**, the global `fetch` interceptor built the Basic credential from the base64 value **verbatim** (`base64("{username}:{token}")`). Azure DevOps rejects Basic auth with a non-empty, non-identity username (e.g. the onboarding docs' `kiro`), so every **raw-fetch** endpoint returned **401**:

- `wit_work_items_link`, `wit_add_child_work_items`, `wit_update_work_items_batch` (the `/_apis/wit/$batch` endpoint)
- work-item comment tools
- wiki write tools

Meanwhile the azure-devops-node-api tools worked, because `getAzureDevOpsClient()` **strips the username** before authenticating. This asymmetry made the bug hard to diagnose (create/update succeed, linking mysteriously 401s).

## The change

`src/index.ts` — normalize the interceptor credential to an **empty-username** `base64(":{token}")`, matching `getAzureDevOpsClient()`:

```ts
const rawToken = Buffer.from(await authenticator(), "base64").toString("utf8").split(":").slice(1).join(":");
const basicValue = Buffer.from(`:${rawToken}`).toString("base64");
```

This makes the documented *"text before the colon is ignored"* contract hold on **every** code path. One-line-of-logic change, no API/behavior change for already-working tools.

## Verification

- `npm run build` — clean
- `npm test` — **1191 passed / 1191**
- `prettier --check` — clean
- Confirmed against the live REST API with the same PAT: `Basic base64("kiro:<PAT>")` → 401, `Basic base64(":<PAT>")` → 200. After the fix, `wit_work_items_link` and `wit_add_child_work_items` succeed.

## Notes

An alternative (or complementary) follow-up: the onboarding docs could recommend encoding with an empty username (`base64(":<PAT>")`); this PR makes that unnecessary by handling any username server-side.
