### PR TITLE
fix: use command line tenantId override for authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ async function main() {
   server.server.oninitialized = () => {
     userAgentComposer.appendMcpClientInfo(server.server.getClientVersion());
   };
-  const tenantId = (await getOrgTenant(orgName)) ?? argv.tenant;
+  const tenantId = argv.tenant ?? (await getOrgTenant(orgName));
   const authenticator = createAuthenticator(argv.authentication, tenantId);
 
   if (argv.authentication === "pat") {


### PR DESCRIPTION
PR changes the priority of `--tenant ...` command line param.
It overwrites tenant resolved for target ADO org.

## GitHub issue number

#1485 
## **Associated Risks**

The behavior changes for users having `--authentication azcli --tenant ...` in MCP startup command.
They'll need to remove `--tenant ...` parameter to get back to auth parameters that were effective before.

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

E2E tested (via VSCode on windows) following startup command variations:
- no params
- `-t valid_tenant`
- `-t wrong_tenant`
- `-a azcli`
- `-a azcli -t valid_tenant`
- `-a azcli -t wrong_tenant`

targeting both MSA-based and Enterprise ADO orgs

