### PR TITLE
feat: add support for hyperlink links in work item tools

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -48,6 +48,8 @@ function getLinkTypeFromName(name: string) {
       return "Microsoft.VSTS.Common.Affects-Reverse";
     case "artifact":
       return "ArtifactLink";
+    case "hyperlink":
+      return "Hyperlink";
     default:
       throw new Error(`Unknown link type: ${name}`);
   }
@@ -838,9 +840,10 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         .array(
           z.object({
             id: z.coerce.number().min(1).describe("The ID of the work item to update."),
-            linkToId: z.coerce.number().min(1).describe("The ID of the work item to link to."),
+            linkToId: z.coerce.number().min(1).optional().describe("The ID of the work item to link to. Required unless type is 'hyperlink'."),
+            url: z.string().optional().describe("The URL for a hyperlink. Required when type is 'hyperlink'."),
             type: z
-              .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by"])
+              .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by", "hyperlink"])
               .default("related")
               .describe("Type of link. Defaults to 'related'."),
             comment: z.string().optional().describe("Optional comment for the link."),
@@ -851,7 +854,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
       // unlink
       id: z.coerce.number().min(1).optional().describe("Work item ID to remove links from. Required for: unlink."),
       type: z
-        .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by", "artifact"])
+        .enum(["parent", "child", "duplicate", "duplicate of", "related", "successor", "predecessor", "tested by", "tests", "affects", "affected by", "artifact", "hyperlink"])
         .optional()
         .describe("Link type to remove. Required for: unlink."),
       url: z.string().optional().describe("URL to match when removing a link. Used for: unlink. If not provided, all links of the specified type are removed."),
@@ -935,15 +938,24 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
             headers: { "Content-Type": "application/json-patch+json" },
             body: updates
               .filter((update) => update.id === uid)
-              .map(({ linkToId, type: linkTypeName, comment: linkComment }) => ({
-                op: "add",
-                path: "/relations/-",
-                value: {
-                  rel: `${getLinkTypeFromName(linkTypeName)}`,
-                  url: `${orgUrl}/${resolvedProject}/_apis/wit/workItems/${linkToId}`,
-                  attributes: { comment: linkComment || "" },
-                },
-              })),
+              .map(({ linkToId, url: linkUrl, type: linkTypeName, comment: linkComment }) => {
+                if (linkTypeName === "hyperlink" && !linkUrl) {
+                  throw new Error("url is required for hyperlink links");
+                }
+                if (linkTypeName !== "hyperlink" && !linkToId) {
+                  throw new Error("linkToId is required for work item links");
+                }
+
+                return {
+                  op: "add",
+                  path: "/relations/-",
+                  value: {
+                    rel: getLinkTypeFromName(linkTypeName),
+                    url: linkTypeName === "hyperlink" ? linkUrl : `${orgUrl}/${resolvedProject}/_apis/wit/workItems/${linkToId}`,
+                    attributes: { comment: linkComment || "" },
+                  },
+                };
+              }),
           }));
 
           const response = await fetch(`${orgUrl}/_apis/wit/$batch?api-version=${batchApiVersion}`, {

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -9,6 +9,7 @@ import { Readable } from "stream";
 import * as fs from "fs";
 import * as path from "path";
 import { QueryExpand } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js";
+import { z } from "zod";
 
 jest.mock("fs");
 import {
@@ -2182,6 +2183,79 @@ describe("configureWorkItemTools", () => {
       );
 
       expect(result.content[0].text).toBe(JSON.stringify([{ id: 1, success: true }], null, 2));
+    });
+
+    it("should add a hyperlink to a work item", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_link_write");
+      if (!call) throw new Error("wit_work_item_link_write tool not registered");
+      const [, , schema, handler] = call;
+
+      expect(
+        z.object(schema).parse({
+          action: "link",
+          project: "TestProject",
+          updates: [{ id: 1, type: "hyperlink", url: "https://www.google.com/", comment: "Search" }],
+        })
+      ).toEqual({
+        action: "link",
+        project: "TestProject",
+        updates: [{ id: 1, type: "hyperlink", url: "https://www.google.com/", comment: "Search" }],
+      });
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue([{ id: 1, success: true }]),
+      });
+
+      await handler({
+        action: "link",
+        project: "TestProject",
+        updates: [{ id: 1, type: "hyperlink", url: "https://www.google.com/", comment: "Search" }],
+      });
+
+      const request = (fetch as jest.Mock).mock.calls[0][1];
+      const body = JSON.parse(request.body);
+      expect(body[0].body).toEqual([
+        {
+          op: "add",
+          path: "/relations/-",
+          value: {
+            rel: "Hyperlink",
+            url: "https://www.google.com/",
+            attributes: { comment: "Search" },
+          },
+        },
+      ]);
+    });
+
+    it("should require a URL when adding a hyperlink", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_link_write");
+      if (!call) throw new Error("wit_work_item_link_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "link", project: "TestProject", updates: [{ id: 1, type: "hyperlink" }] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error linking work items: url is required for hyperlink links");
+    });
+
+    it("should require linkToId when linking work items", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_link_write");
+      if (!call) throw new Error("wit_work_item_link_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "link", project: "TestProject", updates: [{ id: 1, type: "related" }] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("Error linking work items: linkToId is required for work item links");
     });
 
     it("should handle linking failure", async () => {


### PR DESCRIPTION
This pull request adds support for creating and managing "hyperlink" links on work items, in addition to existing work item link types. The changes include updates to the schema, validation logic, and handler implementation to properly handle hyperlinks, as well as new tests to verify this functionality.

**Support for hyperlink links:**

* Added "hyperlink" as a valid link type in the schema for linking and unlinking work items in `configureWorkItemTools`, and updated the `getLinkTypeFromName` function to return the correct relation type for hyperlinks. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R51-R52) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L841-R846) [[3]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L854-R857)
* Updated the handler logic to require a `url` when adding a hyperlink and to require `linkToId` for other link types, with appropriate error messages if these fields are missing.

**Testing and validation:**

* Added tests to ensure hyperlinks can be added, that a URL is required for hyperlinks, and that `linkToId` is required for non-hyperlink links.
* Imported `zod` in the test file to enable schema validation in tests.

## GitHub issue number
#1447

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**
manual testing and automated test updates
