### PR TITLE
Expose pull request iteration identity in get_changes

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -66,7 +66,7 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 | [repo_pull_request](#repo_pull_request)                           | `get`              | Get a pull request by ID                                            |
 | [repo_pull_request](#repo_pull_request)                           | `list`             | List pull requests in a repository or project                       |
 | [repo_pull_request](#repo_pull_request)                           | `list_by_commits`  | Find pull requests that contain specific commit IDs                 |
-| [repo_pull_request](#repo_pull_request)                           | `get_changes`      | Get bounded iteration changes and optional authoritative line diffs |
+| [repo_pull_request](#repo_pull_request)                           | `get_changes`      | Get a bounded PR iteration page with exact commit identity          |
 | [repo_pull_request_thread](#repo_pull_request_thread)             | `list`             | List comment threads on a pull request                              |
 | [repo_pull_request_thread](#repo_pull_request_thread)             | `list_comments`    | List comments in a specific thread                                  |
 | [repo_branch](#repo_branch)                                       | `get`              | Get a branch by name                                                |

--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -66,6 +66,7 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 | [repo_pull_request](#repo_pull_request)                           | `get`              | Get a pull request by ID                                            |
 | [repo_pull_request](#repo_pull_request)                           | `list`             | List pull requests in a repository or project                       |
 | [repo_pull_request](#repo_pull_request)                           | `list_by_commits`  | Find pull requests that contain specific commit IDs                 |
+| [repo_pull_request](#repo_pull_request)                           | `get_changes`      | Get bounded iteration changes and optional authoritative line diffs |
 | [repo_pull_request_thread](#repo_pull_request_thread)             | `list`             | List comment threads on a pull request                              |
 | [repo_pull_request_thread](#repo_pull_request_thread)             | `list_comments`    | List comments in a specific thread                                  |
 | [repo_branch](#repo_branch)                                       | `get`              | Get a branch by name                                                |

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -18,14 +18,9 @@ import {
   GitPullRequestMergeStrategy,
   GitPullRequest,
   GitPullRequestCommentThread,
-  GitPullRequestChange,
   GitPullRequestIteration,
-  FileDiff,
   IterationReason,
-  LineDiffBlock,
-  LineDiffBlockChangeType,
   Comment,
-  VersionControlChangeType,
   VersionControlRecursionType,
 } from "azure-devops-node-api/interfaces/GitInterfaces.js";
 import { z } from "zod";
@@ -47,13 +42,7 @@ const REPO_TOOLS = {
   repo_create_branch: "repo_create_branch",
 };
 
-const CHANGE_PAGE_SIZE_MAX = 200;
-const CHANGE_COUNT_MAX = 1000;
-const FILE_DIFF_BATCH_SIZE = 10;
-const FILE_DIFF_PATH_MAX = 20;
-const FILE_DIFF_BLOCK_MAX = 5000;
-const FILE_DIFF_LINE_MAX = 200000;
-const FILE_DIFF_RESPONSE_BYTE_MAX = 2 * 1024 * 1024;
+const CHANGE_PAGE_SIZE_MAX = 1000;
 const COMMIT_ID_PATTERN = /^[0-9a-f]{40}$/i;
 const REPOSITORY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -72,14 +61,6 @@ function pullRequestChangesError(error: PullRequestChangesError) {
     content: [{ type: "text" as const, text: JSON.stringify({ error: { code: error.code, message: error.message, ...error.details } }, null, 2) }],
     isError: true,
   };
-}
-
-function normalizeGitPath(path: string | undefined): string | undefined {
-  if (path === undefined) return undefined;
-  if (path.includes("\\") || path.includes("\0")) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
-  const normalized = path.replace(/^\/+/, "");
-  if (!normalized || normalized.split("/").includes("..")) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
-  return normalized;
 }
 
 function requireCommitId(commitId: string | undefined, label: string): string {
@@ -126,7 +107,11 @@ function validateIterationBinding(iteration: GitPullRequestIteration) {
     requireBranchRef(iteration.oldTargetRefName, "oldTargetRefName");
     requireBranchRef(iteration.newTargetRefName, "newTargetRefName");
   }
-  return { commonRefCommit, sourceRefCommit, targetRefCommit };
+  return {
+    commonRefCommit: { commitId: commonRefCommit },
+    sourceRefCommit: { commitId: sourceRefCommit },
+    targetRefCommit: { commitId: targetRefCommit },
+  };
 }
 
 function latestIteration(iterations: GitPullRequestIteration[]) {
@@ -149,177 +134,23 @@ function latestIteration(iterations: GitPullRequestIteration[]) {
   return { ...latest, id: latestId };
 }
 
-async function getAllIterationChanges(
-  gitApi: Awaited<ReturnType<WebApi["getGitApi"]>>,
-  repositoryId: string,
-  pullRequestId: number,
-  iterationId: number,
-  project: string | undefined,
-  pageSize: number,
-  changeLimit: number
-) {
-  const changeEntries: GitPullRequestChange[] = [];
-  let nextSkip = 0;
-  let nextTop = Math.min(pageSize, changeLimit);
-  let pages = 0;
-
-  while (true) {
-    const page = await gitApi.getPullRequestIterationChanges(repositoryId, pullRequestId, iterationId, project, nextTop, nextSkip);
-    const entries = page.changeEntries ?? [];
-    pages += 1;
-    if (changeEntries.length + entries.length > changeLimit) {
-      throw new PullRequestChangesError("CHANGES_TRUNCATED", `The iteration contains more than the configured ${changeLimit} change-entry limit.`, {
-        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip, nextTop, changeLimit },
-      });
-    }
-    changeEntries.push(...entries);
-
-    const serverNextSkip = page.nextSkip ?? 0;
-    const serverNextTop = page.nextTop ?? 0;
-    if (serverNextSkip === 0 && serverNextTop === 0) {
-      return { changeEntries, pagination: { complete: true, truncated: false, pages, changeCount: changeEntries.length, nextSkip: 0, nextTop: 0, changeLimit } };
-    }
-    if (changeEntries.length >= changeLimit) {
-      throw new PullRequestChangesError("CHANGES_TRUNCATED", `The iteration contains more than the configured ${changeLimit} change-entry limit.`, {
-        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip: serverNextSkip, nextTop: serverNextTop, changeLimit },
-      });
-    }
-    if (!Number.isInteger(serverNextSkip) || !Number.isInteger(serverNextTop) || serverNextSkip !== nextSkip + entries.length || serverNextTop < 1 || entries.length === 0) {
-      throw new PullRequestChangesError("INCOMPLETE_PAGINATION", "Azure DevOps returned incomplete or malformed iteration-change pagination.", {
-        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip: serverNextSkip, nextTop: serverNextTop, changeLimit },
-      });
-    }
-    nextSkip = serverNextSkip;
-    nextTop = Math.min(serverNextTop, pageSize, changeLimit - changeEntries.length);
+function validateIterationChangesPage(changeEntries: unknown, nextSkip: number, nextTop: number, skip: number, top: number) {
+  if (!Array.isArray(changeEntries)) {
+    throw new PullRequestChangesError("INCOMPLETE_PAGINATION", "Azure DevOps returned malformed iteration change entries.");
   }
-}
-
-function changeTypeNames(changeType: number): string[] {
-  return Object.entries(VersionControlChangeType)
-    .filter(([name, value]) => typeof value === "number" && value !== 0 && (changeType & value) === value && !/^\d+$/.test(name))
-    .map(([name]) => name);
-}
-
-function lineSpan(start: number | undefined, count: number | undefined) {
-  if (count === 0) {
-    if (start !== undefined && start !== 0) throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An empty side of a line diff block has a nonzero start line.");
-    return null;
+  const hasNextPage = nextSkip !== 0 || nextTop !== 0;
+  if (
+    changeEntries.length > top ||
+    !Number.isInteger(nextSkip) ||
+    !Number.isInteger(nextTop) ||
+    nextSkip < 0 ||
+    nextTop < 0 ||
+    nextTop > CHANGE_PAGE_SIZE_MAX ||
+    (hasNextPage && (changeEntries.length === 0 || nextSkip !== skip + changeEntries.length || nextTop === 0))
+  ) {
+    throw new PullRequestChangesError("INCOMPLETE_PAGINATION", "Azure DevOps returned incomplete or malformed iteration-change pagination.");
   }
-  if (typeof start !== "number" || typeof count !== "number" || !Number.isInteger(start) || !Number.isInteger(count) || start < 1 || count < 1) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned a malformed line diff block.");
-  }
-  return { startLine: start, endLine: start + count - 1, lineCount: count };
-}
-
-function validateLineDiffBlock(block: LineDiffBlock) {
-  const changeType = block.changeType;
-  const originalCount = block.originalLinesCount;
-  const modifiedCount = block.modifiedLinesCount;
-  if (changeType === undefined || ![LineDiffBlockChangeType.None, LineDiffBlockChangeType.Add, LineDiffBlockChangeType.Delete, LineDiffBlockChangeType.Edit].includes(changeType)) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned an unknown line diff block change type.");
-  }
-  if (!Number.isInteger(originalCount) || !Number.isInteger(modifiedCount) || (originalCount ?? -1) < 0 || (modifiedCount ?? -1) < 0) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned a malformed line diff block.");
-  }
-  if (changeType === LineDiffBlockChangeType.Add && (originalCount !== 0 || modifiedCount === 0)) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An add block has invalid base/source orientation.");
-  }
-  if (changeType === LineDiffBlockChangeType.Delete && (originalCount === 0 || modifiedCount !== 0)) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "A delete block has invalid base/source orientation.");
-  }
-  if (changeType === LineDiffBlockChangeType.Edit && (originalCount === 0 || modifiedCount === 0)) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An edit block has invalid base/source orientation.");
-  }
-  if (changeType === LineDiffBlockChangeType.None && originalCount !== modifiedCount) {
-    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "A context block has inconsistent base/source line counts.");
-  }
-  return {
-    ...block,
-    changeTypeName: LineDiffBlockChangeType[changeType],
-    originalSpan: lineSpan(block.originalLineNumberStart, originalCount),
-    modifiedSpan: lineSpan(block.modifiedLineNumberStart, modifiedCount),
-  };
-}
-
-function bindRequestedChanges(changeEntries: GitPullRequestChange[], requestedPaths: string[]) {
-  const aliases = new Map<string, Set<GitPullRequestChange>>();
-  const requestedEntries = new Set<GitPullRequestChange>();
-  const normalizedRequested = requestedPaths.map((path) => {
-    const normalizedPath = normalizeGitPath(path);
-    if (!normalizedPath) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
-    return normalizedPath;
-  });
-  if (new Set(normalizedRequested).size !== normalizedRequested.length) {
-    throw new PullRequestChangesError("DUPLICATE_PATH", "Requested paths contain duplicates after normalization.");
-  }
-
-  for (const entry of changeEntries) {
-    const currentPath = normalizeGitPath(entry.item?.path);
-    const originalPath = normalizeGitPath(entry.originalPath);
-    if (!currentPath && !originalPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no current or original path.");
-    for (const alias of new Set([currentPath, originalPath].filter((path): path is string => path !== undefined))) {
-      const matchingEntries = aliases.get(alias) ?? new Set<GitPullRequestChange>();
-      matchingEntries.add(entry);
-      aliases.set(alias, matchingEntries);
-    }
-  }
-
-  return normalizedRequested.map((requestedPath) => {
-    const matchingEntries = aliases.get(requestedPath);
-    if (!matchingEntries) throw new PullRequestChangesError("PATH_NOT_IN_ITERATION", `Requested path '${requestedPath}' is not present in the selected iteration changes.`);
-    if (matchingEntries.size !== 1) throw new PullRequestChangesError("CONFLICTING_PATH", `Multiple change entries resolve to requested path '${requestedPath}'.`);
-    const [entry] = matchingEntries;
-    if (requestedEntries.has(entry)) throw new PullRequestChangesError("DUPLICATE_PATH", `Multiple requested paths resolve to the same change entry at '${requestedPath}'.`);
-    requestedEntries.add(entry);
-    if (entry.item?.isFolder || entry.item?.contentMetadata?.isBinary) {
-      throw new PullRequestChangesError("UNSUPPORTED_FILE", `Requested path '${requestedPath}' is a folder or binary file.`);
-    }
-    const path = normalizeGitPath(entry.item?.path) ?? normalizeGitPath(entry.originalPath);
-    if (!path) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A requested change entry has no current or original path.");
-    const originalPath = normalizeGitPath(entry.originalPath);
-    return { requestedPath, entry, path, originalPath };
-  });
-}
-
-function bindFileDiffs(requests: ReturnType<typeof bindRequestedChanges>, fileDiffs: FileDiff[]) {
-  if (Buffer.byteLength(JSON.stringify(fileDiffs), "utf8") > FILE_DIFF_RESPONSE_BYTE_MAX) {
-    throw new PullRequestChangesError("FILE_DIFF_TOO_LARGE", `FileDiffs response exceeds the ${FILE_DIFF_RESPONSE_BYTE_MAX}-byte safety limit.`);
-  }
-  let blockCount = 0;
-  let lineCount = 0;
-  const unmatched = [...fileDiffs];
-
-  const results = requests.map(({ requestedPath, entry, path, originalPath }) => {
-    const matchIndex = unmatched.findIndex((diff) => {
-      const diffPath = normalizeGitPath(diff.path);
-      const diffOriginalPath = normalizeGitPath(diff.originalPath);
-      return diffPath === path || (originalPath !== undefined && diffOriginalPath === originalPath) || diffPath === requestedPath || diffOriginalPath === requestedPath;
-    });
-    if (matchIndex < 0) throw new PullRequestChangesError("MISSING_FILE_DIFF", `Azure DevOps did not return a FileDiff for '${requestedPath}'.`);
-    const diff = unmatched.splice(matchIndex, 1)[0];
-    const blocks = diff.lineDiffBlocks ?? [];
-    const changeType = entry.changeType ?? VersionControlChangeType.None;
-    const renameOnly = (changeType & VersionControlChangeType.Rename) !== 0 && (changeType & (VersionControlChangeType.Add | VersionControlChangeType.Edit | VersionControlChangeType.Delete)) === 0;
-    if (blocks.length === 0 && !renameOnly) throw new PullRequestChangesError("UNSUPPORTED_FILE_DIFF", `Azure DevOps returned no line diff blocks for '${requestedPath}'.`);
-    blockCount += blocks.length;
-    lineCount += blocks.reduce((total, block) => total + (block.originalLinesCount ?? 0) + (block.modifiedLinesCount ?? 0), 0);
-    if (blockCount > FILE_DIFF_BLOCK_MAX || lineCount > FILE_DIFF_LINE_MAX) {
-      throw new PullRequestChangesError("FILE_DIFF_TOO_LARGE", "FileDiffs response exceeds the line or block safety limit.");
-    }
-    return {
-      provenance: {
-        source: "getFileDiffs",
-        requestedPath,
-        iterationChangeTrackingId: entry.changeTrackingId,
-        orientation: { original: "commonRefCommit", modified: "sourceRefCommit" },
-      },
-      path: normalizeGitPath(diff.path) ?? path,
-      originalPath: normalizeGitPath(diff.originalPath) ?? originalPath ?? null,
-      lineDiffBlocks: blocks.map(validateLineDiffBlock),
-    };
-  });
-  if (unmatched.length > 0) throw new PullRequestChangesError("UNEXPECTED_FILE_DIFF", "Azure DevOps returned FileDiff results that were not requested.");
-  return results;
+  return { changeEntries, hasMoreChanges: hasNextPage };
 }
 
 function branchesFilterOutIrrelevantProperties(branches: GitRef[], top: number) {
@@ -481,21 +312,24 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
   // --- repo_pull_request -----------------------------------------------------
   server.tool(
     REPO_TOOLS.repo_pull_request,
-    "Retrieve pull request data and authoritative, iteration-bound change spans. Use the action parameter to specify the operation.",
+    "Retrieve pull request data and iteration-bound change pages. Use the action parameter to specify the operation.",
     {
       action: z
         .enum(["get", "list", "list_by_commits", "get_changes"])
         .describe(
-          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs), get_changes (get bounded change entries and optional authoritative line diffs for one immutable pull request iteration)."
+          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs), get_changes (get one bounded page of changes with exact pull request iteration commit identity)."
         ),
       repositoryId: z.string().optional().describe("The ID or name of the repository. Required for get. Optional for list. When using a name instead of a GUID, project must also be provided."),
       pullRequestId: z.coerce.number().min(1).optional().describe("The ID of the pull request. Required for get."),
-      project: z.string().optional().describe("Project ID or project name. Required for list_by_commits. Optional for get and list."),
+      project: z.string().optional().describe("Project ID or project name. Required for list_by_commits and for get_changes when repositoryId is a name. Optional for get and list."),
       includeWorkItemRefs: z.boolean().optional().default(false).describe("Whether to include work item references. Used for get."),
       includeLabels: z.boolean().optional().default(false).describe("Whether to include labels. Used for get."),
       includeChangedFiles: z.boolean().optional().default(false).describe("Whether to include the list of changed files. Used for get."),
-      top: z.coerce.number().default(100).describe("The maximum number of pull requests to return. Used for list. Defaults to 100."),
-      skip: z.coerce.number().default(0).describe("The number of pull requests to skip. Used for list. Defaults to 0."),
+      top: z.coerce
+        .number()
+        .default(100)
+        .describe(`The maximum number of results to return. Used for list and get_changes. Defaults to 100; get_changes requires an integer from 1 through ${CHANGE_PAGE_SIZE_MAX}.`),
+      skip: z.coerce.number().default(0).describe("The number of results to skip. Used for list and get_changes. Defaults to 0; get_changes requires a non-negative integer."),
       created_by_me: z.boolean().default(false).describe("Filter pull requests created by the current user. Used for list."),
       created_by_user: z.string().optional().describe("Filter pull requests created by a specific user email. Used for list."),
       i_am_reviewer: z.boolean().default(false).describe("Filter pull requests where the current user is a reviewer. Used for list."),
@@ -514,17 +348,6 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .default(GitPullRequestQueryType[GitPullRequestQueryType.LastMergeCommit])
         .describe("Type of commit query. Used for list_by_commits."),
       iterationId: z.coerce.number().int().min(1).optional().describe("Exact pull request iteration to select. Used for get_changes; defaults to the latest iteration."),
-      includeLineDiffs: z.boolean().optional().default(false).describe("Call FileDiffs for explicitly requested paths. Used for get_changes; defaults to false."),
-      paths: z.array(z.string().min(1)).max(FILE_DIFF_PATH_MAX).optional().describe(`Paths to retrieve line diffs for. Required when includeLineDiffs is true; maximum ${FILE_DIFF_PATH_MAX}.`),
-      changePageSize: z.coerce.number().int().min(1).max(CHANGE_PAGE_SIZE_MAX).optional().default(100).describe(`Iteration-change page size. Used for get_changes; maximum ${CHANGE_PAGE_SIZE_MAX}.`),
-      changeLimit: z.coerce
-        .number()
-        .int()
-        .min(1)
-        .max(CHANGE_COUNT_MAX)
-        .optional()
-        .default(500)
-        .describe(`Maximum complete iteration change count. Used for get_changes; maximum ${CHANGE_COUNT_MAX}; exceeding it fails closed.`),
     },
     async ({
       action,
@@ -547,10 +370,6 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       commits,
       queryType,
       iterationId,
-      includeLineDiffs,
-      paths,
-      changePageSize = 100,
-      changeLimit = 500,
     }) => {
       try {
         const connection = await connectionProvider();
@@ -682,24 +501,17 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         if (action === "get_changes") {
           if (!repositoryId) return { content: [{ type: "text", text: "repositoryId is required for get_changes" }], isError: true };
           if (!pullRequestId) return { content: [{ type: "text", text: "pullRequestId is required for get_changes" }], isError: true };
-          if (includeLineDiffs && !project) return pullRequestChangesError(new PullRequestChangesError("PROJECT_REQUIRED", "project is required when includeLineDiffs is true."));
-          if (includeLineDiffs && (!paths || paths.length === 0)) return pullRequestChangesError(new PullRequestChangesError("PATHS_REQUIRED", "paths is required when includeLineDiffs is true."));
-          if ((paths?.length ?? 0) > FILE_DIFF_PATH_MAX)
-            return pullRequestChangesError(new PullRequestChangesError("PATH_LIMIT_EXCEEDED", `paths cannot contain more than ${FILE_DIFF_PATH_MAX} entries.`));
-          if (!includeLineDiffs && paths?.length) return pullRequestChangesError(new PullRequestChangesError("INVALID_ARGUMENT", "paths can only be used when includeLineDiffs is true."));
+          if (!Number.isInteger(top) || top < 1 || top > CHANGE_PAGE_SIZE_MAX) {
+            return pullRequestChangesError(new PullRequestChangesError("INVALID_ARGUMENT", `top must be an integer from 1 through ${CHANGE_PAGE_SIZE_MAX} for get_changes.`));
+          }
+          if (!Number.isInteger(skip) || skip < 0) {
+            return pullRequestChangesError(new PullRequestChangesError("INVALID_ARGUMENT", "skip must be a non-negative integer for get_changes."));
+          }
+          if (!REPOSITORY_ID_PATTERN.test(repositoryId) && !project) {
+            return pullRequestChangesError(new PullRequestChangesError("PROJECT_REQUIRED", "project is required when repositoryId is a name."));
+          }
 
           try {
-            const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, project);
-            const repositoryMatches = REPOSITORY_ID_PATTERN.test(repositoryId)
-              ? pullRequest.repository?.id?.toLowerCase() === repositoryId.toLowerCase()
-              : pullRequest.repository?.name === repositoryId;
-            if (!repositoryMatches) throw new PullRequestChangesError("REPOSITORY_MISMATCH", "The pull request resolved to a different repository.");
-            if (pullRequest.forkSource || pullRequest.hasMultipleMergeBases || pullRequest.supportsIterations === false) {
-              throw new PullRequestChangesError("AMBIGUOUS_REPOSITORY", "Fork pull requests and pull requests with multiple merge bases are not supported.");
-            }
-            const sourceRefName = requireBranchRef(pullRequest.sourceRefName, "pullRequest.sourceRefName");
-            const targetRefName = requireBranchRef(pullRequest.targetRefName, "pullRequest.targetRefName");
-
             const initialIterations = await gitApi.getPullRequestIterations(repositoryId, pullRequestId, project);
             const initialLatest = latestIteration(initialIterations);
             const selectedIterationId = iterationId ?? initialLatest.id;
@@ -707,60 +519,23 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
               throw new PullRequestChangesError("ITERATION_NOT_FOUND", `Iteration ${selectedIterationId} was not found on this pull request.`);
             }
             const selectedIteration = await gitApi.getPullRequestIteration(repositoryId, pullRequestId, selectedIterationId, project);
-            const commits = validateIterationBinding(selectedIteration);
-            const changes = await getAllIterationChanges(gitApi, repositoryId, pullRequestId, selectedIterationId, project, changePageSize, changeLimit);
-
-            const seenCurrentPaths = new Set<string>();
-            const responseChanges = changes.changeEntries.map((entry) => {
-              const changeType = entry.changeType;
-              if (typeof changeType !== "number" || !Number.isInteger(changeType) || changeType < 1 || (changeType & ~VersionControlChangeType.All) !== 0)
-                throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has an absent or malformed changeType.");
-              const path = normalizeGitPath(entry.item?.path);
-              const originalPath = normalizeGitPath(entry.originalPath);
-              if (!path && !originalPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no current or original path.");
-              const identityPath = path ?? originalPath;
-              if (!identityPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no identity path.");
-              if (seenCurrentPaths.has(identityPath)) throw new PullRequestChangesError("DUPLICATE_PATH", `Duplicate change path '${identityPath}'.`);
-              seenCurrentPaths.add(identityPath);
-              return {
-                provenance: { source: "getPullRequestIterationChanges", iterationId: selectedIterationId, changeTrackingId: entry.changeTrackingId },
-                changeType: { value: changeType, names: changeTypeNames(changeType) },
-                path: path ?? null,
-                originalPath: originalPath ?? null,
-              };
-            });
-
-            let fileDiffs;
-            if (includeLineDiffs) {
-              if (!project || !paths) throw new PullRequestChangesError("INVALID_ARGUMENT", "project and paths are required when includeLineDiffs is true.");
-              const requests = bindRequestedChanges(changes.changeEntries, paths);
-              const allFileDiffs: FileDiff[] = [];
-              for (let index = 0; index < requests.length; index += FILE_DIFF_BATCH_SIZE) {
-                const batch = requests.slice(index, index + FILE_DIFF_BATCH_SIZE);
-                const batchDiffs = await gitApi.getFileDiffs(
-                  {
-                    baseVersionCommit: commits.commonRefCommit,
-                    targetVersionCommit: commits.sourceRefCommit,
-                    fileDiffParams: batch.map(({ entry, path, originalPath }) => {
-                      const changeType = entry.changeType ?? VersionControlChangeType.None;
-                      return {
-                        path,
-                        ...((changeType & VersionControlChangeType.Add) === 0 ? { originalPath: originalPath ?? path } : {}),
-                      };
-                    }),
-                  },
-                  project,
-                  repositoryId
-                );
-                allFileDiffs.push(...batchDiffs);
-              }
-              fileDiffs = bindFileDiffs(requests, allFileDiffs);
+            const binding = validateIterationBinding(selectedIteration);
+            if (selectedIteration.id !== selectedIterationId) {
+              throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "Azure DevOps returned a different iteration than requested.");
             }
+            const changes = await gitApi.getPullRequestIterationChanges(repositoryId, pullRequestId, selectedIterationId, project, top, skip);
+            const changeEntries: unknown = changes.changeEntries ?? [];
+            const nextSkip = changes.nextSkip ?? 0;
+            const nextTop = changes.nextTop ?? 0;
+            const validatedPage = validateIterationChangesPage(changeEntries, nextSkip, nextTop, skip, top);
 
             const finalIterations = await gitApi.getPullRequestIterations(repositoryId, pullRequestId, project);
             const finalLatest = latestIteration(finalIterations);
             const finalSelected = await gitApi.getPullRequestIteration(repositoryId, pullRequestId, selectedIterationId, project);
-            if (finalLatest?.id !== initialLatest.id || JSON.stringify(iterationIdentity(finalSelected)) !== JSON.stringify(iterationIdentity(selectedIteration))) {
+            if (
+              JSON.stringify(iterationIdentity(finalLatest)) !== JSON.stringify(iterationIdentity(initialLatest)) ||
+              JSON.stringify(iterationIdentity(finalSelected)) !== JSON.stringify(iterationIdentity(selectedIteration))
+            ) {
               throw new PullRequestChangesError("ITERATION_MOVED", "The pull request iteration binding changed during the request.");
             }
 
@@ -770,28 +545,16 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
                   type: "text",
                   text: JSON.stringify(
                     {
-                      provenance: {
-                        source: "Azure DevOps Git API",
-                        repository: { id: pullRequest.repository?.id, name: pullRequest.repository?.name },
-                        pullRequestId,
-                        currentPullRequestRefs: { sourceRefName, targetRefName },
-                        iteration: {
-                          id: selectedIterationId,
-                          reason: { value: selectedIteration.reason, name: IterationReason[selectedIteration.reason ?? IterationReason.Unknown] ?? "Unknown" },
-                          commonRefCommit: { commitId: commits.commonRefCommit, role: "fileDiffBase" },
-                          sourceRefCommit: { commitId: commits.sourceRefCommit, role: "fileDiffTarget" },
-                          targetRefCommit: { commitId: commits.targetRefCommit, role: "targetTipAtIteration" },
-                          retarget: { oldTargetRefName: selectedIteration.oldTargetRefName ?? null, newTargetRefName: selectedIteration.newTargetRefName ?? null },
-                        },
-                        pagination: changes.pagination,
-                        truncation: {
-                          iterationCommits: selectedIteration.hasMoreCommits ?? false,
-                          changeEntries: false,
-                          fileDiffs: includeLineDiffs ? { responseLimitHit: false, apiProvidesTruncationIndicator: false } : null,
-                        },
-                      },
-                      changes: responseChanges,
-                      ...(fileDiffs ? { fileDiffs } : {}),
+                      iterationId: selectedIterationId,
+                      iterationReason: { value: selectedIteration.reason, name: IterationReason[selectedIteration.reason ?? IterationReason.Unknown] ?? "Unknown" },
+                      ...binding,
+                      oldTargetRefName: selectedIteration.oldTargetRefName ?? null,
+                      newTargetRefName: selectedIteration.newTargetRefName ?? null,
+                      commitsTruncated: selectedIteration.hasMoreCommits ?? false,
+                      hasMoreChanges: validatedPage.hasMoreChanges,
+                      nextSkip,
+                      nextTop,
+                      changes: validatedPage.changeEntries,
                     },
                     null,
                     2

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -45,6 +45,14 @@ const REPO_TOOLS = {
 const CHANGE_PAGE_SIZE_MAX = 1000;
 const COMMIT_ID_PATTERN = /^[0-9a-f]{40}$/i;
 const REPOSITORY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ITERATION_REASON_FLAGS = [
+  { value: IterationReason.ForcePush, name: "ForcePush" },
+  { value: IterationReason.Create, name: "Create" },
+  { value: IterationReason.Rebase, name: "Rebase" },
+  { value: IterationReason.Unknown, name: "Unknown" },
+  { value: IterationReason.Retarget, name: "Retarget" },
+  { value: IterationReason.ResolveConflicts, name: "ResolveConflicts" },
+] as const;
 
 class PullRequestChangesError extends Error {
   constructor(
@@ -77,10 +85,22 @@ function requireBranchRef(refName: string | undefined, label: string): string {
   return refName;
 }
 
+function formatIterationReason(reason: IterationReason | null | undefined) {
+  if (reason === null || reason === undefined) return { value: null, names: [], unrecognizedBits: 0 };
+  if (!Number.isSafeInteger(reason) || reason < 0) {
+    throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "The selected iteration reason is malformed.");
+  }
+  if (reason === IterationReason.Push) return { value: reason, names: ["Push"], unrecognizedBits: 0 };
+
+  const names = ITERATION_REASON_FLAGS.filter((flag) => Math.floor(reason / flag.value) % 2 === 1).map((flag) => flag.name);
+  const knownValue = ITERATION_REASON_FLAGS.filter((flag) => names.includes(flag.name)).reduce((value, flag) => value + flag.value, 0);
+  return { value: reason, names, unrecognizedBits: reason - knownValue };
+}
+
 function iterationIdentity(iteration: GitPullRequestIteration) {
   return {
     id: iteration.id,
-    reason: iteration.reason,
+    reason: iteration.reason ?? null,
     commonRefCommit: iteration.commonRefCommit?.commitId,
     sourceRefCommit: iteration.sourceRefCommit?.commitId,
     targetRefCommit: iteration.targetRefCommit?.commitId,
@@ -95,6 +115,7 @@ function validateIterationBinding(iteration: GitPullRequestIteration) {
   if (!Number.isInteger(iteration.id) || (iteration.id ?? 0) < 1) {
     throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "The selected iteration ID is absent or malformed.");
   }
+  const iterationReason = formatIterationReason(iteration.reason);
   const commonRefCommit = requireCommitId(iteration.commonRefCommit?.commitId, "commonRefCommit.commitId");
   const sourceRefCommit = requireCommitId(iteration.sourceRefCommit?.commitId, "sourceRefCommit.commitId");
   const targetRefCommit = requireCommitId(iteration.targetRefCommit?.commitId, "targetRefCommit.commitId");
@@ -108,6 +129,7 @@ function validateIterationBinding(iteration: GitPullRequestIteration) {
     requireBranchRef(iteration.newTargetRefName, "newTargetRefName");
   }
   return {
+    iterationReason,
     commonRefCommit: { commitId: commonRefCommit },
     sourceRefCommit: { commitId: sourceRefCommit },
     targetRefCommit: { commitId: targetRefCommit },
@@ -317,7 +339,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       action: z
         .enum(["get", "list", "list_by_commits", "get_changes"])
         .describe(
-          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs), get_changes (get one bounded page of changes with exact pull request iteration commit identity)."
+          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs), get_changes (get one bounded page of changes with exact pull request iteration commit identity and lossless reason flags)."
         ),
       repositoryId: z.string().optional().describe("The ID or name of the repository. Required for get. Optional for list. When using a name instead of a GUID, project must also be provided."),
       pullRequestId: z.coerce.number().min(1).optional().describe("The ID of the pull request. Required for get."),
@@ -546,7 +568,6 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
                   text: JSON.stringify(
                     {
                       iterationId: selectedIterationId,
-                      iterationReason: { value: selectedIteration.reason, name: IterationReason[selectedIteration.reason ?? IterationReason.Unknown] ?? "Unknown" },
                       ...binding,
                       oldTargetRefName: selectedIteration.oldTargetRefName ?? null,
                       newTargetRefName: selectedIteration.newTargetRefName ?? null,

--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -18,7 +18,14 @@ import {
   GitPullRequestMergeStrategy,
   GitPullRequest,
   GitPullRequestCommentThread,
+  GitPullRequestChange,
+  GitPullRequestIteration,
+  FileDiff,
+  IterationReason,
+  LineDiffBlock,
+  LineDiffBlockChangeType,
   Comment,
+  VersionControlChangeType,
   VersionControlRecursionType,
 } from "azure-devops-node-api/interfaces/GitInterfaces.js";
 import { z } from "zod";
@@ -39,6 +46,281 @@ const REPO_TOOLS = {
   repo_pull_request_thread_write: "repo_pull_request_thread_write",
   repo_create_branch: "repo_create_branch",
 };
+
+const CHANGE_PAGE_SIZE_MAX = 200;
+const CHANGE_COUNT_MAX = 1000;
+const FILE_DIFF_BATCH_SIZE = 10;
+const FILE_DIFF_PATH_MAX = 20;
+const FILE_DIFF_BLOCK_MAX = 5000;
+const FILE_DIFF_LINE_MAX = 200000;
+const FILE_DIFF_RESPONSE_BYTE_MAX = 2 * 1024 * 1024;
+const COMMIT_ID_PATTERN = /^[0-9a-f]{40}$/i;
+const REPOSITORY_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+class PullRequestChangesError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly details?: Record<string, unknown>
+  ) {
+    super(message);
+  }
+}
+
+function pullRequestChangesError(error: PullRequestChangesError) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ error: { code: error.code, message: error.message, ...error.details } }, null, 2) }],
+    isError: true,
+  };
+}
+
+function normalizeGitPath(path: string | undefined): string | undefined {
+  if (path === undefined) return undefined;
+  if (path.includes("\\") || path.includes("\0")) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
+  const normalized = path.replace(/^\/+/, "");
+  if (!normalized || normalized.split("/").includes("..")) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
+  return normalized;
+}
+
+function requireCommitId(commitId: string | undefined, label: string): string {
+  if (!commitId || !COMMIT_ID_PATTERN.test(commitId)) {
+    throw new PullRequestChangesError("INVALID_ITERATION_BINDING", `${label} is absent or malformed.`);
+  }
+  return commitId;
+}
+
+function requireBranchRef(refName: string | undefined, label: string): string {
+  if (!refName || !refName.startsWith("refs/heads/") || refName.length === "refs/heads/".length) {
+    throw new PullRequestChangesError("INVALID_ITERATION_BINDING", `${label} is absent or malformed.`);
+  }
+  return refName;
+}
+
+function iterationIdentity(iteration: GitPullRequestIteration) {
+  return {
+    id: iteration.id,
+    reason: iteration.reason,
+    commonRefCommit: iteration.commonRefCommit?.commitId,
+    sourceRefCommit: iteration.sourceRefCommit?.commitId,
+    targetRefCommit: iteration.targetRefCommit?.commitId,
+    oldTargetRefName: iteration.oldTargetRefName,
+    newTargetRefName: iteration.newTargetRefName,
+    hasMoreCommits: iteration.hasMoreCommits ?? false,
+    updatedDate: iteration.updatedDate,
+  };
+}
+
+function validateIterationBinding(iteration: GitPullRequestIteration) {
+  if (!Number.isInteger(iteration.id) || (iteration.id ?? 0) < 1) {
+    throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "The selected iteration ID is absent or malformed.");
+  }
+  const commonRefCommit = requireCommitId(iteration.commonRefCommit?.commitId, "commonRefCommit.commitId");
+  const sourceRefCommit = requireCommitId(iteration.sourceRefCommit?.commitId, "sourceRefCommit.commitId");
+  const targetRefCommit = requireCommitId(iteration.targetRefCommit?.commitId, "targetRefCommit.commitId");
+  const hasOldTarget = iteration.oldTargetRefName !== undefined;
+  const hasNewTarget = iteration.newTargetRefName !== undefined;
+  if (hasOldTarget !== hasNewTarget) {
+    throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "Retarget metadata must contain both oldTargetRefName and newTargetRefName.");
+  }
+  if (hasOldTarget && hasNewTarget) {
+    requireBranchRef(iteration.oldTargetRefName, "oldTargetRefName");
+    requireBranchRef(iteration.newTargetRefName, "newTargetRefName");
+  }
+  return { commonRefCommit, sourceRefCommit, targetRefCommit };
+}
+
+function latestIteration(iterations: GitPullRequestIteration[]) {
+  const iterationIds = new Set<number>();
+  let latest: GitPullRequestIteration | undefined;
+  let latestId = 0;
+  for (const iteration of iterations) {
+    const iterationId = iteration.id;
+    if (typeof iterationId !== "number" || !Number.isInteger(iterationId) || iterationId < 1) {
+      throw new PullRequestChangesError("INVALID_ITERATION_BINDING", "The pull request contains an absent or malformed iteration ID.");
+    }
+    if (iterationIds.has(iterationId)) throw new PullRequestChangesError("INVALID_ITERATION_BINDING", `The pull request contains duplicate iteration ID ${iterationId}.`);
+    iterationIds.add(iterationId);
+    if (!latest || iterationId > latestId) {
+      latest = iteration;
+      latestId = iterationId;
+    }
+  }
+  if (!latest) throw new PullRequestChangesError("NO_ITERATIONS", "No valid iterations were found for this pull request.");
+  return { ...latest, id: latestId };
+}
+
+async function getAllIterationChanges(
+  gitApi: Awaited<ReturnType<WebApi["getGitApi"]>>,
+  repositoryId: string,
+  pullRequestId: number,
+  iterationId: number,
+  project: string | undefined,
+  pageSize: number,
+  changeLimit: number
+) {
+  const changeEntries: GitPullRequestChange[] = [];
+  let nextSkip = 0;
+  let nextTop = Math.min(pageSize, changeLimit);
+  let pages = 0;
+
+  while (true) {
+    const page = await gitApi.getPullRequestIterationChanges(repositoryId, pullRequestId, iterationId, project, nextTop, nextSkip);
+    const entries = page.changeEntries ?? [];
+    pages += 1;
+    if (changeEntries.length + entries.length > changeLimit) {
+      throw new PullRequestChangesError("CHANGES_TRUNCATED", `The iteration contains more than the configured ${changeLimit} change-entry limit.`, {
+        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip, nextTop, changeLimit },
+      });
+    }
+    changeEntries.push(...entries);
+
+    const serverNextSkip = page.nextSkip ?? 0;
+    const serverNextTop = page.nextTop ?? 0;
+    if (serverNextSkip === 0 && serverNextTop === 0) {
+      return { changeEntries, pagination: { complete: true, truncated: false, pages, changeCount: changeEntries.length, nextSkip: 0, nextTop: 0, changeLimit } };
+    }
+    if (changeEntries.length >= changeLimit) {
+      throw new PullRequestChangesError("CHANGES_TRUNCATED", `The iteration contains more than the configured ${changeLimit} change-entry limit.`, {
+        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip: serverNextSkip, nextTop: serverNextTop, changeLimit },
+      });
+    }
+    if (!Number.isInteger(serverNextSkip) || !Number.isInteger(serverNextTop) || serverNextSkip !== nextSkip + entries.length || serverNextTop < 1 || entries.length === 0) {
+      throw new PullRequestChangesError("INCOMPLETE_PAGINATION", "Azure DevOps returned incomplete or malformed iteration-change pagination.", {
+        pagination: { complete: false, truncated: true, pages, changeCount: changeEntries.length, nextSkip: serverNextSkip, nextTop: serverNextTop, changeLimit },
+      });
+    }
+    nextSkip = serverNextSkip;
+    nextTop = Math.min(serverNextTop, pageSize, changeLimit - changeEntries.length);
+  }
+}
+
+function changeTypeNames(changeType: number): string[] {
+  return Object.entries(VersionControlChangeType)
+    .filter(([name, value]) => typeof value === "number" && value !== 0 && (changeType & value) === value && !/^\d+$/.test(name))
+    .map(([name]) => name);
+}
+
+function lineSpan(start: number | undefined, count: number | undefined) {
+  if (count === 0) {
+    if (start !== undefined && start !== 0) throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An empty side of a line diff block has a nonzero start line.");
+    return null;
+  }
+  if (typeof start !== "number" || typeof count !== "number" || !Number.isInteger(start) || !Number.isInteger(count) || start < 1 || count < 1) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned a malformed line diff block.");
+  }
+  return { startLine: start, endLine: start + count - 1, lineCount: count };
+}
+
+function validateLineDiffBlock(block: LineDiffBlock) {
+  const changeType = block.changeType;
+  const originalCount = block.originalLinesCount;
+  const modifiedCount = block.modifiedLinesCount;
+  if (changeType === undefined || ![LineDiffBlockChangeType.None, LineDiffBlockChangeType.Add, LineDiffBlockChangeType.Delete, LineDiffBlockChangeType.Edit].includes(changeType)) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned an unknown line diff block change type.");
+  }
+  if (!Number.isInteger(originalCount) || !Number.isInteger(modifiedCount) || (originalCount ?? -1) < 0 || (modifiedCount ?? -1) < 0) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "Azure DevOps returned a malformed line diff block.");
+  }
+  if (changeType === LineDiffBlockChangeType.Add && (originalCount !== 0 || modifiedCount === 0)) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An add block has invalid base/source orientation.");
+  }
+  if (changeType === LineDiffBlockChangeType.Delete && (originalCount === 0 || modifiedCount !== 0)) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "A delete block has invalid base/source orientation.");
+  }
+  if (changeType === LineDiffBlockChangeType.Edit && (originalCount === 0 || modifiedCount === 0)) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "An edit block has invalid base/source orientation.");
+  }
+  if (changeType === LineDiffBlockChangeType.None && originalCount !== modifiedCount) {
+    throw new PullRequestChangesError("MALFORMED_FILE_DIFF", "A context block has inconsistent base/source line counts.");
+  }
+  return {
+    ...block,
+    changeTypeName: LineDiffBlockChangeType[changeType],
+    originalSpan: lineSpan(block.originalLineNumberStart, originalCount),
+    modifiedSpan: lineSpan(block.modifiedLineNumberStart, modifiedCount),
+  };
+}
+
+function bindRequestedChanges(changeEntries: GitPullRequestChange[], requestedPaths: string[]) {
+  const aliases = new Map<string, Set<GitPullRequestChange>>();
+  const requestedEntries = new Set<GitPullRequestChange>();
+  const normalizedRequested = requestedPaths.map((path) => {
+    const normalizedPath = normalizeGitPath(path);
+    if (!normalizedPath) throw new PullRequestChangesError("INVALID_PATH", `Invalid Git path '${path}'.`);
+    return normalizedPath;
+  });
+  if (new Set(normalizedRequested).size !== normalizedRequested.length) {
+    throw new PullRequestChangesError("DUPLICATE_PATH", "Requested paths contain duplicates after normalization.");
+  }
+
+  for (const entry of changeEntries) {
+    const currentPath = normalizeGitPath(entry.item?.path);
+    const originalPath = normalizeGitPath(entry.originalPath);
+    if (!currentPath && !originalPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no current or original path.");
+    for (const alias of new Set([currentPath, originalPath].filter((path): path is string => path !== undefined))) {
+      const matchingEntries = aliases.get(alias) ?? new Set<GitPullRequestChange>();
+      matchingEntries.add(entry);
+      aliases.set(alias, matchingEntries);
+    }
+  }
+
+  return normalizedRequested.map((requestedPath) => {
+    const matchingEntries = aliases.get(requestedPath);
+    if (!matchingEntries) throw new PullRequestChangesError("PATH_NOT_IN_ITERATION", `Requested path '${requestedPath}' is not present in the selected iteration changes.`);
+    if (matchingEntries.size !== 1) throw new PullRequestChangesError("CONFLICTING_PATH", `Multiple change entries resolve to requested path '${requestedPath}'.`);
+    const [entry] = matchingEntries;
+    if (requestedEntries.has(entry)) throw new PullRequestChangesError("DUPLICATE_PATH", `Multiple requested paths resolve to the same change entry at '${requestedPath}'.`);
+    requestedEntries.add(entry);
+    if (entry.item?.isFolder || entry.item?.contentMetadata?.isBinary) {
+      throw new PullRequestChangesError("UNSUPPORTED_FILE", `Requested path '${requestedPath}' is a folder or binary file.`);
+    }
+    const path = normalizeGitPath(entry.item?.path) ?? normalizeGitPath(entry.originalPath);
+    if (!path) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A requested change entry has no current or original path.");
+    const originalPath = normalizeGitPath(entry.originalPath);
+    return { requestedPath, entry, path, originalPath };
+  });
+}
+
+function bindFileDiffs(requests: ReturnType<typeof bindRequestedChanges>, fileDiffs: FileDiff[]) {
+  if (Buffer.byteLength(JSON.stringify(fileDiffs), "utf8") > FILE_DIFF_RESPONSE_BYTE_MAX) {
+    throw new PullRequestChangesError("FILE_DIFF_TOO_LARGE", `FileDiffs response exceeds the ${FILE_DIFF_RESPONSE_BYTE_MAX}-byte safety limit.`);
+  }
+  let blockCount = 0;
+  let lineCount = 0;
+  const unmatched = [...fileDiffs];
+
+  const results = requests.map(({ requestedPath, entry, path, originalPath }) => {
+    const matchIndex = unmatched.findIndex((diff) => {
+      const diffPath = normalizeGitPath(diff.path);
+      const diffOriginalPath = normalizeGitPath(diff.originalPath);
+      return diffPath === path || (originalPath !== undefined && diffOriginalPath === originalPath) || diffPath === requestedPath || diffOriginalPath === requestedPath;
+    });
+    if (matchIndex < 0) throw new PullRequestChangesError("MISSING_FILE_DIFF", `Azure DevOps did not return a FileDiff for '${requestedPath}'.`);
+    const diff = unmatched.splice(matchIndex, 1)[0];
+    const blocks = diff.lineDiffBlocks ?? [];
+    const changeType = entry.changeType ?? VersionControlChangeType.None;
+    const renameOnly = (changeType & VersionControlChangeType.Rename) !== 0 && (changeType & (VersionControlChangeType.Add | VersionControlChangeType.Edit | VersionControlChangeType.Delete)) === 0;
+    if (blocks.length === 0 && !renameOnly) throw new PullRequestChangesError("UNSUPPORTED_FILE_DIFF", `Azure DevOps returned no line diff blocks for '${requestedPath}'.`);
+    blockCount += blocks.length;
+    lineCount += blocks.reduce((total, block) => total + (block.originalLinesCount ?? 0) + (block.modifiedLinesCount ?? 0), 0);
+    if (blockCount > FILE_DIFF_BLOCK_MAX || lineCount > FILE_DIFF_LINE_MAX) {
+      throw new PullRequestChangesError("FILE_DIFF_TOO_LARGE", "FileDiffs response exceeds the line or block safety limit.");
+    }
+    return {
+      provenance: {
+        source: "getFileDiffs",
+        requestedPath,
+        iterationChangeTrackingId: entry.changeTrackingId,
+        orientation: { original: "commonRefCommit", modified: "sourceRefCommit" },
+      },
+      path: normalizeGitPath(diff.path) ?? path,
+      originalPath: normalizeGitPath(diff.originalPath) ?? originalPath ?? null,
+      lineDiffBlocks: blocks.map(validateLineDiffBlock),
+    };
+  });
+  if (unmatched.length > 0) throw new PullRequestChangesError("UNEXPECTED_FILE_DIFF", "Azure DevOps returned FileDiff results that were not requested.");
+  return results;
+}
 
 function branchesFilterOutIrrelevantProperties(branches: GitRef[], top: number) {
   return branches
@@ -199,12 +481,12 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
   // --- repo_pull_request -----------------------------------------------------
   server.tool(
     REPO_TOOLS.repo_pull_request,
-    "Retrieve pull request data. Use the action parameter to specify the operation.",
+    "Retrieve pull request data and authoritative, iteration-bound change spans. Use the action parameter to specify the operation.",
     {
       action: z
-        .enum(["get", "list", "list_by_commits"])
+        .enum(["get", "list", "list_by_commits", "get_changes"])
         .describe(
-          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs)."
+          "The action to perform. Options: get (get a pull request by ID), list (list pull requests in a repository or project), list_by_commits (find pull requests that contain specific commit IDs), get_changes (get bounded change entries and optional authoritative line diffs for one immutable pull request iteration)."
         ),
       repositoryId: z.string().optional().describe("The ID or name of the repository. Required for get. Optional for list. When using a name instead of a GUID, project must also be provided."),
       pullRequestId: z.coerce.number().min(1).optional().describe("The ID of the pull request. Required for get."),
@@ -231,6 +513,18 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
         .optional()
         .default(GitPullRequestQueryType[GitPullRequestQueryType.LastMergeCommit])
         .describe("Type of commit query. Used for list_by_commits."),
+      iterationId: z.coerce.number().int().min(1).optional().describe("Exact pull request iteration to select. Used for get_changes; defaults to the latest iteration."),
+      includeLineDiffs: z.boolean().optional().default(false).describe("Call FileDiffs for explicitly requested paths. Used for get_changes; defaults to false."),
+      paths: z.array(z.string().min(1)).max(FILE_DIFF_PATH_MAX).optional().describe(`Paths to retrieve line diffs for. Required when includeLineDiffs is true; maximum ${FILE_DIFF_PATH_MAX}.`),
+      changePageSize: z.coerce.number().int().min(1).max(CHANGE_PAGE_SIZE_MAX).optional().default(100).describe(`Iteration-change page size. Used for get_changes; maximum ${CHANGE_PAGE_SIZE_MAX}.`),
+      changeLimit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(CHANGE_COUNT_MAX)
+        .optional()
+        .default(500)
+        .describe(`Maximum complete iteration change count. Used for get_changes; maximum ${CHANGE_COUNT_MAX}; exceeding it fails closed.`),
     },
     async ({
       action,
@@ -252,6 +546,11 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       repository,
       commits,
       queryType,
+      iterationId,
+      includeLineDiffs,
+      paths,
+      changePageSize = 100,
+      changeLimit = 500,
     }) => {
       try {
         const connection = await connectionProvider();
@@ -378,6 +677,132 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
 
           const queryResult = await gitApi.getPullRequestQuery(query, repository, project);
           return { content: [{ type: "text", text: JSON.stringify(queryResult, null, 2) }] };
+        }
+
+        if (action === "get_changes") {
+          if (!repositoryId) return { content: [{ type: "text", text: "repositoryId is required for get_changes" }], isError: true };
+          if (!pullRequestId) return { content: [{ type: "text", text: "pullRequestId is required for get_changes" }], isError: true };
+          if (includeLineDiffs && !project) return pullRequestChangesError(new PullRequestChangesError("PROJECT_REQUIRED", "project is required when includeLineDiffs is true."));
+          if (includeLineDiffs && (!paths || paths.length === 0)) return pullRequestChangesError(new PullRequestChangesError("PATHS_REQUIRED", "paths is required when includeLineDiffs is true."));
+          if ((paths?.length ?? 0) > FILE_DIFF_PATH_MAX)
+            return pullRequestChangesError(new PullRequestChangesError("PATH_LIMIT_EXCEEDED", `paths cannot contain more than ${FILE_DIFF_PATH_MAX} entries.`));
+          if (!includeLineDiffs && paths?.length) return pullRequestChangesError(new PullRequestChangesError("INVALID_ARGUMENT", "paths can only be used when includeLineDiffs is true."));
+
+          try {
+            const pullRequest = await gitApi.getPullRequest(repositoryId, pullRequestId, project);
+            const repositoryMatches = REPOSITORY_ID_PATTERN.test(repositoryId)
+              ? pullRequest.repository?.id?.toLowerCase() === repositoryId.toLowerCase()
+              : pullRequest.repository?.name === repositoryId;
+            if (!repositoryMatches) throw new PullRequestChangesError("REPOSITORY_MISMATCH", "The pull request resolved to a different repository.");
+            if (pullRequest.forkSource || pullRequest.hasMultipleMergeBases || pullRequest.supportsIterations === false) {
+              throw new PullRequestChangesError("AMBIGUOUS_REPOSITORY", "Fork pull requests and pull requests with multiple merge bases are not supported.");
+            }
+            const sourceRefName = requireBranchRef(pullRequest.sourceRefName, "pullRequest.sourceRefName");
+            const targetRefName = requireBranchRef(pullRequest.targetRefName, "pullRequest.targetRefName");
+
+            const initialIterations = await gitApi.getPullRequestIterations(repositoryId, pullRequestId, project);
+            const initialLatest = latestIteration(initialIterations);
+            const selectedIterationId = iterationId ?? initialLatest.id;
+            if (!initialIterations.some((iteration) => iteration.id === selectedIterationId)) {
+              throw new PullRequestChangesError("ITERATION_NOT_FOUND", `Iteration ${selectedIterationId} was not found on this pull request.`);
+            }
+            const selectedIteration = await gitApi.getPullRequestIteration(repositoryId, pullRequestId, selectedIterationId, project);
+            const commits = validateIterationBinding(selectedIteration);
+            const changes = await getAllIterationChanges(gitApi, repositoryId, pullRequestId, selectedIterationId, project, changePageSize, changeLimit);
+
+            const seenCurrentPaths = new Set<string>();
+            const responseChanges = changes.changeEntries.map((entry) => {
+              const changeType = entry.changeType;
+              if (typeof changeType !== "number" || !Number.isInteger(changeType) || changeType < 1 || (changeType & ~VersionControlChangeType.All) !== 0)
+                throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has an absent or malformed changeType.");
+              const path = normalizeGitPath(entry.item?.path);
+              const originalPath = normalizeGitPath(entry.originalPath);
+              if (!path && !originalPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no current or original path.");
+              const identityPath = path ?? originalPath;
+              if (!identityPath) throw new PullRequestChangesError("MALFORMED_CHANGE_ENTRY", "A change entry has no identity path.");
+              if (seenCurrentPaths.has(identityPath)) throw new PullRequestChangesError("DUPLICATE_PATH", `Duplicate change path '${identityPath}'.`);
+              seenCurrentPaths.add(identityPath);
+              return {
+                provenance: { source: "getPullRequestIterationChanges", iterationId: selectedIterationId, changeTrackingId: entry.changeTrackingId },
+                changeType: { value: changeType, names: changeTypeNames(changeType) },
+                path: path ?? null,
+                originalPath: originalPath ?? null,
+              };
+            });
+
+            let fileDiffs;
+            if (includeLineDiffs) {
+              if (!project || !paths) throw new PullRequestChangesError("INVALID_ARGUMENT", "project and paths are required when includeLineDiffs is true.");
+              const requests = bindRequestedChanges(changes.changeEntries, paths);
+              const allFileDiffs: FileDiff[] = [];
+              for (let index = 0; index < requests.length; index += FILE_DIFF_BATCH_SIZE) {
+                const batch = requests.slice(index, index + FILE_DIFF_BATCH_SIZE);
+                const batchDiffs = await gitApi.getFileDiffs(
+                  {
+                    baseVersionCommit: commits.commonRefCommit,
+                    targetVersionCommit: commits.sourceRefCommit,
+                    fileDiffParams: batch.map(({ entry, path, originalPath }) => {
+                      const changeType = entry.changeType ?? VersionControlChangeType.None;
+                      return {
+                        path,
+                        ...((changeType & VersionControlChangeType.Add) === 0 ? { originalPath: originalPath ?? path } : {}),
+                      };
+                    }),
+                  },
+                  project,
+                  repositoryId
+                );
+                allFileDiffs.push(...batchDiffs);
+              }
+              fileDiffs = bindFileDiffs(requests, allFileDiffs);
+            }
+
+            const finalIterations = await gitApi.getPullRequestIterations(repositoryId, pullRequestId, project);
+            const finalLatest = latestIteration(finalIterations);
+            const finalSelected = await gitApi.getPullRequestIteration(repositoryId, pullRequestId, selectedIterationId, project);
+            if (finalLatest?.id !== initialLatest.id || JSON.stringify(iterationIdentity(finalSelected)) !== JSON.stringify(iterationIdentity(selectedIteration))) {
+              throw new PullRequestChangesError("ITERATION_MOVED", "The pull request iteration binding changed during the request.");
+            }
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      provenance: {
+                        source: "Azure DevOps Git API",
+                        repository: { id: pullRequest.repository?.id, name: pullRequest.repository?.name },
+                        pullRequestId,
+                        currentPullRequestRefs: { sourceRefName, targetRefName },
+                        iteration: {
+                          id: selectedIterationId,
+                          reason: { value: selectedIteration.reason, name: IterationReason[selectedIteration.reason ?? IterationReason.Unknown] ?? "Unknown" },
+                          commonRefCommit: { commitId: commits.commonRefCommit, role: "fileDiffBase" },
+                          sourceRefCommit: { commitId: commits.sourceRefCommit, role: "fileDiffTarget" },
+                          targetRefCommit: { commitId: commits.targetRefCommit, role: "targetTipAtIteration" },
+                          retarget: { oldTargetRefName: selectedIteration.oldTargetRefName ?? null, newTargetRefName: selectedIteration.newTargetRefName ?? null },
+                        },
+                        pagination: changes.pagination,
+                        truncation: {
+                          iterationCommits: selectedIteration.hasMoreCommits ?? false,
+                          changeEntries: false,
+                          fileDiffs: includeLineDiffs ? { responseLimitHit: false, apiProvidesTruncationIndicator: false } : null,
+                        },
+                      },
+                      changes: responseChanges,
+                      ...(fileDiffs ? { fileDiffs } : {}),
+                    },
+                    null,
+                    2
+                  ),
+                },
+              ],
+            };
+          } catch (error) {
+            if (error instanceof PullRequestChangesError) return pullRequestChangesError(error);
+            throw error;
+          }
         }
 
         return { content: [{ type: "text", text: `Unknown action: ${action}` }], isError: true };

