### PR TITLE
fix: update work item configuration to use repro steps for Bug child …

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -735,8 +735,6 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
             const ops: { op: string; path: string; value: unknown }[] = [
               { op: "add", path: "/id", value: `-${x + 1}` },
               { op: "add", path: "/fields/System.Title", value: item.title },
-              { op: "add", path: "/fields/System.Description", value: encodedDescription },
-              { op: "add", path: "/fields/Microsoft.VSTS.TCM.ReproSteps", value: encodedDescription },
               {
                 op: "add",
                 path: "/relations/-",
@@ -755,9 +753,20 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
               ops.push({ op: "add", path: "/fields/System.IterationPath", value: item.iterationPath });
             }
 
-            if (item.format && item.format === "Markdown") {
-              ops.push({ op: "add", path: "/multilineFieldsFormat/System.Description", value: item.format });
-              ops.push({ op: "add", path: "/multilineFieldsFormat/Microsoft.VSTS.TCM.ReproSteps", value: item.format });
+            // check if the work item type is "Bug" to determine which field to use for the description
+            // ReproSteps is used for Bugs, while Description is used for other work item types
+            if (workItemType.toLowerCase() === "bug") {
+              ops.push({ op: "add", path: "/fields/Microsoft.VSTS.TCM.ReproSteps", value: encodedDescription });
+
+              if (item.format && item.format === "Markdown") {
+                ops.push({ op: "add", path: "/multilineFieldsFormat/Microsoft.VSTS.TCM.ReproSteps", value: item.format });
+              }
+            } else {
+              ops.push({ op: "add", path: "/fields/System.Description", value: encodedDescription });
+
+              if (item.format && item.format === "Markdown") {
+                ops.push({ op: "add", path: "/multilineFieldsFormat/System.Description", value: item.format });
+              }
             }
 
             return {

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -3290,13 +3290,58 @@ describe("configureWorkItemTools", () => {
           body: expect.stringContaining("multilineFieldsFormat/System.Description"),
         })
       );
+    });
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://dev.azure.com/contoso/_apis/wit/$batch?api-version=5.0",
-        expect.objectContaining({
-          body: expect.stringContaining("multilineFieldsFormat/Microsoft.VSTS.TCM.ReproSteps"),
-        })
+    it("should use repro steps for Bug child work items", async () => {
+      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
+
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item_write");
+      if (!call) throw new Error("wit_work_item_write tool not registered");
+      const [, , , handler] = call;
+
+      mockConnection.serverUrl = "https://dev.azure.com/contoso";
+      (tokenProvider as jest.Mock).mockResolvedValue("fake-token");
+
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ responses: [{ body: { id: 123 } }] }),
+      });
+      global.fetch = mockFetch;
+
+      await handler({
+        action: "add_child",
+        parentId: 1,
+        project: "TestProject",
+        workItemType: "Bug",
+        items: [
+          {
+            title: "Markdown Bug",
+            description: "Bug repro steps in **Markdown**",
+            format: "Markdown",
+          },
+          {
+            title: "HTML Bug",
+            description: "<p>Bug repro steps in HTML</p>",
+            format: "Html",
+          },
+        ],
+      });
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+
+      expect(requestBody[0].body).toEqual(
+        expect.arrayContaining([
+          { op: "add", path: "/fields/Microsoft.VSTS.TCM.ReproSteps", value: "Bug repro steps in **Markdown**" },
+          { op: "add", path: "/multilineFieldsFormat/Microsoft.VSTS.TCM.ReproSteps", value: "Markdown" },
+        ])
       );
+      expect(requestBody[1].body).toContainEqual({
+        op: "add",
+        path: "/fields/Microsoft.VSTS.TCM.ReproSteps",
+        value: "<p>Bug repro steps in HTML</p>",
+      });
+      expect(requestBody[1].body).not.toContainEqual(expect.objectContaining({ path: "/multilineFieldsFormat/Microsoft.VSTS.TCM.ReproSteps" }));
+      expect(mockFetch.mock.calls[0][1].body).not.toContain("System.Description");
     });
 
     it("should handle fetch failure response", async () => {


### PR DESCRIPTION
This pull request updates the logic for assigning description fields when creating child work items, ensuring that bug work items use the correct field for repro steps. It also adds comprehensive tests to verify this behavior.

**Work item field assignment improvements:**

* Updated `configureWorkItemTools` so that for work items of type "Bug", the description is added to the `Microsoft.VSTS.TCM.ReproSteps` field, while for other types, it remains in `System.Description`. The correct multiline format field is also set depending on the work item type. [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L738-L739) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311R756-R770)

**Testing enhancements:**

* Added a new test to ensure that bug child work items use the `ReproSteps` field and not `System.Description`, and that the multiline format is only set for Markdown-formatted bugs.

## GitHub issue number
#1521

## **Associated Risks**

N/A

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Manually tested and updated auto tests
