### PR TITLE
Add reorder functionality for backlog work items and tests

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -53,6 +53,7 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 | [wit_query](#wit_query)                                     | `wiql`                 | Execute an ad-hoc WIQL query                                            |
 | [wit_backlog](#wit_backlog)                                 | `list`                 | List backlog levels for a team                                          |
 | [wit_backlog](#wit_backlog)                                 | `list_work_items`      | Get work items in a specific backlog level                              |
+| [wit_backlog](#wit_backlog)                                 | `reorder`              | Reorder work items in a backlog or iteration                            |
 | [wit_work_item_attachment](#wit_work_item_attachment)       |                        | Download a work item attachment; save locally or return as base64       |
 
 ### Repositories

--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -374,12 +374,27 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
     WORKITEM_TOOLS.wit_backlog,
     "Retrieve backlog data for a project and team. Use the action parameter to specify the operation.",
     {
-      action: z.enum(["list", "list_work_items"]).describe("The action to perform. Options: list (list backlog levels for a team), list_work_items (list work items in a specific backlog level)."),
+      action: z
+        .enum(["list", "list_work_items", "reorder"])
+        .describe(
+          "The action to perform. Options: list (list backlog levels for a team), list_work_items (list work items in a specific backlog level), reorder (move work items to a new position in a backlog or iteration)."
+        ),
       project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
       team: z.string().optional().describe("The name or ID of the Azure DevOps team. Reuse from prior context if already known. If not provided, a team selection prompt will be shown."),
       backlogId: z.string().optional().describe("The ID of the backlog category to retrieve work items from. Required for: list_work_items."),
+      ids: z.array(z.coerce.number().int().min(1)).min(1).optional().describe("The IDs of the work items to reorder. Required for: reorder."),
+      previousId: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe("The ID of the work item that should be before the reordered items. Use 0 to specify the beginning of the list. Optional for: reorder."),
+      nextId: z.coerce.number().int().min(0).optional().describe("The ID of the work item that should be after the reordered items. Use 0 to specify the end of the list. Optional for: reorder."),
+      parentId: z.coerce.number().int().min(0).optional().describe("The parent ID for all work items involved in the operation. Use 0 to indicate the items have no parent. Optional for: reorder."),
+      iterationPath: z.string().optional().describe("The iteration path for the reorder operation. Used when reordering items in an iteration backlog. Optional for: reorder."),
+      iterationId: z.string().optional().describe("The iteration ID. When provided, reorder items in that iteration instead of the team backlog. Used for: reorder."),
     },
-    async ({ action, project, team, backlogId }) => {
+    async ({ action, project, team, backlogId, ids, previousId, nextId, parentId, iterationPath, iterationId }) => {
       try {
         const connection = await connectionProvider();
 
@@ -413,12 +428,22 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
           return { content: [{ type: "text", text: JSON.stringify(workItems, null, 2) }] };
         }
 
+        if (action === "reorder") {
+          if (!ids?.length) return { content: [{ type: "text", text: "ids is required for reorder" }], isError: true };
+
+          const operation = { ids, previousId, nextId, parentId, iterationPath };
+          const reorderedItems = iterationId ? await workApi.reorderIterationWorkItems(operation, teamContext, iterationId) : await workApi.reorderBacklogWorkItems(operation, teamContext);
+
+          return { content: [{ type: "text", text: JSON.stringify(reorderedItems, null, 2) }] };
+        }
+
         return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
         const msgs: Record<string, string> = {
           list: `Error listing backlogs: ${errorMessage}`,
           list_work_items: `Error listing backlog work items: ${errorMessage}`,
+          reorder: `Error reordering backlog work items: ${errorMessage}`,
         };
         return { content: [{ type: "text", text: msgs[action] ?? `Error: ${errorMessage}` }], isError: true };
       }

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -32,6 +32,8 @@ type ConnectionProviderMock = () => Promise<WebApi>;
 interface WorkApiMock {
   getBacklogs: jest.Mock;
   getBacklogLevelWorkItems: jest.Mock;
+  reorderBacklogWorkItems: jest.Mock;
+  reorderIterationWorkItems: jest.Mock;
   getPredefinedQueryResults: jest.Mock;
   getTeamIterations: jest.Mock;
   getIterationWorkItems: jest.Mock;
@@ -75,6 +77,8 @@ describe("configureWorkItemTools", () => {
     mockWorkApi = {
       getBacklogs: jest.fn(),
       getBacklogLevelWorkItems: jest.fn(),
+      reorderBacklogWorkItems: jest.fn(),
+      reorderIterationWorkItems: jest.fn(),
       getPredefinedQueryResults: jest.fn(),
       getTeamIterations: jest.fn(),
       getIterationWorkItems: jest.fn(),
@@ -204,6 +208,116 @@ describe("configureWorkItemTools", () => {
           2
         )
       );
+    });
+  });
+
+  describe("reorder_backlog_work_items tool", () => {
+    it("should reorder work items in the team backlog", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_backlog");
+      if (!call) throw new Error("wit_backlog tool not registered");
+      const [, , , handler] = call;
+
+      const reorderedItems = [
+        { id: 101, order: 1 },
+        { id: 102, order: 2 },
+      ];
+      (mockWorkApi.reorderBacklogWorkItems as jest.Mock).mockResolvedValue(reorderedItems);
+
+      const params = {
+        project: "Contoso",
+        team: "Fabrikam",
+        ids: [101, 102],
+        previousId: 0,
+        nextId: 103,
+        parentId: 0,
+      };
+
+      const result = await handler({ action: "reorder", ...params });
+
+      expect(mockWorkApi.reorderBacklogWorkItems).toHaveBeenCalledWith(
+        {
+          ids: params.ids,
+          previousId: params.previousId,
+          nextId: params.nextId,
+          parentId: params.parentId,
+          iterationPath: undefined,
+        },
+        { project: params.project, team: params.team }
+      );
+      expect(mockWorkApi.reorderIterationWorkItems).not.toHaveBeenCalled();
+      expect(result.content[0].text).toBe(JSON.stringify(reorderedItems, null, 2));
+    });
+
+    it("should reorder work items in an iteration and pass optional fields", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_backlog");
+      if (!call) throw new Error("wit_backlog tool not registered");
+      const [, , , handler] = call;
+
+      const reorderedItems = [{ id: 101, order: 4 }];
+      (mockWorkApi.reorderIterationWorkItems as jest.Mock).mockResolvedValue(reorderedItems);
+
+      const params = {
+        project: "Contoso",
+        team: "Fabrikam",
+        iterationId: "iteration-1",
+        ids: [101],
+        nextId: 0,
+        iterationPath: "Contoso\\Sprint 1",
+      };
+
+      const result = await handler({ action: "reorder", ...params });
+
+      expect(mockWorkApi.reorderIterationWorkItems).toHaveBeenCalledWith(
+        {
+          ids: params.ids,
+          previousId: undefined,
+          nextId: params.nextId,
+          parentId: undefined,
+          iterationPath: params.iterationPath,
+        },
+        { project: params.project, team: params.team },
+        params.iterationId
+      );
+      expect(mockWorkApi.reorderBacklogWorkItems).not.toHaveBeenCalled();
+      expect(result.content[0].text).toBe(JSON.stringify(reorderedItems, null, 2));
+    });
+
+    it("should return an error when ids are missing", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_backlog");
+      if (!call) throw new Error("wit_backlog tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "reorder", project: "Contoso", team: "Fabrikam" });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "ids is required for reorder" }],
+        isError: true,
+      });
+      expect(mockWorkApi.reorderBacklogWorkItems).not.toHaveBeenCalled();
+      expect(mockWorkApi.reorderIterationWorkItems).not.toHaveBeenCalled();
+    });
+
+    it("should return an error when the reorder API fails", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_backlog");
+      if (!call) throw new Error("wit_backlog tool not registered");
+      const [, , , handler] = call;
+
+      (mockWorkApi.reorderBacklogWorkItems as jest.Mock).mockRejectedValue(new Error("API Error"));
+
+      const result = await handler({ action: "reorder", project: "Contoso", team: "Fabrikam", ids: [101] });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Error reordering backlog work items: API Error" }],
+        isError: true,
+      });
     });
   });
 


