### PR TITLE
Enhance comment handling with email mentions and HTML formatting

### DIFF
--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -59,10 +59,12 @@ async function searchIdentities(identity: string, tokenProvider: () => Promise<s
   return await response.json();
 }
 
-/**
- * Gets the user ID from email or unique name using Azure DevOps Identity API
- */
-async function getUserIdFromEmail(userEmail: string, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string): Promise<string> {
+async function getUserIdentityFromEmail(
+  userEmail: string,
+  tokenProvider: () => Promise<string>,
+  connectionProvider: () => Promise<WebApi>,
+  userAgentProvider: () => string
+): Promise<{ id: string; displayName: string }> {
   const identities = await searchIdentities(userEmail, tokenProvider, connectionProvider, userAgentProvider);
 
   if (!identities || identities.value?.length === 0) {
@@ -74,7 +76,15 @@ async function getUserIdFromEmail(userEmail: string, tokenProvider: () => Promis
     throw new Error(`No ID found for user with email/unique name: ${userEmail}`);
   }
 
-  return firstIdentity.id;
+  return { id: firstIdentity.id, displayName: firstIdentity.providerDisplayName ?? userEmail };
 }
 
-export { getCurrentUserDetails, getUserIdFromEmail, searchIdentities };
+/**
+ * Gets the user ID from email or unique name using Azure DevOps Identity API
+ */
+async function getUserIdFromEmail(userEmail: string, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string): Promise<string> {
+  const identity = await getUserIdentityFromEmail(userEmail, tokenProvider, connectionProvider, userAgentProvider);
+  return identity.id;
+}
+
+export { getCurrentUserDetails, getUserIdFromEmail, getUserIdentityFromEmail, searchIdentities };

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { batchApiVersion, markdownCommentsApiVersion, getEnumKeys, safeEnumConvert, encodeFormattedValue } from "../utils.js";
 import { elicitProject, elicitTeam } from "../shared/elicitations.js";
 import { createExternalContentResponse } from "../shared/content-safety.js";
+import { getUserIdentityFromEmail } from "./auth.js";
 
 const WORKITEM_TOOLS = {
   wit_work_item: "wit_work_item",
@@ -62,6 +63,44 @@ function getArtifactLinkAttributeName(linkType: string): string {
     default:
       return linkType;
   }
+}
+
+function escapeHtml(value: string): string {
+  const entities: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  };
+
+  return value.replace(/[&<>"']/g, (character) => entities[character]);
+}
+
+async function resolveCommentMentions(
+  text: string,
+  format: "Markdown" | "Html" | undefined,
+  tokenProvider: () => Promise<string>,
+  connectionProvider: () => Promise<WebApi>,
+  userAgentProvider: () => string
+): Promise<string> {
+  const emailMatches = [...text.matchAll(/@<([^<>\s]+@[^<>\s]+)>/g)];
+  if (emailMatches.length === 0) return text;
+
+  const identities = new Map<string, { id: string; displayName: string }>();
+  for (const email of new Set(emailMatches.map((match) => match[1]))) {
+    try {
+      identities.set(email, await getUserIdentityFromEmail(email, tokenProvider, connectionProvider, userAgentProvider));
+    } catch {
+      // Leave mentions unchanged when their identities cannot be resolved.
+    }
+  }
+
+  return text.replace(/@<([^<>\s]+@[^<>\s]+)>/g, (mention, email: string) => {
+    const identity = identities.get(email);
+    if (!identity) return escapeHtml(mention);
+    return format === "Markdown" || format === undefined ? `@<${identity.id}>` : `<a href="#" data-vss-mention="version:2.0,${identity.id}">@${escapeHtml(identity.displayName)}</a>`;
+  });
 }
 
 function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<string>, connectionProvider: () => Promise<WebApi>, userAgentProvider: () => string) {
@@ -767,6 +806,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
         const orgUrl = connection.serverUrl;
         const accessToken = await tokenProvider();
         const formatParameter = (format ?? "Markdown") === "Markdown" ? 0 : 1;
+        const resolvedText = await resolveCommentMentions(text, format, tokenProvider, connectionProvider, userAgentProvider);
 
         if (action === "add") {
           const response = await fetch(
@@ -778,7 +818,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
                 "Content-Type": "application/json",
                 "User-Agent": userAgentProvider(),
               },
-              body: JSON.stringify({ text }),
+              body: JSON.stringify({ text: resolvedText }),
             }
           );
 
@@ -801,7 +841,7 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
                 "Content-Type": "application/json",
                 "User-Agent": userAgentProvider(),
               },
-              body: JSON.stringify({ text }),
+              body: JSON.stringify({ text: resolvedText }),
             }
           );
 

