### PR TITLE
Add rename_pipeline functionality and update schemas and tests

### DIFF
--- a/docs/TOOLSET.md
+++ b/docs/TOOLSET.md
@@ -103,6 +103,7 @@ This page lists all available tools provided by the local Azure DevOps MCP serve
 | [pipelines_artifact](#pipelines_artifact)     | `download`           | Download a named build artifact                     |
 | [pipelines_write](#pipelines_write)           | `run_pipeline`       | Queue a new pipeline run                            |
 | [pipelines_write](#pipelines_write)           | `create_pipeline`    | Create a new YAML pipeline definition               |
+| [pipelines_write](#pipelines_write)           | `rename_pipeline`    | Rename an existing pipeline definition              |
 | [pipelines_write](#pipelines_write)           | `update_build_stage` | Cancel, retry, or run a stage on an in-flight build |
 
 ### Test Plans

--- a/src/tools/pipelines.dto.ts
+++ b/src/tools/pipelines.dto.ts
@@ -69,7 +69,7 @@ export const runPipelineShape = {
 /** create_pipeline inputs. */
 export const createPipelineShape = {
   ...projectShape,
-  name: z.string().optional().describe("Name of the new pipeline. Required for: create_pipeline."),
+  name: z.string().optional().describe("Pipeline name. Required for: create_pipeline, rename_pipeline."),
   folder: z.string().optional().describe("Folder path for the new pipeline. Used for: create_pipeline."),
   yamlPath: z.string().optional().describe("Path to the YAML file in the repository. Required for: create_pipeline."),
   repositoryType: z
@@ -79,6 +79,13 @@ export const createPipelineShape = {
   repositoryName: z.string().optional().describe("Name of the repository (for GitHub: owner/repo). Required for: create_pipeline."),
   repositoryId: z.string().optional().describe("ID of the repository. Used for: create_pipeline."),
   repositoryConnectionId: z.string().optional().describe("Service connection ID for GitHub repositories. Used for: create_pipeline."),
+};
+
+/** rename_pipeline inputs. */
+export const renamePipelineShape = {
+  ...projectShape,
+  pipelineId: z.coerce.number().min(1).optional().describe("ID of the pipeline. Required for: run_pipeline, rename_pipeline."),
+  name: z.string().optional().describe("Pipeline name. Required for: create_pipeline, rename_pipeline."),
 };
 
 /** update_build_stage inputs. */
@@ -96,12 +103,13 @@ export const updateBuildStageShape = {
 /** The composed input shape for the grouped `pipelines_write` tool. */
 export const pipelinesWriteShape = {
   action: z
-    .enum(["run_pipeline", "create_pipeline", "update_build_stage"])
+    .enum(["run_pipeline", "create_pipeline", "rename_pipeline", "update_build_stage"])
     .describe(
-      "The action to perform. Options: run_pipeline (queue a new pipeline run), create_pipeline (create a new YAML pipeline definition), update_build_stage (cancel, retry, or run a stage on an in-flight build)."
+      "The action to perform. Options: run_pipeline (queue a new pipeline run), create_pipeline (create a new YAML pipeline definition), rename_pipeline (rename an existing pipeline definition), update_build_stage (cancel, retry, or run a stage on an in-flight build)."
     ),
   ...runPipelineShape,
   ...createPipelineShape,
+  ...renamePipelineShape,
   ...updateBuildStageShape,
 };
 
@@ -109,10 +117,12 @@ export const pipelinesWriteShape = {
 // lockstep with the schemas above.
 export const runPipelineSchema = z.object(runPipelineShape);
 export const createPipelineSchema = z.object(createPipelineShape);
+export const renamePipelineSchema = z.object(renamePipelineShape);
 export const updateBuildStageSchema = z.object(updateBuildStageShape);
 export const pipelinesWriteSchema = z.object(pipelinesWriteShape);
 
 export type RunPipelineArgs = z.infer<typeof runPipelineSchema>;
 export type CreatePipelineArgs = z.infer<typeof createPipelineSchema>;
+export type RenamePipelineArgs = z.infer<typeof renamePipelineSchema>;
 export type UpdateBuildStageArgs = z.infer<typeof updateBuildStageSchema>;
 export type PipelinesWriteArgs = z.infer<typeof pipelinesWriteSchema>;

--- a/src/tools/pipelines.ts
+++ b/src/tools/pipelines.ts
@@ -12,7 +12,7 @@ import { mkdirSync, createWriteStream } from "fs";
 import { createExternalContentResponse } from "../shared/content-safety.js";
 import { join, posix, resolve, win32 } from "path";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { pipelinesWriteShape, RunPipelineArgs, CreatePipelineArgs, UpdateBuildStageArgs, PipelinesWriteArgs } from "./pipelines.dto.js";
+import { pipelinesWriteShape, RunPipelineArgs, CreatePipelineArgs, RenamePipelineArgs, UpdateBuildStageArgs, PipelinesWriteArgs } from "./pipelines.dto.js";
 
 const errorResult = (text: string): CallToolResult => ({ content: [{ type: "text", text }], isError: true });
 
@@ -70,6 +70,18 @@ async function createPipeline(args: CreatePipelineArgs, connectionProvider: () =
   return { content: [{ type: "text", text: JSON.stringify(newPipeline, null, 2) }] };
 }
 
+async function renamePipeline(args: RenamePipelineArgs, connectionProvider: () => Promise<WebApi>): Promise<CallToolResult> {
+  if (!args.pipelineId) return errorResult("pipelineId is required for rename_pipeline");
+  if (!args.name) return errorResult("name is required for rename_pipeline");
+
+  const connection = await connectionProvider();
+  const buildApi = await connection.getBuildApi();
+  const definition = await buildApi.getDefinition(args.project, args.pipelineId);
+  const updatedDefinition = await buildApi.updateDefinition({ ...definition, name: args.name }, args.project, args.pipelineId);
+
+  return { content: [{ type: "text", text: JSON.stringify(updatedDefinition, null, 2) }] };
+}
+
 async function updateBuildStage(args: UpdateBuildStageArgs, connectionProvider: () => Promise<WebApi>, tokenProvider: () => Promise<string>, userAgentProvider: () => string): Promise<CallToolResult> {
   if (!args.buildId) return errorResult("buildId is required for update_build_stage");
   if (!args.stageName) return errorResult("stageName is required for update_build_stage");
@@ -99,6 +111,7 @@ async function updateBuildStage(args: UpdateBuildStageArgs, connectionProvider: 
 const pipelinesWriteErrorPrefixes: Record<PipelinesWriteArgs["action"], string> = {
   run_pipeline: "Error running pipeline: ",
   create_pipeline: "Error creating pipeline: ",
+  rename_pipeline: "Error renaming pipeline: ",
   update_build_stage: "Error updating build stage: ",
 };
 
@@ -516,6 +529,8 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
           return await runPipeline(args, connectionProvider);
         case "create_pipeline":
           return await createPipeline(args, connectionProvider);
+        case "rename_pipeline":
+          return await renamePipeline(args, connectionProvider);
         case "update_build_stage":
           return await updateBuildStage(args, connectionProvider, tokenProvider, userAgentProvider);
         default: {
@@ -530,5 +545,5 @@ function configurePipelineTools(server: McpServer, tokenProvider: () => Promise<
   });
 }
 
-export { PIPELINE_TOOLS, configurePipelineTools, runPipeline, createPipeline, updateBuildStage };
-export type { RunPipelineArgs, CreatePipelineArgs, UpdateBuildStageArgs };
+export { PIPELINE_TOOLS, configurePipelineTools, runPipeline, createPipeline, renamePipeline, updateBuildStage };
+export type { RunPipelineArgs, CreatePipelineArgs, RenamePipelineArgs, UpdateBuildStageArgs };

--- a/test/src/tools/pipelines.test.ts
+++ b/test/src/tools/pipelines.test.ts
@@ -1441,6 +1441,52 @@ describe("configurePipelineTools", () => {
   });
 
   describe("pipelines_write tool", () => {
+    it("should rename a pipeline while preserving the complete build definition", async () => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_write");
+      if (!call) throw new Error("pipelines_write tool not registered");
+      const [, , , handler] = call;
+
+      const definition = {
+        id: 42,
+        name: "Old Pipeline Name",
+        path: "\\Production",
+        revision: 7,
+        repository: { id: "repo-id", type: "TfsGit", defaultBranch: "refs/heads/main" },
+        process: { type: 2, yamlFilename: "azure-pipelines.yml" },
+        variables: { configuration: { value: "Release", isSecret: false } },
+      };
+      const renamedDefinition = { ...definition, name: "New Pipeline Name", revision: 8 };
+      const mockBuildApi = {
+        getDefinition: jest.fn().mockResolvedValue(definition),
+        updateDefinition: jest.fn().mockResolvedValue(renamedDefinition),
+      };
+      mockConnection.getBuildApi.mockResolvedValue(mockBuildApi);
+
+      const result = await handler({ action: "rename_pipeline", project: "ProjectName", pipelineId: 42, name: "New Pipeline Name" });
+
+      expect(mockBuildApi.getDefinition).toHaveBeenCalledWith("ProjectName", 42);
+      expect(mockBuildApi.updateDefinition).toHaveBeenCalledWith({ ...definition, name: "New Pipeline Name" }, "ProjectName", 42);
+      expect(result.content[0].text).toBe(JSON.stringify(renamedDefinition, null, 2));
+      expect(result.isError).toBeUndefined();
+    });
+
+    it.each([
+      ["pipelineId", { name: "New Pipeline Name" }, "pipelineId is required for rename_pipeline"],
+      ["name", { pipelineId: 42 }, "name is required for rename_pipeline"],
+    ])("should return error when %s is missing for rename_pipeline", async (_field, extra, expectedMessage) => {
+      configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
+      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_write");
+      if (!call) throw new Error("pipelines_write tool not registered");
+      const [, , , handler] = call;
+
+      const result = await handler({ action: "rename_pipeline", project: "ProjectName", ...extra });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe(expectedMessage);
+      expect(connectionProvider).not.toHaveBeenCalled();
+    });
+
     it("should create a YAML pipeline for AzureReposGit and return created pipeline", async () => {
       configurePipelineTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "pipelines_write");
@@ -1863,7 +1909,7 @@ describe("configurePipelineTools", () => {
       const result = await handler({ action: "unknown" as any, project: "test-project" });
 
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toBe("Unknown action: unknown. Supported actions: create_pipeline, run_pipeline, update_build_stage");
+      expect(result.content[0].text).toBe("Unknown action: unknown. Supported actions: create_pipeline, rename_pipeline, run_pipeline, update_build_stage");
       expect(connectionProvider as jest.Mock).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
This pull request adds support for renaming Azure DevOps pipeline definitions through the new `rename_pipeline` action in the `pipelines_write` tool. It introduces the necessary DTOs, handler logic, and tests to ensure the action works correctly and validates required parameters.

**New pipeline renaming support:**

- Added a new `rename_pipeline` action to the `pipelines_write` tool, allowing users to rename existing pipeline definitions. (`docs/TOOLSET.md` [[1]](diffhunk://#diff-63809bcf7da46bf515d3deeb8551a8a5cd63b3fff00ee8dd3517e46bb2bd6025R106) `src/tools/pipelines.dto.ts` [[2]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560L72-R72) [[3]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560R84-R90) [[4]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560L99-R126) `src/tools/pipelines.ts` [[5]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eL15-R15) [[6]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR73-R84) [[7]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR114) [[8]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR532-R533) [[9]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eL533-R549)

**DTO and schema updates:**

- Introduced the `RenamePipelineArgs` type and `renamePipelineShape` schema, and updated the composed `pipelinesWriteShape` to include the new action and its parameters. (`src/tools/pipelines.dto.ts` [[1]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560L72-R72) [[2]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560R84-R90) [[3]](diffhunk://#diff-625f89f9c30e4ba9aa7f36c9f0dd0215af8adcfc2cbe0bf57dec0e95df0dd560L99-R126)

**Handler and error handling:**

- Implemented the `renamePipeline` function, which validates required arguments, retrieves the pipeline definition, updates its name, and returns the updated definition. Error handling for missing parameters was also added. (`src/tools/pipelines.ts` [[1]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR73-R84) [[2]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR114) [[3]](diffhunk://#diff-61ea19714cb175a5845bd938c66c5f6f0226448eb281419059c7c3ef889fb29eR532-R533)

**Testing enhancements:**

- Added comprehensive tests for the `rename_pipeline` action, including successful renaming and error handling for missing required fields. Also updated error messages for unknown actions to include `rename_pipeline`. (`test/src/tools/pipelines.test.ts` [[1]](diffhunk://#diff-fb7cbb4ca60175990b48782444c077c05ca3c38613aa12b0d8169ed3da0eb6cbR1444-R1489) [[2]](diffhunk://#diff-fb7cbb4ca60175990b48782444c077c05ca3c38613aa12b0d8169ed3da0eb6cbL1866-R1912)

## GitHub issue number
#1426

## **Associated Risks**

None

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Tested manually and updated automated tests