--- a/test/src/tools/repositories-get-changes.test.ts
+++ b/test/src/tools/repositories-get-changes.test.ts
@@ -90,7 +90,7 @@ describe("repo_pull_request get_changes", () => {
     expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenCalledWith(REPOSITORY_ID, 42, 7, "project", 100, 0);
     expect(parsed(result)).toEqual({
       iterationId: 7,
-      iterationReason: { value: IterationReason.Push, name: "Push" },
+      iterationReason: { value: IterationReason.Push, names: ["Push"], unrecognizedBits: 0 },
       commonRefCommit: { commitId: COMMON_COMMIT },
       sourceRefCommit: { commitId: SOURCE_COMMIT },
       targetRefCommit: { commitId: TARGET_COMMIT },
@@ -150,11 +150,46 @@ describe("repo_pull_request get_changes", () => {
     );
 
     expect(parsed(await invoke({ iterationId: 7 }))).toMatchObject({
-      iterationReason: { value: IterationReason.Retarget, name: "Retarget" },
+      iterationReason: { value: IterationReason.Retarget, names: ["Retarget"], unrecognizedBits: 0 },
       oldTargetRefName: "refs/heads/main",
       newTargetRefName: "refs/heads/release",
       commitsTruncated: true,
     });
+  });
+
+  it.each([
+    [IterationReason.Push, ["Push"], 0],
+    [IterationReason.ForcePush, ["ForcePush"], 0],
+    [IterationReason.Create, ["Create"], 0],
+    [IterationReason.Rebase, ["Rebase"], 0],
+    [IterationReason.Unknown, ["Unknown"], 0],
+    [IterationReason.Retarget, ["Retarget"], 0],
+    [IterationReason.ResolveConflicts, ["ResolveConflicts"], 0],
+    [IterationReason.ForcePush | IterationReason.Rebase, ["ForcePush", "Rebase"], 0],
+    [IterationReason.Retarget | IterationReason.ResolveConflicts, ["Retarget", "ResolveConflicts"], 0],
+    [IterationReason.ResolveConflicts | IterationReason.Unknown | IterationReason.Create | IterationReason.ForcePush, ["ForcePush", "Create", "Unknown", "ResolveConflicts"], 0],
+    [64, [], 64],
+    [IterationReason.Unknown | 64, ["Unknown"], 64],
+  ])("returns iteration reason %s as ordered lossless flags", async (reason, names, unrecognizedBits) => {
+    prime(iteration({ reason }));
+
+    expect(parsed(await invoke()).iterationReason).toEqual({ value: reason, names, unrecognizedBits });
+  });
+
+  it.each([undefined, null])("returns a stable nullable shape for absent iteration reason %s", async (reason) => {
+    prime(iteration({ reason }));
+
+    expect(parsed(await invoke()).iterationReason).toEqual({ value: null, names: [], unrecognizedBits: 0 });
+  });
+
+  it.each([-1, 1.5])("fails closed on malformed iteration reason %s", async (reason) => {
+    prime(iteration({ reason }));
+
+    const result = await invoke();
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INVALID_ITERATION_BINDING");
+    expect(mockGitApi.getPullRequestIterationChanges).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/test/src/tools/repositories-get-changes.test.ts
+++ b/test/src/tools/repositories-get-changes.test.ts
@@ -3,7 +3,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebApi } from "azure-devops-node-api";
-import { IterationReason, LineDiffBlockChangeType, VersionControlChangeType } from "azure-devops-node-api/interfaces/GitInterfaces.js";
+import { IterationReason, VersionControlChangeType } from "azure-devops-node-api/interfaces/GitInterfaces.js";
 import { configureRepoTools, REPO_TOOLS } from "../../../src/tools/repositories";
 
 jest.mock("../../../src/tools/auth", () => ({
@@ -13,7 +13,7 @@ jest.mock("../../../src/tools/auth", () => ({
 jest.mock("../../../src/index", () => ({ orgName: "test-org" }));
 
 const REPOSITORY_ID = "12345678-1234-1234-1234-123456789012";
-const BASE_COMMIT = "1".repeat(40);
+const COMMON_COMMIT = "1".repeat(40);
 const SOURCE_COMMIT = "2".repeat(40);
 const TARGET_COMMIT = "3".repeat(40);
 
@@ -21,44 +21,36 @@ interface ToolResult {
   content: { type: string; text: string }[];
   isError?: boolean;
 }
+
 type ToolHandler = (params: Record<string, unknown>) => Promise<ToolResult>;
-interface ApiMock {
-  getPullRequest: jest.Mock;
-  getPullRequestIterations: jest.Mock;
-  getPullRequestIteration: jest.Mock;
-  getPullRequestIterationChanges: jest.Mock;
-  getFileDiffs: jest.Mock;
-}
 
 describe("repo_pull_request get_changes", () => {
   let server: McpServer;
-  let mockGitApi: ApiMock;
   let handler: ToolHandler;
-  let readSchema: Record<string, { safeParse: (value: unknown) => { success: boolean } }>;
-  let readDescription: string;
+  let mockGitApi: {
+    getPullRequestIterations: jest.Mock;
+    getPullRequestIteration: jest.Mock;
+    getPullRequestIterationChanges: jest.Mock;
+  };
 
   const iteration = (overrides: Record<string, unknown> = {}) => ({
     id: 7,
     reason: IterationReason.Push,
-    commonRefCommit: { commitId: BASE_COMMIT },
+    commonRefCommit: { commitId: COMMON_COMMIT },
     sourceRefCommit: { commitId: SOURCE_COMMIT },
     targetRefCommit: { commitId: TARGET_COMMIT },
     hasMoreCommits: false,
     ...overrides,
   });
 
-  const prime = (changeEntries: Record<string, unknown>[] = [], selectedIteration = iteration()) => {
-    mockGitApi.getPullRequest.mockResolvedValue({
-      pullRequestId: 42,
-      repository: { id: REPOSITORY_ID, name: "repository" },
-      sourceRefName: "refs/heads/feature",
-      targetRefName: "refs/heads/main",
-      supportsIterations: true,
-    });
+  const prime = (selectedIteration = iteration()) => {
     mockGitApi.getPullRequestIterations.mockResolvedValue([selectedIteration]);
     mockGitApi.getPullRequestIteration.mockResolvedValue(selectedIteration);
-    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({ changeEntries, nextSkip: 0, nextTop: 0 });
-    mockGitApi.getFileDiffs.mockResolvedValue([]);
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
+      changeEntries: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/src/file.ts" } }],
+      nextSkip: 1,
+      nextTop: 100,
+    });
   };
 
   const invoke = (params: Record<string, unknown> = {}) =>
@@ -67,9 +59,8 @@ describe("repo_pull_request get_changes", () => {
       repositoryId: REPOSITORY_ID,
       pullRequestId: 42,
       project: "project",
-      changePageSize: 100,
-      changeLimit: 500,
-      includeLineDiffs: false,
+      top: 100,
+      skip: 0,
       ...params,
     });
 
@@ -78,11 +69,9 @@ describe("repo_pull_request get_changes", () => {
   beforeEach(() => {
     server = { tool: jest.fn() } as unknown as McpServer;
     mockGitApi = {
-      getPullRequest: jest.fn(),
       getPullRequestIterations: jest.fn(),
       getPullRequestIteration: jest.fn(),
       getPullRequestIterationChanges: jest.fn(),
-      getFileDiffs: jest.fn(),
     };
     const connectionProvider = jest.fn().mockResolvedValue({
       getGitApi: jest.fn().mockResolvedValue(mockGitApi),
@@ -90,168 +79,68 @@ describe("repo_pull_request get_changes", () => {
     configureRepoTools(server, jest.fn(), connectionProvider as unknown as () => Promise<WebApi>, () => "Jest");
     const readCall = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request);
     if (!readCall) throw new Error("repo_pull_request tool not registered");
-    readDescription = readCall[1] as string;
-    readSchema = readCall[2] as typeof readSchema;
     handler = readCall[3] as ToolHandler;
     prime();
   });
 
-  it("returns edit, add, delete, and rename spans while excluding target-tip-only changes", async () => {
-    const entries = [
-      { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/edit.ts" } },
-      { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/added.ts" } },
-      { changeTrackingId: 3, changeType: VersionControlChangeType.Delete, item: {}, originalPath: "/deleted.ts" },
-      { changeTrackingId: 4, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" },
-    ];
-    prime(entries);
-    mockGitApi.getFileDiffs.mockResolvedValue([
-      {
-        path: "edit.ts",
-        originalPath: "edit.ts",
-        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Edit, originalLineNumberStart: 4, originalLinesCount: 1, modifiedLineNumberStart: 4, modifiedLinesCount: 2 }],
-      },
-      {
-        path: "added.ts",
-        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Add, originalLineNumberStart: 0, originalLinesCount: 0, modifiedLineNumberStart: 1, modifiedLinesCount: 3 }],
-      },
-      {
-        path: "deleted.ts",
-        originalPath: "deleted.ts",
-        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 8, originalLinesCount: 2, modifiedLineNumberStart: 0, modifiedLinesCount: 0 }],
-      },
-      { path: "new.ts", originalPath: "old.ts", lineDiffBlocks: [] },
-    ]);
-
-    const result = await invoke({ includeLineDiffs: true, paths: ["/edit.ts", "added.ts", "deleted.ts", "old.ts"] });
-
-    expect(result.isError).toBeUndefined();
-    expect(mockGitApi.getFileDiffs).toHaveBeenCalledWith(
-      {
-        baseVersionCommit: BASE_COMMIT,
-        targetVersionCommit: SOURCE_COMMIT,
-        fileDiffParams: [{ path: "edit.ts", originalPath: "edit.ts" }, { path: "added.ts" }, { path: "deleted.ts", originalPath: "deleted.ts" }, { path: "new.ts", originalPath: "old.ts" }],
-      },
-      "project",
-      REPOSITORY_ID
-    );
-    const body = parsed(result);
-    expect(body.provenance.iteration.targetRefCommit).toEqual({ commitId: TARGET_COMMIT, role: "targetTipAtIteration" });
-    expect(body.fileDiffs[0].provenance.orientation).toEqual({ original: "commonRefCommit", modified: "sourceRefCommit" });
-    expect(body.fileDiffs[0].lineDiffBlocks[0].originalSpan).toEqual({ startLine: 4, endLine: 4, lineCount: 1 });
-    expect(body.fileDiffs[0].lineDiffBlocks[0].modifiedSpan).toEqual({ startLine: 4, endLine: 5, lineCount: 2 });
-    expect(body.fileDiffs[2].lineDiffBlocks[0].modifiedSpan).toBeNull();
-    expect(JSON.stringify(mockGitApi.getFileDiffs.mock.calls)).not.toContain(TARGET_COMMIT);
-  });
-
-  it("preserves context and delete-only orientation", async () => {
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
-    mockGitApi.getFileDiffs.mockResolvedValue([
-      {
-        path: "file.ts",
-        originalPath: "file.ts",
-        lineDiffBlocks: [
-          { changeType: LineDiffBlockChangeType.None, originalLineNumberStart: 1, originalLinesCount: 3, modifiedLineNumberStart: 1, modifiedLinesCount: 3 },
-          { changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 4, originalLinesCount: 2, modifiedLineNumberStart: 0, modifiedLinesCount: 0 },
-        ],
-      },
-    ]);
-
-    const body = parsed(await invoke({ includeLineDiffs: true, paths: ["file.ts"] }));
-    expect(body.fileDiffs[0].lineDiffBlocks[0].changeTypeName).toBe("None");
-    expect(body.fileDiffs[0].lineDiffBlocks[1].originalSpan).toEqual({ startLine: 4, endLine: 5, lineCount: 2 });
-    expect(body.fileDiffs[0].lineDiffBlocks[1].modifiedSpan).toBeNull();
-  });
-
-  it("does not call FileDiffs in metadata-only mode", async () => {
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
-
+  it("returns the remote page shape with exact iteration commit identity", async () => {
     const result = await invoke();
 
-    expect(mockGitApi.getFileDiffs).not.toHaveBeenCalled();
-    expect(parsed(result)).not.toHaveProperty("fileDiffs");
-    expect(parsed(result).provenance.pagination).toMatchObject({ complete: true, truncated: false, changeCount: 1 });
-    expect(mockGitApi.getPullRequestIterations).toHaveBeenCalledTimes(2);
-    expect(mockGitApi.getPullRequestIteration).toHaveBeenCalledTimes(2);
-  });
-
-  it("paginates change entries with server nextSkip and nextTop", async () => {
-    const first = { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } };
-    const second = { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/two.ts" } };
-    prime();
-    mockGitApi.getPullRequestIterationChanges
-      .mockReset()
-      .mockResolvedValueOnce({ changeEntries: [first], nextSkip: 1, nextTop: 25 })
-      .mockResolvedValueOnce({ changeEntries: [second], nextSkip: 0, nextTop: 0 });
-
-    const body = parsed(await invoke({ changePageSize: 10 }));
-
-    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenNthCalledWith(1, REPOSITORY_ID, 42, 7, "project", 10, 0);
-    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenNthCalledWith(2, REPOSITORY_ID, 42, 7, "project", 10, 1);
-    expect(body.provenance.pagination).toMatchObject({ complete: true, truncated: false, pages: 2, changeCount: 2 });
-  });
-
-  it("fails closed when pagination skips unseen entries", async () => {
-    prime();
-    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
-      changeEntries: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } }],
-      nextSkip: 2,
-      nextTop: 10,
+    expect(result.isError).toBeUndefined();
+    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenCalledWith(REPOSITORY_ID, 42, 7, "project", 100, 0);
+    expect(parsed(result)).toEqual({
+      iterationId: 7,
+      iterationReason: { value: IterationReason.Push, name: "Push" },
+      commonRefCommit: { commitId: COMMON_COMMIT },
+      sourceRefCommit: { commitId: SOURCE_COMMIT },
+      targetRefCommit: { commitId: TARGET_COMMIT },
+      oldTargetRefName: null,
+      newTargetRefName: null,
+      commitsTruncated: false,
+      hasMoreChanges: true,
+      nextSkip: 1,
+      nextTop: 100,
+      changes: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/src/file.ts" } }],
     });
+  });
 
-    expect(parsed(await invoke()).error.code).toBe("INCOMPLETE_PAGINATION");
+  it("keeps identity identical across requested pages", async () => {
+    mockGitApi.getPullRequestIterationChanges
+      .mockResolvedValueOnce({
+        changeEntries: [{ changeTrackingId: 1 }],
+        nextSkip: 1,
+        nextTop: 100,
+      })
+      .mockResolvedValueOnce({
+        changeEntries: [{ changeTrackingId: 2 }],
+        nextSkip: 0,
+        nextTop: 0,
+      });
+
+    const firstPage = parsed(await invoke());
+    const secondPage = parsed(await invoke({ iterationId: firstPage.iterationId, skip: firstPage.nextSkip, top: firstPage.nextTop }));
+
+    expect(secondPage.sourceRefCommit).toEqual(firstPage.sourceRefCommit);
+    expect(secondPage.targetRefCommit).toEqual(firstPage.targetRefCommit);
+    expect(secondPage.commonRefCommit).toEqual(firstPage.commonRefCommit);
+    expect(secondPage.hasMoreChanges).toBe(false);
+    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenLastCalledWith(REPOSITORY_ID, 42, 7, "project", 100, 1);
   });
 
   it("selects the highest iteration ID regardless of response order", async () => {
     const older = iteration();
     const newer = iteration({ id: 8 });
-    prime([], newer);
+    prime(newer);
     mockGitApi.getPullRequestIterations.mockResolvedValue([newer, older]);
 
     const body = parsed(await invoke());
 
-    expect(body.provenance.iteration.id).toBe(8);
+    expect(body.iterationId).toBe(8);
     expect(mockGitApi.getPullRequestIteration).toHaveBeenCalledWith(REPOSITORY_ID, 42, 8, "project");
   });
 
-  it.each([
-    ["latest iteration", iteration(), [iteration(), iteration({ id: 8 })]],
-    ["force-pushed binding", iteration(), [iteration(), iteration({ reason: IterationReason.ForcePush, sourceRefCommit: { commitId: "4".repeat(40) } })]],
-    ["rebased binding", iteration(), [iteration(), iteration({ reason: IterationReason.Rebase, sourceRefCommit: { commitId: "5".repeat(40) } })]],
-    [
-      "retargeted binding",
-      iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" }),
-      [
-        iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" }),
-        iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/other" }),
-      ],
-    ],
-  ])("fails closed when the %s moves", async (_name, selected, finalState) => {
-    prime([], selected);
-    if (Array.isArray(finalState) && finalState.length === 2 && (finalState[0] as { id: number }).id !== (finalState[1] as { id: number }).id) {
-      mockGitApi.getPullRequestIterations.mockReset().mockResolvedValueOnce([selected]).mockResolvedValueOnce(finalState);
-    } else {
-      mockGitApi.getPullRequestIteration.mockReset().mockResolvedValueOnce(finalState[0]).mockResolvedValueOnce(finalState[1]);
-    }
-
-    const result = await invoke();
-
-    expect(result.isError).toBe(true);
-    expect(parsed(result).error.code).toBe("ITERATION_MOVED");
-  });
-
-  it("fails closed on a missing common ref", async () => {
-    prime([], iteration({ commonRefCommit: undefined }));
-
-    const result = await invoke();
-
-    expect(result.isError).toBe(true);
-    expect(parsed(result).error.code).toBe("INVALID_ITERATION_BINDING");
-    expect(mockGitApi.getPullRequestIterationChanges).not.toHaveBeenCalled();
-  });
-
-  it("exposes iteration reason, retarget names, commit truncation, and closed refs", async () => {
+  it("returns retarget names and commit truncation from the selected iteration", async () => {
     prime(
-      [],
       iteration({
         reason: IterationReason.Retarget,
         oldTargetRefName: "refs/heads/main",
@@ -260,141 +149,122 @@ describe("repo_pull_request get_changes", () => {
       })
     );
 
-    const body = parsed(await invoke({ iterationId: 7 }));
-
-    expect(body.provenance.iteration).toMatchObject({
-      id: 7,
-      reason: { value: IterationReason.Retarget, name: "Retarget" },
-      commonRefCommit: { commitId: BASE_COMMIT, role: "fileDiffBase" },
-      sourceRefCommit: { commitId: SOURCE_COMMIT, role: "fileDiffTarget" },
-      targetRefCommit: { commitId: TARGET_COMMIT, role: "targetTipAtIteration" },
-      retarget: { oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" },
+    expect(parsed(await invoke({ iterationId: 7 }))).toMatchObject({
+      iterationReason: { value: IterationReason.Retarget, name: "Retarget" },
+      oldTargetRefName: "refs/heads/main",
+      newTargetRefName: "refs/heads/release",
+      commitsTruncated: true,
     });
-    expect(body.provenance.currentPullRequestRefs).toEqual({ sourceRefName: "refs/heads/feature", targetRefName: "refs/heads/main" });
-    expect(body.provenance.truncation).toMatchObject({ iterationCommits: true, changeEntries: false, fileDiffs: null });
   });
 
-  it("fails closed on malformed refs and repository ambiguity", async () => {
-    mockGitApi.getPullRequest.mockResolvedValue({
-      repository: { id: REPOSITORY_ID },
-      sourceRefName: "feature",
-      targetRefName: "refs/heads/main",
-    });
-    expect(parsed(await invoke()).error.code).toBe("INVALID_ITERATION_BINDING");
+  it.each([
+    ["latest iteration", iteration(), [iteration(), iteration({ id: 8 })]],
+    ["force-pushed iteration", iteration(), iteration({ reason: IterationReason.ForcePush, sourceRefCommit: { commitId: "4".repeat(40) } })],
+    ["rebased iteration", iteration(), iteration({ reason: IterationReason.Rebase, sourceRefCommit: { commitId: "5".repeat(40) } })],
+    [
+      "retargeted iteration",
+      iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" }),
+      iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/other" }),
+    ],
+  ])("fails closed when the %s moves during the request", async (_name, selected, finalState) => {
+    prime(selected);
+    if (Array.isArray(finalState)) {
+      mockGitApi.getPullRequestIterations.mockReset().mockResolvedValueOnce([selected]).mockResolvedValueOnce(finalState);
+    } else {
+      mockGitApi.getPullRequestIteration.mockReset().mockResolvedValueOnce(selected).mockResolvedValueOnce(finalState);
+    }
 
-    prime();
-    mockGitApi.getPullRequest.mockResolvedValue({
-      repository: { id: REPOSITORY_ID },
-      sourceRefName: "refs/heads/feature",
-      targetRefName: "refs/heads/main",
-      forkSource: { repository: { id: "another" } },
-    });
-    expect(parsed(await invoke()).error.code).toBe("AMBIGUOUS_REPOSITORY");
-  });
-
-  it("fails closed on duplicate and conflicting paths", async () => {
-    const renameAndReAdd = [
-      { changeTrackingId: 1, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" },
-      { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/old.ts" } },
-    ];
-    prime(renameAndReAdd);
-    expect((await invoke()).isError).toBeUndefined();
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["old.ts"] })).error.code).toBe("CONFLICTING_PATH");
-
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["/file.ts", "file.ts"] })).error.code).toBe("DUPLICATE_PATH");
-
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" }]);
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["old.ts", "new.ts"] })).error.code).toBe("DUPLICATE_PATH");
-  });
-
-  it("fails closed when pagination is incomplete or exceeds its cap", async () => {
-    prime();
-    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
-      changeEntries: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } }],
-      nextSkip: 1,
-      nextTop: 10,
-    });
-    expect(parsed(await invoke({ changeLimit: 1 })).error).toMatchObject({
-      code: "CHANGES_TRUNCATED",
-      pagination: { complete: false, truncated: true },
-    });
-
-    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
-      changeEntries: [
-        { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } },
-        { changeTrackingId: 2, changeType: VersionControlChangeType.Edit, item: { path: "/two.ts" } },
-      ],
-      nextSkip: 0,
-      nextTop: 0,
-    });
-    expect(parsed(await invoke({ changeLimit: 1 })).error.code).toBe("CHANGES_TRUNCATED");
-  });
-
-  it("fails closed on FileDiffs API errors", async () => {
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
-    mockGitApi.getFileDiffs.mockRejectedValue(new Error("FileDiffs unavailable"));
-
-    const result = await invoke({ includeLineDiffs: true, paths: ["file.ts"] });
+    const result = await invoke();
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("FileDiffs unavailable");
+    expect(parsed(result).error.code).toBe("ITERATION_MOVED");
   });
 
-  it("batches FileDiffs at ten paths per request", async () => {
-    const entries = Array.from({ length: 11 }, (_, index) => ({
-      changeTrackingId: index + 1,
-      changeType: VersionControlChangeType.Rename,
-      item: { path: `/new-${index}.ts` },
-      originalPath: `/old-${index}.ts`,
-    }));
-    prime(entries);
-    mockGitApi.getFileDiffs.mockImplementation(async (criteria: { fileDiffParams: { path: string; originalPath: string }[] }) =>
-      criteria.fileDiffParams.map(({ path, originalPath }) => ({ path, originalPath, lineDiffBlocks: [] }))
-    );
+  it.each([
+    ["commonRefCommit", { commonRefCommit: undefined }],
+    ["sourceRefCommit", { sourceRefCommit: { commitId: "not-a-commit" } }],
+    ["targetRefCommit", { targetRefCommit: undefined }],
+    ["retarget names", { oldTargetRefName: "refs/heads/main", newTargetRefName: undefined }],
+  ])("fails closed on malformed %s", async (_name, overrides) => {
+    prime(iteration(overrides));
 
-    await invoke({ includeLineDiffs: true, paths: entries.map((entry) => entry.originalPath) });
+    const result = await invoke();
 
-    expect(mockGitApi.getFileDiffs).toHaveBeenCalledTimes(2);
-    expect(mockGitApi.getFileDiffs.mock.calls[0][0].fileDiffParams).toHaveLength(10);
-    expect(mockGitApi.getFileDiffs.mock.calls[1][0].fileDiffParams).toHaveLength(1);
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INVALID_ITERATION_BINDING");
+    expect(mockGitApi.getPullRequestIterationChanges).not.toHaveBeenCalled();
   });
 
-  it("fails closed on binary and oversized FileDiffs responses", async () => {
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/binary.dat", contentMetadata: { isBinary: true } } }]);
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["binary.dat"] })).error.code).toBe("UNSUPPORTED_FILE");
+  it("requires project when repositoryId is a name", async () => {
+    const result = await invoke({ repositoryId: "repository", project: undefined });
 
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/large.ts" } }]);
-    mockGitApi.getFileDiffs.mockResolvedValue([
-      {
-        path: "large.ts",
-        originalPath: "large.ts",
-        oversizedServerPayload: "x".repeat(2 * 1024 * 1024),
-        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Edit, originalLineNumberStart: 1, originalLinesCount: 1, modifiedLineNumberStart: 1, modifiedLinesCount: 1 }],
-      },
-    ]);
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["large.ts"] })).error.code).toBe("FILE_DIFF_TOO_LARGE");
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("PROJECT_REQUIRED");
   });
 