--- a/test/src/pat-auth.test.ts
+++ b/test/src/pat-auth.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
 import { jest } from "@jest/globals";
+import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential } from "@azure/identity";
+import { PublicClientApplication } from "@azure/msal-node";
+import open from "open";
 
 jest.mock("../../src/logger.js", () => ({
   logger: {
@@ -32,6 +35,11 @@ describe("PAT authentication", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    (AzureCliCredential as unknown as jest.Mock).mockReset();
+    (ChainedTokenCredential as unknown as jest.Mock).mockReset();
+    (DefaultAzureCredential as unknown as jest.Mock).mockReset();
+    (PublicClientApplication as unknown as jest.Mock).mockReset();
+    (open as jest.Mock).mockReset();
   });
 
   afterEach(() => {
@@ -78,6 +86,109 @@ describe("PAT authentication", () => {
 
       expect(resultA).toBe(b64PatA);
       expect(resultB).toBe(b64PatB);
+    });
+  });
+
+  describe("createAuthenticator('envvar')", () => {
+    it("should return ADO_MCP_AUTH_TOKEN", async () => {
+      process.env["ADO_MCP_AUTH_TOKEN"] = "environment-token";
+
+      await expect(createAuthenticator("envvar")()).resolves.toBe("environment-token");
+    });
+
+    it("should throw when ADO_MCP_AUTH_TOKEN is not set", async () => {
+      delete process.env["ADO_MCP_AUTH_TOKEN"];
+
+      await expect(createAuthenticator("envvar")()).rejects.toThrow("Environment variable 'ADO_MCP_AUTH_TOKEN' is not set or empty");
+    });
+  });
+
+  describe("Azure credential authentication", () => {
+    it("should use DefaultAzureCredential for env authentication", async () => {
+      const getToken = jest.fn().mockResolvedValue({ token: "default-token" });
+      (DefaultAzureCredential as unknown as jest.Mock).mockImplementation(() => ({ getToken }));
+      delete process.env.AZURE_TOKEN_CREDENTIALS;
+
+      await expect(createAuthenticator("env")()).resolves.toBe("default-token");
+
+      expect(process.env.AZURE_TOKEN_CREDENTIALS).toBeUndefined();
+      expect(getToken).toHaveBeenCalledWith(["499b84ac-1321-427f-aa17-267ca6975798/.default"]);
+    });
+
+    it("should use a tenant-specific Azure CLI credential chain for azcli authentication", async () => {
+      const defaultCredential = { getToken: jest.fn() };
+      const azureCliCredential = { getToken: jest.fn() };
+      const getToken = jest.fn().mockResolvedValue({ token: "chained-token" });
+      (DefaultAzureCredential as unknown as jest.Mock).mockImplementation(() => defaultCredential);
+      (AzureCliCredential as unknown as jest.Mock).mockImplementation(() => azureCliCredential);
+      (ChainedTokenCredential as unknown as jest.Mock).mockImplementation(() => ({ getToken }));
+
+      await expect(createAuthenticator("azcli", "tenant-id")()).resolves.toBe("chained-token");
+
+      expect(process.env.AZURE_TOKEN_CREDENTIALS).toBe("dev");
+      expect(AzureCliCredential).toHaveBeenCalledWith({ tenantId: "tenant-id" });
+      expect(ChainedTokenCredential).toHaveBeenCalledWith(azureCliCredential, defaultCredential);
+    });
+
+    it("should throw when the Azure credential returns no token", async () => {
+      (DefaultAzureCredential as unknown as jest.Mock).mockImplementation(() => ({ getToken: jest.fn().mockResolvedValue(null) }));
+
+      await expect(createAuthenticator("env")()).rejects.toThrow("Failed to obtain Azure DevOps token");
+    });
+  });
+
+  describe("OAuth authentication", () => {
+    it("should use tenant-specific interactive authentication, open the browser, and cache the account", async () => {
+      const account = { homeAccountId: "account-id" };
+      const acquireTokenSilent = jest.fn().mockResolvedValue({ accessToken: "silent-token", account });
+      const acquireTokenInteractive = jest.fn().mockImplementation(async ({ openBrowser }) => {
+        await openBrowser("https://login.example.com");
+        return { accessToken: "interactive-token", account };
+      });
+      (PublicClientApplication as unknown as jest.Mock).mockImplementation(() => ({ acquireTokenSilent, acquireTokenInteractive }));
+
+      const authenticator = createAuthenticator("oauth", "tenant-id");
+
+      await expect(authenticator()).resolves.toBe("interactive-token");
+      await expect(authenticator()).resolves.toBe("silent-token");
+      expect(PublicClientApplication).toHaveBeenCalledWith({
+        auth: {
+          clientId: "0d50963b-7bb9-4fe7-94c7-a99af00b5136",
+          authority: "https://login.microsoftonline.com/tenant-id",
+        },
+      });
+      expect(open).toHaveBeenCalledWith("https://login.example.com");
+      expect(acquireTokenSilent).toHaveBeenCalledWith(expect.objectContaining({ account }));
+      expect(acquireTokenInteractive).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([new Error("silent failure"), "silent failure"])("should fall back to interactive authentication when silent acquisition rejects with %p", async (error) => {
+      const account = { homeAccountId: "account-id" };
+      const acquireTokenSilent = jest.fn().mockRejectedValue(error);
+      const acquireTokenInteractive = jest.fn().mockResolvedValueOnce({ accessToken: "first-token", account }).mockResolvedValueOnce({ accessToken: "fallback-token", account });
+      (PublicClientApplication as unknown as jest.Mock).mockImplementation(() => ({ acquireTokenSilent, acquireTokenInteractive }));
+
+      const authenticator = createAuthenticator("oauth");
+
+      await expect(authenticator()).resolves.toBe("first-token");
+      await expect(authenticator()).resolves.toBe("fallback-token");
+      expect(acquireTokenInteractive).toHaveBeenCalledTimes(2);
+    });
+
+    it("should use the common authority for the zero tenant ID", async () => {
+      const acquireTokenInteractive = jest.fn().mockResolvedValue({ accessToken: "token", account: null });
+      (PublicClientApplication as unknown as jest.Mock).mockImplementation(() => ({ acquireTokenInteractive }));
+
+      await expect(createAuthenticator("oauth", "00000000-0000-0000-0000-000000000000")()).resolves.toBe("token");
+
+      expect(PublicClientApplication).toHaveBeenCalledWith(expect.objectContaining({ auth: expect.objectContaining({ authority: "https://login.microsoftonline.com/common" }) }));
+    });
+
+    it("should throw when interactive authentication returns no access token", async () => {
+      const acquireTokenInteractive = jest.fn().mockResolvedValue({ accessToken: "", account: null });
+      (PublicClientApplication as unknown as jest.Mock).mockImplementation(() => ({ acquireTokenInteractive }));
+
+      await expect(createAuthenticator("oauth")()).rejects.toThrow("Failed to obtain Azure DevOps OAuth token");
     });
   });
 

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -898,6 +898,33 @@ describe("configureWorkItemTools", () => {
       expect(result.content[0].text).toBe(JSON.stringify(_mockWorkItemComment));
     });
 
+    it("should resolve all email mentions and preserve unresolved Markdown mentions as visible text", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_comment_write");
+      if (!call) throw new Error("wit_work_item_comment_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ value: [{ id: "guid-one" }] }) })
+        .mockResolvedValueOnce({ ok: false, status: 404, text: () => Promise.resolve("Not Found") })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ value: [{ id: "guid-two" }] }) })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify(_mockWorkItemComment)) });
+      global.fetch = mockFetch;
+
+      await handler({
+        action: "add",
+        project: "Contoso",
+        workItemId: 299,
+        text: "Hello @<one@example.com>, @<missing@example.com>, and @<two@example.com>",
+      });
+
+      expect(JSON.parse(mockFetch.mock.calls[3][1].body)).toEqual({ text: "Hello @<guid-one>, @&lt;missing@example.com&gt;, and @<guid-two>" });
+    });
+
     it("should call Add Work Item Comments API with format=1 when format is Html", async () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
 
@@ -913,6 +940,48 @@ describe("configureWorkItemTools", () => {
       await handler({ action: "add", text: "hello world!", project: "Contoso", workItemId: 299, format: "Html" });
 
       expect(mockFetch).toHaveBeenCalledWith("https://dev.azure.com/contoso/Contoso/_apis/wit/workItems/299/comments?format=1&api-version=7.2-preview.4", expect.objectContaining({ method: "POST" }));
+    });
+
+    it("should use HTML mention syntax when the comment format is Html", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_comment_write");
+      if (!call) throw new Error("wit_work_item_comment_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ value: [{ id: "guid-one", providerDisplayName: `Jane & <Doe> "Admin" O'Neil` }] }) })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify(_mockWorkItemComment)) });
+      global.fetch = mockFetch;
+
+      await handler({ action: "add", text: "Hello @<jane@example.com>", project: "Contoso", workItemId: 299, format: "Html" });
+
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+        text: 'Hello <a href="#" data-vss-mention="version:2.0,guid-one">@Jane &amp; &lt;Doe&gt; &quot;Admin&quot; O&#39;Neil</a>',
+      });
+    });
+
+    it("should preserve unresolved email mentions as visible text when the comment format is Html", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_comment_write");
+      if (!call) throw new Error("wit_work_item_comment_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ value: [] }) })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify(_mockWorkItemComment)) });
+      global.fetch = mockFetch;
+
+      await handler({ action: "add", text: "Hello @<missing@example.com>", project: "Contoso", workItemId: 299, format: "Html" });
+
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({ text: "Hello @&lt;missing@example.com&gt;" });
     });
 
     it("should handle fetch failure response", async () => {
@@ -1049,6 +1118,33 @@ describe("configureWorkItemTools", () => {
 
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.text).toBe("Updated comment text");
+    });
+
+    it("should resolve repeated email mentions before updating a comment", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_comment_write");
+      if (!call) throw new Error("wit_work_item_comment_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+      const mockFetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ value: [{ id: "guid-one" }] }) })
+        .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(JSON.stringify(_mockWorkItemComment)) });
+      global.fetch = mockFetch;
+
+      await handler({
+        action: "update",
+        project: "Contoso",
+        workItemId: 299,
+        commentId: 1,
+        text: "@<one@example.com> follow up with @<one@example.com>",
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({ text: "@<guid-one> follow up with @<guid-one>" });
     });
 
     it("should handle update work item comment failure", async () => {


### PR DESCRIPTION
This pull request introduces enhancements to work item comment handling, particularly for resolving email mentions to Azure DevOps identities, and expands test coverage for authentication and comment mention resolution. The most important changes are summarized below.

### Work Item Comment Mention Resolution

* Added a new function `resolveCommentMentions` in `src/tools/work-items.ts` that detects email mentions in the format `@<email>` within work item comments and replaces them with Azure DevOps identity IDs or HTML mention tags, depending on the comment format. If an identity cannot be resolved, the mention is escaped and shown as visible text.
* Updated the work item comment write and update logic to use the resolved mentions before sending the comment to the server, ensuring consistent mention formatting and identity resolution. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R809) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L781-R821) [[3]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L804-R844)

### Identity Lookup Enhancements

* Refactored identity lookup logic: introduced `getUserIdentityFromEmail` in `src/tools/auth.ts` to return both the user ID and display name, and updated `getUserIdFromEmail` to use this new function. Exported `getUserIdentityFromEmail` for use in work item tools. [[1]](diffhunk://#diff-0f6a40b4809bfc8010e8bbd5731668bbf918c90c25fc5f1682f0000701b76265L62-R67) [[2]](diffhunk://#diff-0f6a40b4809bfc8010e8bbd5731668bbf918c90c25fc5f1682f0000701b76265L77-R90)
* Updated imports in `src/tools/work-items.ts` to use the new identity lookup function.

### Test Coverage Improvements

* Added comprehensive tests in `test/src/tools/work-items.test.ts` to verify mention resolution in both Markdown and HTML formats, handling of unresolved mentions, and repeated mentions. [[1]](diffhunk://#diff-1ed6ae5f1c97b40dd2e906035bca44eddce5d0045d8e1807ffba699ef1892be6R901-R927) [[2]](diffhunk://#diff-1ed6ae5f1c97b40dd2e906035bca44eddce5d0045d8e1807ffba699ef1892be6R945-R986) [[3]](diffhunk://#diff-1ed6ae5f1c97b40dd2e906035bca44eddce5d0045d8e1807ffba699ef1892be6R1123-R1149)
* Enhanced authentication tests in `test/src/pat-auth.test.ts` to cover environment variable, Azure credential, and OAuth authentication flows, including error handling and credential resets. [[1]](diffhunk://#diff-12d48a14aa809fe1cf3baa0946feb4080af042054720beb7e09eefc00bfc8b74R6-R8) [[2]](diffhunk://#diff-12d48a14aa809fe1cf3baa0946feb4080af042054720beb7e09eefc00bfc8b74R38-R42) [[3]](diffhunk://#diff-12d48a14aa809fe1cf3baa0946feb4080af042054720beb7e09eefc00bfc8b74R92-R194)

## GitHub issue number
#1494

## **Associated Risks**

Change in behavior

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Multiple manual tests and updated automated tests
