### PR TITLE
Add support for parent comments in reply functionality

### DIFF
--- a/src/tools/repositories.ts
+++ b/src/tools/repositories.ts
@@ -924,6 +924,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       project: z.string().optional().describe("Project ID or project name. Required when repositoryId is a name instead of a GUID."),
       threadId: z.coerce.number().min(1).optional().describe("The ID of the thread. Required for reply and update_status."),
       content: z.string().optional().describe("The content of the comment. Required for create and reply."),
+      parentCommentId: z.coerce.number().int().min(1).optional().describe("The ID of the parent comment. Used for reply."),
       status: z
         .enum(getEnumKeys(CommentThreadStatus) as [string, ...string[]])
         .optional()
@@ -936,7 +937,22 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
       rightFileEndLine: z.number().optional().describe("End line in the right file. Used for create."),
       rightFileEndOffset: z.number().optional().describe("End character offset in the right file. Used for create."),
     },
-    async ({ action, repositoryId, pullRequestId, project, threadId, content, status, filePath, fullResponse, rightFileStartLine, rightFileStartOffset, rightFileEndLine, rightFileEndOffset }) => {
+    async ({
+      action,
+      repositoryId,
+      pullRequestId,
+      project,
+      threadId,
+      content,
+      parentCommentId,
+      status,
+      filePath,
+      fullResponse,
+      rightFileStartLine,
+      rightFileStartOffset,
+      rightFileEndLine,
+      rightFileEndOffset,
+    }) => {
       try {
         const connection = await connectionProvider();
         const gitApi = await connection.getGitApi();
@@ -988,7 +1004,11 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
           }
 
           const thread = await gitApi.createThread(
-            { comments: [{ content, commentType: 1 }], threadContext, status: CommentThreadStatus[status as keyof typeof CommentThreadStatus] },
+            {
+              comments: [{ content, commentType: 1 }],
+              threadContext,
+              status: CommentThreadStatus[status as keyof typeof CommentThreadStatus],
+            },
             repositoryId,
             pullRequestId,
             project
@@ -1001,7 +1021,7 @@ function configureRepoTools(server: McpServer, tokenProvider: () => Promise<stri
           if (!threadId) return { content: [{ type: "text", text: "threadId is required for reply" }], isError: true };
           if (!content) return { content: [{ type: "text", text: "content is required for reply" }], isError: true };
 
-          const comment = await gitApi.createComment({ content, commentType: 1 }, repositoryId, pullRequestId, threadId, project);
+          const comment = await gitApi.createComment({ content, commentType: 1, parentCommentId }, repositoryId, pullRequestId, threadId, project);
 
           if (!comment) {
             return { content: [{ type: "text", text: `Error: Failed to add comment to thread ${threadId}. The comment was not created successfully.` }], isError: true };

--- a/test/src/tools/repositories.test.ts
+++ b/test/src/tools/repositories.test.ts
@@ -4412,6 +4412,27 @@ describe("repos tools", () => {
       expect(result.content[0].text).toBe("Comment successfully added to thread 789.");
     });
 
+    it("should reply to a parent comment", async () => {
+      configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === REPO_TOOLS.repo_pull_request_thread_write);
+      if (!call) throw new Error("repo_pull_request_thread_write tool not registered");
+      const [, , , handler] = call;
+
+      mockGitApi.createComment.mockResolvedValue({ id: 2, content: "Nested reply" });
+
+      await handler({
+        action: "reply",
+        repositoryId: "repo123",
+        pullRequestId: 456,
+        threadId: 789,
+        content: "Nested reply",
+        parentCommentId: 1,
+      });
+
+      expect(mockGitApi.createComment).toHaveBeenCalledWith({ content: "Nested reply", commentType: 1, parentCommentId: 1 }, "repo123", 456, 789, undefined);
+    });
+
     it("should return full response when requested", async () => {
       configureRepoTools(server, tokenProvider, connectionProvider, userAgentProvider);
 


### PR DESCRIPTION
This pull request adds support for replying to a specific parent comment within a pull request thread, enabling nested comment replies. The main changes involve updating the schema and handler logic to accept and use a new `parentCommentId` parameter, as well as adding a corresponding test to ensure this functionality works as expected.

**Support for nested comment replies:**

* Added a new optional `parentCommentId` parameter to the schema for the `repo_pull_request_thread_write` tool, allowing replies to reference a specific parent comment.
* Updated the handler function to accept and forward `parentCommentId` when creating a comment reply, ensuring the reply is nested under the correct parent comment. [[1]](diffhunk://#diff-e3b482da7e394e782902c348cf01ce12c7c881ed9745c10aff16e8f873714103L939-R955) [[2]](diffhunk://#diff-e3b482da7e394e782902c348cf01ce12c7c881ed9745c10aff16e8f873714103L1004-R1024)

**Testing:**

* Added a test case in `repositories.test.ts` to verify that replies to a parent comment correctly call the API with the `parentCommentId` parameter.

**Code consistency:**

* Refactored the call to `gitApi.createThread` for clarity and consistency in argument formatting.

## GitHub issue number
#1510 

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manual tested and updated the automated tests
