### PR TITLE
chore: switch runner for pre-release to windows

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout code
@@ -37,8 +37,9 @@ jobs:
         run: npm test
 
       - name: Publish to npm with nightly version
+        shell: pwsh
         run: |
-          DATE_STRING=$(date +%Y%m%d)
-          CURRENT_VERSION=$(npm pkg get version | tr -d '"')
-          npm version "$CURRENT_VERSION-nightly.$DATE_STRING" --no-git-tag-version
+          $dateString = Get-Date -Format "yyyyMMdd"
+          $currentVersion = (npm pkg get version).Trim('"')
+          npm version "$currentVersion-nightly.$dateString" --no-git-tag-version
           npm publish --access public --tag nightly --tag next --provenance


### PR DESCRIPTION
Use `windows-latest` runner for Nightly releases.

## ✅ **PR Checklist**

- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [ ] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [ ] Title of the pull request is clear and informative.
- [ ] 👌 Code hygiene
- [ ] 🔭 Telemetry added, updated, or N/A
- [ ] 📄 Documentation added, updated, or N/A
- [ ] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Executed Action from the branch