### PR DESCRIPTION
This pull request adds support for reordering work items in Azure DevOps backlogs and iterations through the `wit_backlog` tool. It introduces a new `reorder` action, updates the tool interface and documentation, and provides comprehensive tests to ensure correct behavior and error handling.

### Feature: Work Item Reordering

* Added a new `reorder` action to the `wit_backlog` tool, allowing users to reorder work items in either a team backlog or a specific iteration. This includes new parameters such as `ids`, `previousId`, `nextId`, `parentId`, `iterationPath`, and `iterationId` to specify the details of the reorder operation. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L377-R397) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R431-R446)
* Updated the documentation in `TOOLSET.md` to describe the new `reorder` action and its usage.

### Testing and Mocks

* Extended the `WorkApiMock` interface and test setup to include `reorderBacklogWorkItems` and `reorderIterationWorkItems` mocks, ensuring the new functionality is properly tested. [[1]](diffhunk://#diff-1ed6ae5f1c97b40dd2e906035bca44eddce5d0045d8e1807ffba699ef1892be6R35-R36) [[2]](diffhunk://#diff-1ed6ae5f1c97b40dd2e906035bca44eddce5d0045d8e1807ffba699ef1892be6R80-R81)
* Added comprehensive test cases covering successful reordering in both backlogs and iterations, missing required parameters, and API error handling for the `reorder` action.

## GitHub issue number
#1486

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Ran several manual tests. Updated automated tests,
