### PR TITLE
fix: npm install in envs with stricter policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,9 @@
     "**/*.(js|ts|jsx|tsx|json|css|md)": [
       "npm run format"
     ]
+  },
+  "allowScripts": {
+    "keytar@7.9.0": true,
+    "@azure/msal-node-extensions@5.3.5": true
   }
 }


### PR DESCRIPTION
Explicitly sets policy allowing post install scripts to be executed for selected packages.
It is required to fix error that some stricter envs may experience:

```
FAIL test/src/pat-auth.test.ts
  ● Test suite failed to run

    libsecret-1.so.0: cannot open shared object file: No such file or directory

      4 | import { AzureCliCredential, ChainedTokenCredential, DefaultAzureCredential, TokenCredential } from "@azure/identity";
      5 | import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
    > 6 | import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
        | ^
      7 | import open from "open";
      8 | import { logger } from "./logger.js";
      9 |

      at CjsLoader.loadModule (node_modules/jest-runtime/build/index.js:312:29)
      at Object.<anonymous> (node_modules/keytar/lib/keytar.js:1:14)
      at Object.<anonymous> (node_modules/@azure/msal-node-extensions/lib/msal-node-extensions.cjs:9:14)
      at Object.require (src/auth.ts:6:1)
      at Object.<anonymous> (test/src/pat-auth.test.ts:31:1)
```

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Reproduced on a machine not executing post install scripts by default. Applied diff and retried.