-  it("validates wrong-orientation blocks", async () => {
-    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
-    mockGitApi.getFileDiffs.mockResolvedValue([
-      {
-        path: "file.ts",
-        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 0, originalLinesCount: 0, modifiedLineNumberStart: 1, modifiedLinesCount: 1 }],
-      },
-    ]);
+  it.each([{ top: 0 }, { top: 1001 }, { skip: -1 }, { top: 1.5 }])("enforces get_changes paging caps without constraining list schema", async (params) => {
+    const result = await invoke(params);
 
-    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["file.ts"] })).error.code).toBe("MALFORMED_FILE_DIFF");
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INVALID_ARGUMENT");
+    expect(mockGitApi.getPullRequestIterationChanges).not.toHaveBeenCalled();
   });
 
-  it("keeps get_changes in the read-only dispatcher schema and inventory", () => {
-    expect(readDescription).toContain("authoritative, iteration-bound change spans");
-    expect(readSchema.action.safeParse("get_changes").success).toBe(true);
-    expect(readSchema.paths.safeParse(Array.from({ length: 21 }, (_, index) => `file-${index}.ts`)).success).toBe(false);
-    expect(Object.values(REPO_TOOLS)).not.toContain("repo_pull_request_changes");
-    expect((server.tool as jest.Mock).mock.calls.map(([name]) => name)).toContain(REPO_TOOLS.repo_pull_request);
+  it("fails closed on incomplete pagination", async () => {
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
+      changeEntries: [{ changeTrackingId: 1 }],
+      nextSkip: 2,
+      nextTop: 100,
+    });
+
+    const result = await invoke();
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INCOMPLETE_PAGINATION");
+  });
+
+  it.each([
+    [{ changeEntries: {}, nextSkip: 0, nextTop: 0 }, 100],
+    [{ changeEntries: [{ changeTrackingId: 1 }, { changeTrackingId: 2 }], nextSkip: 0, nextTop: 0 }, 1],
+    [{ changeEntries: [{ changeTrackingId: 1 }], nextSkip: 1, nextTop: 1001 }, 100],
+  ])("fails closed on malformed server paging metadata", async (page, top) => {
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue(page);
+
+    const result = await invoke({ top });
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INCOMPLETE_PAGINATION");
+  });
+
+  it("fails when an explicit iteration does not exist", async () => {
+    const result = await invoke({ iterationId: 6 });
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("ITERATION_NOT_FOUND");
+    expect(mockGitApi.getPullRequestIteration).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on iteration-change API errors", async () => {
+    mockGitApi.getPullRequestIterationChanges.mockRejectedValue(new Error("changes unavailable"));
+
+    const result = await invoke();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("changes unavailable");
+  });
+
+  it("keeps get_changes in the read-only dispatcher with bounded paging", () => {
+    const readCall = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request);
     const writeCall = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request_write);
