### PR TITLE
fix: use command line tenantId override for azcli authentication

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -75,8 +75,8 @@ class OAuthAuthenticator {
   }
 }
 
-function createAuthenticator(type: string, tenantId?: string): () => Promise<string> {
-  logger.debug(`Creating authenticator of type '${type}' with tenantId='${tenantId ?? "undefined"}'`);
+function createAuthenticator(type: string, orgTenantId?: string, tenantIdOverride?: string): () => Promise<string> {
+  logger.debug(`Creating authenticator of type '${type}' with orgTenantId='${orgTenantId ?? "undefined"}' and tenantIdOverride='${tenantIdOverride ?? "undefined"}'`);
   switch (type) {
     case "pat":
       logger.debug(`Authenticator: Using PAT authentication (PERSONAL_ACCESS_TOKEN)`);
@@ -113,6 +113,7 @@ function createAuthenticator(type: string, tenantId?: string): () => Promise<str
         process.env.AZURE_TOKEN_CREDENTIALS = "dev";
       }
       let credential: TokenCredential = new DefaultAzureCredential(); // CodeQL [SM05138] resolved by explicitly setting AZURE_TOKEN_CREDENTIALS
+      const tenantId = tenantIdOverride ?? orgTenantId;
       if (tenantId) {
         // Use Azure CLI credential if tenantId is provided for multi-tenant scenarios
         const azureCliCredential = new AzureCliCredential({ tenantId });
@@ -130,7 +131,7 @@ function createAuthenticator(type: string, tenantId?: string): () => Promise<str
 
     default:
       logger.debug(`Authenticator: Using OAuth interactive authentication (default)`);
-      const authenticator = new OAuthAuthenticator(tenantId);
+      const authenticator = new OAuthAuthenticator(orgTenantId);
       return () => {
         return authenticator.getToken();
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const argv = yargs(hideBin(process.argv))
   })
   .option("tenant", {
     alias: "t",
-    describe: "Azure tenant ID (optional, applied when using 'interactive' and 'azcli' type of authentication)",
+    describe: "Azure tenant ID (optional, only applied when using 'azcli' type of authentication)",
     type: "string",
   })
   .help()
@@ -105,8 +105,8 @@ async function main() {
   server.server.oninitialized = () => {
     userAgentComposer.appendMcpClientInfo(server.server.getClientVersion());
   };
-  const tenantId = (await getOrgTenant(orgName)) ?? argv.tenant;
-  const authenticator = createAuthenticator(argv.authentication, tenantId);
+  const orgTenantId = await getOrgTenant(orgName);
+  const authenticator = createAuthenticator(argv.authentication, orgTenantId, argv.tenant);
 
   if (argv.authentication === "pat") {
     const basicValue = await authenticator();


### PR DESCRIPTION
PR changes the way `--tenant ...` command line param is handled:
1. when interactive authentication is used parameter is ignored. Tested that MSA-based ADO orgs with external users (e.g. me@microsoft.com) are able to login despite browser opening `https://login.microsoftonline.com/common/...` page. Interactive login allows "tenant selection"
2. when `azcli` authentication is used `--tenant guid` value takes priority over value derived from ADO org name

## GitHub issue number

#1485 

## **Associated Risks**

The behavior changes for users having `--authentication azcli --tenant ...` in MCP startup command.
They'll need to remove `--tenant ...` parameter to get back to auth parameters that were effective before.

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

E2E tested (via VSCode on windows) following startup command variations:
- no params
- `-a azcli`
- `-a azcli -t valid_tenant`
- `-a azcli -t wrong_tenant`

targeting both MSA-based and Enterprise ADO orgs
