### PR TITLE
Refactor project selection handling in wit_work_item tool

### DIFF
--- a/src/tools/work-items.ts
+++ b/src/tools/work-items.ts
@@ -107,14 +107,19 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
   // --- wit_work_item ----------------------------------------------------------
   server.tool(
     WORKITEM_TOOLS.wit_work_item,
-    "Retrieve work item data for a project. Use the action parameter to specify the operation.",
+    "Retrieve work item data. Use the action parameter to specify the operation.",
     {
       action: z
         .enum(["get", "get_batch", "list_comments", "my", "list_revisions", "list_for_iteration", "get_type"])
         .describe(
           "The action to perform. Options: get (get a single work item by ID), get_batch (get multiple work items by IDs), list_comments (list comments on a work item), my (get work items relevant to the authenticated user), list_revisions (list revisions of a work item), list_for_iteration (list work items for a team iteration), get_type (get metadata for a work item type)."
         ),
-      project: z.string().optional().describe("The name or ID of the Azure DevOps project. Reuse from prior context if already known. If not provided, a project selection prompt will be shown."),
+      project: z
+        .string()
+        .optional()
+        .describe(
+          "The name or ID of the Azure DevOps project. Optional for get; when omitted, the work item is retrieved at organization scope. For other actions, a project selection prompt will be shown if omitted."
+        ),
       id: z.coerce.number().min(1).optional().describe("Work item ID. Required for: get."),
       ids: z.array(z.coerce.number().min(1)).optional().describe("Work item IDs. Required for: get_batch."),
       workItemId: z.coerce.number().min(1).optional().describe("Work item ID. Required for: list_comments, list_revisions."),
@@ -140,11 +145,6 @@ function configureWorkItemTools(server: McpServer, tokenProvider: () => Promise<
 
         if (action === "get") {
           if (!id) return { content: [{ type: "text", text: "id is required for get" }], isError: true };
-          if (!resolvedProject) {
-            const result = await elicitProject(server, connection, "Select the Azure DevOps project to retrieve the work item from.");
-            if ("response" in result) return result.response;
-            resolvedProject = result.resolved;
-          }
           let effectiveExpand = expand;
           if (fields && fields.length > 0 && effectiveExpand != null) {
             effectiveExpand = "none";

--- a/test/src/tools/work-items.test.ts
+++ b/test/src/tools/work-items.test.ts
@@ -5230,18 +5230,6 @@ describe("configureWorkItemTools", () => {
       expect(result.content[0].text).toBe("Project selection cancelled.");
     });
 
-    it("get_work_item: should return elicitation response when project selection is declined", async () => {
-      configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
-      const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item");
-      if (!call) throw new Error("wit_work_item not registered");
-      const [, , , handler] = call;
-
-      setupElicitMocks("decline");
-
-      const result = await handler({ action: "get", id: 1 });
-      expect(result.content[0].text).toBe("Project selection cancelled.");
-    });
-
     it("list_work_item_comments: should return elicitation response when project selection is declined", async () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item");
@@ -5489,17 +5477,17 @@ describe("configureWorkItemTools", () => {
       expect(mockWorkItemTrackingApi.getWorkItemsBatch).toHaveBeenCalledWith({ ids: [1, 2], fields: expect.any(Array) }, "Contoso");
     });
 
-    it("get_work_item: should use elicited project when project is not provided", async () => {
+    it("get_work_item: should retrieve at organization scope when project is not provided", async () => {
       configureWorkItemTools(server, tokenProvider, connectionProvider, userAgentProvider);
       const call = (server.tool as jest.Mock).mock.calls.find(([toolName]) => toolName === "wit_work_item");
       if (!call) throw new Error("wit_work_item not registered");
       const [, , , handler] = call;
 
-      setupAcceptMocks();
       (mockWorkItemTrackingApi.getWorkItem as jest.Mock).mockResolvedValue({ id: 1 });
 
       await handler({ action: "get", id: 1 });
-      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, undefined, undefined, undefined, "Contoso");
+      expect(mockWorkItemTrackingApi.getWorkItem).toHaveBeenCalledWith(1, undefined, undefined, undefined, undefined);
+      expect((server as unknown as { server: { elicitInput: jest.Mock } }).server.elicitInput).not.toHaveBeenCalled();
     });
 
     it("list_work_item_comments: should use elicited project when project is not provided", async () => {


### PR DESCRIPTION
This pull request updates the behavior and documentation for the "get" action in the `wit_work_item` tool, allowing retrieval of work items at the organization scope (without requiring a project). It also updates related tests to reflect this new behavior and cleans up unnecessary code.

**Work item retrieval behavior changes:**

* The "get" action for the `wit_work_item` tool no longer requires a project to be specified; if omitted, the work item is retrieved at the organization scope. The project selection prompt is now only shown for other actions. (`src/tools/work-items.ts`) [[1]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L110-R122) [[2]](diffhunk://#diff-ceebe3f2554b2fdf7c02d32394ee2293ac80b4c51ee0f3bd05f5f633ec4d0311L143-L147)

**Documentation updates:**

* Updated the tool's description and the `project` parameter documentation to clarify that the project is optional for "get" and required (or prompted) for other actions. (`src/tools/work-items.ts`)

**Test updates and cleanup:**

* Removed the test that expected a project selection prompt for "get" when the project was not provided, since it's no longer applicable. (`test/src/tools/work-items.test.ts`)
* Updated the test for "get" to verify that the organization scope is used when no project is provided, and that no project selection is prompted. (`test/src/tools/work-items.test.ts`)

## GitHub issue number
#1575

## **Associated Risks**

None really

## ✅ **PR Checklist**

- [x] **I have read the [contribution guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CONTRIBUTING.md)**
- [x] **I have read the [code of conduct guidelines](https://github.com/microsoft/azure-devops-mcp/blob/main/CODE_OF_CONDUCT.md)**
- [x] Title of the pull request is clear and informative.
- [x] 👌 Code hygiene
- [x] 🔭 Telemetry added, updated, or N/A
- [x] 📄 Documentation added, updated, or N/A
- [x] 🛡️ Automated tests added, or N/A

## 🧪 **How did you test it?**

Ran several manual tests on fetching work item with project and without. Matches REST API. Updated automated tests
