### PR TITLE
Update test-plans read tools description to specify continuation token usage

### DIFF
--- a/src/tools/test-plans.ts
+++ b/src/tools/test-plans.ts
@@ -19,7 +19,7 @@ function configureTestPlanTools(server: McpServer, tokenProvider: () => Promise<
   // ─── testplan (read-only) ────────────────────────────────────────────
   server.tool(
     TEST_PLAN_TOOLS.testplan,
-    "Retrieve test plan data for a project. Use the action parameter to specify the operation.",
+    "Retrieve paginated test plan, suite, and case data for a project. Use the action parameter to specify the operation. When a response includes a continuationToken, pass it back with the same action and query parameters to fetch the next batch; null token indicates the last batch.",
     {
       action: z
         .enum(["list_plans", "list_suites", "list_cases"])


### PR DESCRIPTION
## Description and usage

Updates the `testplan` tool description to explain how to retrieve additional paginated batches. When a response includes a `continuationToken`, callers should pass it back with the same action and query parameters to fetch the next batch.
This addresses scenarios where only the first 200 test cases are read. No runtime behavior was changed.

Even before this change, capable agents could inspect the returned `continuationToken` and fetch subsequent batches. This update only makes that pagination workflow explicit in the tool description, ensuring agents consistently retrieve all results rather than stopping after the first batch.

## GitHub issue number

N/A 

## **Associated Risks**

Low risk. This is a tool-description-only change and does not modify API calls, pagination logic, or response formats.

## ✅ **PR Checklist**

- [ ] **I have read the [[contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [[code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
All tests running successfully.