### PR TITLE
Restore star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ Read the [Contributions Guide](./CONTRIBUTING.md) before creating a pull request
 This project follows the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For questions, see the [FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [open@microsoft.com](mailto:open@microsoft.com).
 
+## Project Stats
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=microsoft/azure-devops-mcp&type=Date)](https://star-history.dera.page/#microsoft/azure-devops-mcp&type=Date)
+
 ## Hall of Fame
 
 Thanks to all contributors who make this project awesome! ❤️


### PR DESCRIPTION
The star history chart was removed from the README in the documentation refactor (#1518), leaving the project without its Project Stats section. This change restores the section at the same location using a working chart provider, since the previous star history chart is broken due to GitHub stargazer API restrictions. The chart also serves as a useful signal of project health for potential contributors.