-    expect((writeCall[2] as typeof readSchema).action.safeParse("get_changes").success).toBe(false);
+    const readSchema = readCall[2];
+    const writeSchema = writeCall[2];
+
+    expect(readCall[1]).toContain("iteration-bound change pages");
+    expect(readSchema.action.safeParse("get_changes").success).toBe(true);
+    expect(readSchema.top.safeParse(1001).success).toBe(true);
+    expect(readSchema.skip.safeParse(-1).success).toBe(true);
+    expect(readSchema.includeLineDiffs).toBeUndefined();
+    expect(writeSchema.action.safeParse("get_changes").success).toBe(false);
+    expect(Object.values(REPO_TOOLS)).not.toContain("repo_pull_request_changes");
   });
 });

--- a/test/src/tools/repositories-get-changes.test.ts
+++ b/test/src/tools/repositories-get-changes.test.ts
@@ -1,0 +1,400 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebApi } from "azure-devops-node-api";
+import { IterationReason, LineDiffBlockChangeType, VersionControlChangeType } from "azure-devops-node-api/interfaces/GitInterfaces.js";
+import { configureRepoTools, REPO_TOOLS } from "../../../src/tools/repositories";
+
+jest.mock("../../../src/tools/auth", () => ({
+  getCurrentUserDetails: jest.fn(),
+  getUserIdFromEmail: jest.fn(),
+}));
+jest.mock("../../../src/index", () => ({ orgName: "test-org" }));
+
+const REPOSITORY_ID = "12345678-1234-1234-1234-123456789012";
+const BASE_COMMIT = "1".repeat(40);
+const SOURCE_COMMIT = "2".repeat(40);
+const TARGET_COMMIT = "3".repeat(40);
+
+interface ToolResult {
+  content: { type: string; text: string }[];
+  isError?: boolean;
+}
+type ToolHandler = (params: Record<string, unknown>) => Promise<ToolResult>;
+interface ApiMock {
+  getPullRequest: jest.Mock;
+  getPullRequestIterations: jest.Mock;
+  getPullRequestIteration: jest.Mock;
+  getPullRequestIterationChanges: jest.Mock;
+  getFileDiffs: jest.Mock;
+}
+
+describe("repo_pull_request get_changes", () => {
+  let server: McpServer;
+  let mockGitApi: ApiMock;
+  let handler: ToolHandler;
+  let readSchema: Record<string, { safeParse: (value: unknown) => { success: boolean } }>;
+  let readDescription: string;
+
+  const iteration = (overrides: Record<string, unknown> = {}) => ({
+    id: 7,
+    reason: IterationReason.Push,
+    commonRefCommit: { commitId: BASE_COMMIT },
+    sourceRefCommit: { commitId: SOURCE_COMMIT },
+    targetRefCommit: { commitId: TARGET_COMMIT },
+    hasMoreCommits: false,
+    ...overrides,
+  });
+
+  const prime = (changeEntries: Record<string, unknown>[] = [], selectedIteration = iteration()) => {
+    mockGitApi.getPullRequest.mockResolvedValue({
+      pullRequestId: 42,
+      repository: { id: REPOSITORY_ID, name: "repository" },
+      sourceRefName: "refs/heads/feature",
+      targetRefName: "refs/heads/main",
+      supportsIterations: true,
+    });
+    mockGitApi.getPullRequestIterations.mockResolvedValue([selectedIteration]);
+    mockGitApi.getPullRequestIteration.mockResolvedValue(selectedIteration);
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({ changeEntries, nextSkip: 0, nextTop: 0 });
+    mockGitApi.getFileDiffs.mockResolvedValue([]);
+  };
+
+  const invoke = (params: Record<string, unknown> = {}) =>
+    handler({
+      action: "get_changes",
+      repositoryId: REPOSITORY_ID,
+      pullRequestId: 42,
+      project: "project",
+      changePageSize: 100,
+      changeLimit: 500,
+      includeLineDiffs: false,
+      ...params,
+    });
+
+  const parsed = (result: ToolResult) => JSON.parse(result.content[0].text);
+
+  beforeEach(() => {
+    server = { tool: jest.fn() } as unknown as McpServer;
+    mockGitApi = {
+      getPullRequest: jest.fn(),
+      getPullRequestIterations: jest.fn(),
+      getPullRequestIteration: jest.fn(),
+      getPullRequestIterationChanges: jest.fn(),
+      getFileDiffs: jest.fn(),
+    };
+    const connectionProvider = jest.fn().mockResolvedValue({
+      getGitApi: jest.fn().mockResolvedValue(mockGitApi),
+    });
+    configureRepoTools(server, jest.fn(), connectionProvider as unknown as () => Promise<WebApi>, () => "Jest");
+    const readCall = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request);
+    if (!readCall) throw new Error("repo_pull_request tool not registered");
+    readDescription = readCall[1] as string;
+    readSchema = readCall[2] as typeof readSchema;
+    handler = readCall[3] as ToolHandler;
+    prime();
+  });
+
+  it("returns edit, add, delete, and rename spans while excluding target-tip-only changes", async () => {
+    const entries = [
+      { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/edit.ts" } },
+      { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/added.ts" } },
+      { changeTrackingId: 3, changeType: VersionControlChangeType.Delete, item: {}, originalPath: "/deleted.ts" },
+      { changeTrackingId: 4, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" },
+    ];
+    prime(entries);
+    mockGitApi.getFileDiffs.mockResolvedValue([
+      {
+        path: "edit.ts",
+        originalPath: "edit.ts",
+        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Edit, originalLineNumberStart: 4, originalLinesCount: 1, modifiedLineNumberStart: 4, modifiedLinesCount: 2 }],
+      },
+      {
+        path: "added.ts",
+        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Add, originalLineNumberStart: 0, originalLinesCount: 0, modifiedLineNumberStart: 1, modifiedLinesCount: 3 }],
+      },
+      {
+        path: "deleted.ts",
+        originalPath: "deleted.ts",
+        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 8, originalLinesCount: 2, modifiedLineNumberStart: 0, modifiedLinesCount: 0 }],
+      },
+      { path: "new.ts", originalPath: "old.ts", lineDiffBlocks: [] },
+    ]);
+
+    const result = await invoke({ includeLineDiffs: true, paths: ["/edit.ts", "added.ts", "deleted.ts", "old.ts"] });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockGitApi.getFileDiffs).toHaveBeenCalledWith(
+      {
+        baseVersionCommit: BASE_COMMIT,
+        targetVersionCommit: SOURCE_COMMIT,
+        fileDiffParams: [{ path: "edit.ts", originalPath: "edit.ts" }, { path: "added.ts" }, { path: "deleted.ts", originalPath: "deleted.ts" }, { path: "new.ts", originalPath: "old.ts" }],
+      },
+      "project",
+      REPOSITORY_ID
+    );
+    const body = parsed(result);
+    expect(body.provenance.iteration.targetRefCommit).toEqual({ commitId: TARGET_COMMIT, role: "targetTipAtIteration" });
+    expect(body.fileDiffs[0].provenance.orientation).toEqual({ original: "commonRefCommit", modified: "sourceRefCommit" });
+    expect(body.fileDiffs[0].lineDiffBlocks[0].originalSpan).toEqual({ startLine: 4, endLine: 4, lineCount: 1 });
+    expect(body.fileDiffs[0].lineDiffBlocks[0].modifiedSpan).toEqual({ startLine: 4, endLine: 5, lineCount: 2 });
+    expect(body.fileDiffs[2].lineDiffBlocks[0].modifiedSpan).toBeNull();
+    expect(JSON.stringify(mockGitApi.getFileDiffs.mock.calls)).not.toContain(TARGET_COMMIT);
+  });
+
+  it("preserves context and delete-only orientation", async () => {
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
+    mockGitApi.getFileDiffs.mockResolvedValue([
+      {
+        path: "file.ts",
+        originalPath: "file.ts",
+        lineDiffBlocks: [
+          { changeType: LineDiffBlockChangeType.None, originalLineNumberStart: 1, originalLinesCount: 3, modifiedLineNumberStart: 1, modifiedLinesCount: 3 },
+          { changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 4, originalLinesCount: 2, modifiedLineNumberStart: 0, modifiedLinesCount: 0 },
+        ],
+      },
+    ]);
+
+    const body = parsed(await invoke({ includeLineDiffs: true, paths: ["file.ts"] }));
+    expect(body.fileDiffs[0].lineDiffBlocks[0].changeTypeName).toBe("None");
+    expect(body.fileDiffs[0].lineDiffBlocks[1].originalSpan).toEqual({ startLine: 4, endLine: 5, lineCount: 2 });
+    expect(body.fileDiffs[0].lineDiffBlocks[1].modifiedSpan).toBeNull();
+  });
+
+  it("does not call FileDiffs in metadata-only mode", async () => {
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
+
+    const result = await invoke();
+
+    expect(mockGitApi.getFileDiffs).not.toHaveBeenCalled();
+    expect(parsed(result)).not.toHaveProperty("fileDiffs");
+    expect(parsed(result).provenance.pagination).toMatchObject({ complete: true, truncated: false, changeCount: 1 });
+    expect(mockGitApi.getPullRequestIterations).toHaveBeenCalledTimes(2);
+    expect(mockGitApi.getPullRequestIteration).toHaveBeenCalledTimes(2);
+  });
+
+  it("paginates change entries with server nextSkip and nextTop", async () => {
+    const first = { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } };
+    const second = { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/two.ts" } };
+    prime();
+    mockGitApi.getPullRequestIterationChanges
+      .mockReset()
+      .mockResolvedValueOnce({ changeEntries: [first], nextSkip: 1, nextTop: 25 })
+      .mockResolvedValueOnce({ changeEntries: [second], nextSkip: 0, nextTop: 0 });
+
+    const body = parsed(await invoke({ changePageSize: 10 }));
+
+    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenNthCalledWith(1, REPOSITORY_ID, 42, 7, "project", 10, 0);
+    expect(mockGitApi.getPullRequestIterationChanges).toHaveBeenNthCalledWith(2, REPOSITORY_ID, 42, 7, "project", 10, 1);
+    expect(body.provenance.pagination).toMatchObject({ complete: true, truncated: false, pages: 2, changeCount: 2 });
+  });
+
+  it("fails closed when pagination skips unseen entries", async () => {
+    prime();
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
+      changeEntries: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } }],
+      nextSkip: 2,
+      nextTop: 10,
+    });
+
+    expect(parsed(await invoke()).error.code).toBe("INCOMPLETE_PAGINATION");
+  });
+
+  it("selects the highest iteration ID regardless of response order", async () => {
+    const older = iteration();
+    const newer = iteration({ id: 8 });
+    prime([], newer);
+    mockGitApi.getPullRequestIterations.mockResolvedValue([newer, older]);
+
+    const body = parsed(await invoke());
+
+    expect(body.provenance.iteration.id).toBe(8);
+    expect(mockGitApi.getPullRequestIteration).toHaveBeenCalledWith(REPOSITORY_ID, 42, 8, "project");
+  });
+
+  it.each([
+    ["latest iteration", iteration(), [iteration(), iteration({ id: 8 })]],
+    ["force-pushed binding", iteration(), [iteration(), iteration({ reason: IterationReason.ForcePush, sourceRefCommit: { commitId: "4".repeat(40) } })]],
+    ["rebased binding", iteration(), [iteration(), iteration({ reason: IterationReason.Rebase, sourceRefCommit: { commitId: "5".repeat(40) } })]],
+    [
+      "retargeted binding",
+      iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" }),
+      [
+        iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" }),
+        iteration({ reason: IterationReason.Retarget, oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/other" }),
+      ],
+    ],
+  ])("fails closed when the %s moves", async (_name, selected, finalState) => {
+    prime([], selected);
+    if (Array.isArray(finalState) && finalState.length === 2 && (finalState[0] as { id: number }).id !== (finalState[1] as { id: number }).id) {
+      mockGitApi.getPullRequestIterations.mockReset().mockResolvedValueOnce([selected]).mockResolvedValueOnce(finalState);
+    } else {
+      mockGitApi.getPullRequestIteration.mockReset().mockResolvedValueOnce(finalState[0]).mockResolvedValueOnce(finalState[1]);
+    }
+
+    const result = await invoke();
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("ITERATION_MOVED");
+  });
+
+  it("fails closed on a missing common ref", async () => {
+    prime([], iteration({ commonRefCommit: undefined }));
+
+    const result = await invoke();
+
+    expect(result.isError).toBe(true);
+    expect(parsed(result).error.code).toBe("INVALID_ITERATION_BINDING");
+    expect(mockGitApi.getPullRequestIterationChanges).not.toHaveBeenCalled();
+  });
+
+  it("exposes iteration reason, retarget names, commit truncation, and closed refs", async () => {
+    prime(
+      [],
+      iteration({
+        reason: IterationReason.Retarget,
+        oldTargetRefName: "refs/heads/main",
+        newTargetRefName: "refs/heads/release",
+        hasMoreCommits: true,
+      })
+    );
+
+    const body = parsed(await invoke({ iterationId: 7 }));
+
+    expect(body.provenance.iteration).toMatchObject({
+      id: 7,
+      reason: { value: IterationReason.Retarget, name: "Retarget" },
+      commonRefCommit: { commitId: BASE_COMMIT, role: "fileDiffBase" },
+      sourceRefCommit: { commitId: SOURCE_COMMIT, role: "fileDiffTarget" },
+      targetRefCommit: { commitId: TARGET_COMMIT, role: "targetTipAtIteration" },
+      retarget: { oldTargetRefName: "refs/heads/main", newTargetRefName: "refs/heads/release" },
+    });
+    expect(body.provenance.currentPullRequestRefs).toEqual({ sourceRefName: "refs/heads/feature", targetRefName: "refs/heads/main" });
+    expect(body.provenance.truncation).toMatchObject({ iterationCommits: true, changeEntries: false, fileDiffs: null });
+  });
+
+  it("fails closed on malformed refs and repository ambiguity", async () => {
+    mockGitApi.getPullRequest.mockResolvedValue({
+      repository: { id: REPOSITORY_ID },
+      sourceRefName: "feature",
+      targetRefName: "refs/heads/main",
+    });
+    expect(parsed(await invoke()).error.code).toBe("INVALID_ITERATION_BINDING");
+
+    prime();
+    mockGitApi.getPullRequest.mockResolvedValue({
+      repository: { id: REPOSITORY_ID },
+      sourceRefName: "refs/heads/feature",
+      targetRefName: "refs/heads/main",
+      forkSource: { repository: { id: "another" } },
+    });
+    expect(parsed(await invoke()).error.code).toBe("AMBIGUOUS_REPOSITORY");
+  });
+
+  it("fails closed on duplicate and conflicting paths", async () => {
+    const renameAndReAdd = [
+      { changeTrackingId: 1, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" },
+      { changeTrackingId: 2, changeType: VersionControlChangeType.Add, item: { path: "/old.ts" } },
+    ];
+    prime(renameAndReAdd);
+    expect((await invoke()).isError).toBeUndefined();
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["old.ts"] })).error.code).toBe("CONFLICTING_PATH");
+
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["/file.ts", "file.ts"] })).error.code).toBe("DUPLICATE_PATH");
+
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Rename, item: { path: "/new.ts" }, originalPath: "/old.ts" }]);
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["old.ts", "new.ts"] })).error.code).toBe("DUPLICATE_PATH");
+  });
+
+  it("fails closed when pagination is incomplete or exceeds its cap", async () => {
+    prime();
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
+      changeEntries: [{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } }],
+      nextSkip: 1,
+      nextTop: 10,
+    });
+    expect(parsed(await invoke({ changeLimit: 1 })).error).toMatchObject({
+      code: "CHANGES_TRUNCATED",
+      pagination: { complete: false, truncated: true },
+    });
+
+    mockGitApi.getPullRequestIterationChanges.mockResolvedValue({
+      changeEntries: [
+        { changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/one.ts" } },
+        { changeTrackingId: 2, changeType: VersionControlChangeType.Edit, item: { path: "/two.ts" } },
+      ],
+      nextSkip: 0,
+      nextTop: 0,
+    });
+    expect(parsed(await invoke({ changeLimit: 1 })).error.code).toBe("CHANGES_TRUNCATED");
+  });
+
+  it("fails closed on FileDiffs API errors", async () => {
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
+    mockGitApi.getFileDiffs.mockRejectedValue(new Error("FileDiffs unavailable"));
+
+    const result = await invoke({ includeLineDiffs: true, paths: ["file.ts"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("FileDiffs unavailable");
+  });
+
+  it("batches FileDiffs at ten paths per request", async () => {
+    const entries = Array.from({ length: 11 }, (_, index) => ({
+      changeTrackingId: index + 1,
+      changeType: VersionControlChangeType.Rename,
+      item: { path: `/new-${index}.ts` },
+      originalPath: `/old-${index}.ts`,
+    }));
+    prime(entries);
+    mockGitApi.getFileDiffs.mockImplementation(async (criteria: { fileDiffParams: { path: string; originalPath: string }[] }) =>
+      criteria.fileDiffParams.map(({ path, originalPath }) => ({ path, originalPath, lineDiffBlocks: [] }))
+    );
+
+    await invoke({ includeLineDiffs: true, paths: entries.map((entry) => entry.originalPath) });
+
+    expect(mockGitApi.getFileDiffs).toHaveBeenCalledTimes(2);
+    expect(mockGitApi.getFileDiffs.mock.calls[0][0].fileDiffParams).toHaveLength(10);
+    expect(mockGitApi.getFileDiffs.mock.calls[1][0].fileDiffParams).toHaveLength(1);
+  });
+
+  it("fails closed on binary and oversized FileDiffs responses", async () => {
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/binary.dat", contentMetadata: { isBinary: true } } }]);
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["binary.dat"] })).error.code).toBe("UNSUPPORTED_FILE");
+
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/large.ts" } }]);
+    mockGitApi.getFileDiffs.mockResolvedValue([
+      {
+        path: "large.ts",
+        originalPath: "large.ts",
+        oversizedServerPayload: "x".repeat(2 * 1024 * 1024),
+        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Edit, originalLineNumberStart: 1, originalLinesCount: 1, modifiedLineNumberStart: 1, modifiedLinesCount: 1 }],
+      },
+    ]);
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["large.ts"] })).error.code).toBe("FILE_DIFF_TOO_LARGE");
+  });
+
+  it("validates wrong-orientation blocks", async () => {
+    prime([{ changeTrackingId: 1, changeType: VersionControlChangeType.Edit, item: { path: "/file.ts" } }]);
+    mockGitApi.getFileDiffs.mockResolvedValue([
+      {
+        path: "file.ts",
+        lineDiffBlocks: [{ changeType: LineDiffBlockChangeType.Delete, originalLineNumberStart: 0, originalLinesCount: 0, modifiedLineNumberStart: 1, modifiedLinesCount: 1 }],
+      },
+    ]);
+
+    expect(parsed(await invoke({ includeLineDiffs: true, paths: ["file.ts"] })).error.code).toBe("MALFORMED_FILE_DIFF");
+  });
+
+  it("keeps get_changes in the read-only dispatcher schema and inventory", () => {
+    expect(readDescription).toContain("authoritative, iteration-bound change spans");
+    expect(readSchema.action.safeParse("get_changes").success).toBe(true);
+    expect(readSchema.paths.safeParse(Array.from({ length: 21 }, (_, index) => `file-${index}.ts`)).success).toBe(false);
+    expect(Object.values(REPO_TOOLS)).not.toContain("repo_pull_request_changes");
+    expect((server.tool as jest.Mock).mock.calls.map(([name]) => name)).toContain(REPO_TOOLS.repo_pull_request);
+    const writeCall = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request_write);
+    expect((writeCall[2] as typeof readSchema).action.safeParse("get_changes").success).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the remote-documented `repo_pull_request:get_changes` action to the consolidated local repository tool using the smallest page-level contract needed to bind review data to an exact pull request iteration.

Each bounded page preserves `{ iterationId, nextSkip, nextTop, changes }` and adds `sourceRefCommit`, `targetRefCommit`, and `commonRefCommit`, plus iteration reason, retarget names, and explicit commit/change continuation indicators. Callers can pass the returned `iterationId`, `nextSkip`, and `nextTop` to continue paging without changing identity.

Iteration reasons use the stable lossless shape `{ value, names, unrecognizedBits }`. Known flag names are deterministically ordered, `Push` is represented explicitly for zero, `Unknown` appears only when its SDK bit is set, absent reasons preserve a nullable shape, and any unrecognized integer bits remain visible.

The implementation validates commit IDs and pagination metadata, caps `get_changes` pages at 1,000 entries without changing the existing `list` schema, and re-reads both the latest and selected iteration after retrieving changes. It fails closed if either identity moves. It does not use `compareTo`, target-tip comparisons, synthetic merges, FileDiffs, write operations, or additional OAuth scopes.

## GitHub issue number

Follow-up to #868 and #1198. This aligns the local server with the `repo_pull_request:get_changes` action already documented for the remote MCP server.

## **Associated Risks**

The action intentionally rejects absent or malformed refs, malformed or incomplete pagination, malformed iteration reasons, and concurrent iteration movement instead of returning data with uncertain provenance.

The hosted remote MCP service has an independent source and deployment pipeline. Merging this public local-server contribution does not itself add these identity fields to the hosted service; a separate hosted-service change is required for remote parity.

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

- Added mocked Git API coverage for latest and explicit iteration selection, exact identity fields, stable pagination identity, all single and combined iteration-reason flags, genuine Unknown, absent/null and unrecognized reasons, deterministic flag ordering, retarget/truncation metadata, malformed refs, force-push/rebase/retarget races, runtime page caps, malformed continuation metadata, missing iterations, API errors, schema descriptions, and read-only tool inventory.
- Ran the full Jest suite (1,248 tests), TypeScript type-check, production build, tool-name/schema validation, ESLint, and changed-file Prettier checks.
- Completed independent rubber-duck and code-review passes. Review findings for shared paging schema and lossless iteration-reason flags were fixed and re-reviewed.